### PR TITLE
[COLDFIX] Replace Moq With Nsubstitute

### DIFF
--- a/tests.props
+++ b/tests.props
@@ -13,7 +13,6 @@
     <PackageReference Include="FluentAssertions" Version="6.11.0" />
     <PackageReference Include="FsCheck.XUnit" Version="3.0.0-rc1"/>
     <PackageReference Include="coverlet.msbuild" Version="6.0.0" />
-    <PackageReference Include="Moq" Version="[4.18.2]"/>
     <PackageReference Include="NodaTime.Bogus" Version="3.0.1" />
   </ItemGroup>
 </Project>

--- a/tests.props
+++ b/tests.props
@@ -13,7 +13,7 @@
     <PackageReference Include="FluentAssertions" Version="6.11.0" />
     <PackageReference Include="FsCheck.XUnit" Version="3.0.0-rc1"/>
     <PackageReference Include="coverlet.msbuild" Version="6.0.0" />
-    <PackageReference Include="Moq" Version="4.20.2"/>
+    <PackageReference Include="Moq" Version="[4.18.2]"/>
     <PackageReference Include="NodaTime.Bogus" Version="3.0.1" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
### ⚠️ Breaking Changes
• Dropped net5.0 support
• Dropped netcoreapp3.1 support
### ⚙️ Technical changes
• Moved pipeline to Ubuntu agent
• Moved build definition to [Candoumbe.Pipelines](https://www.nuget.org/packages/Candoumbe.Pipelines/0.3.0-beta0001)

Full changelog at https://github.com/candoumbe/DataFilters/blob/coldfix/replace-moq-with-nsubstitute/CHANGELOG.md

Resolves #206