### PR TITLE
[FEATURE] Update `Candoumbe.Pipelines` to 0.6.0-rc0000

### DIFF
--- a/.nuke/build.schema.json
+++ b/.nuke/build.schema.json
@@ -150,7 +150,8 @@
           "description": "Path to a solution file that is automatically loaded"
         },
         "StrykerDashboardApiKey": {
-          "type": "string"
+          "type": "string",
+          "description": "API KEY used to submit mutation report to a stryker dashboard"
         },
         "Target": {
           "type": "array",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Dropped `net5.0` support
 - Dropped `netcoreapp3.1` support
 
-### ⚙️ Technical changes
+### 🧹 Housekeeping
 - Moved pipeline to Ubuntu agent
-- Moved build definition to [Candoumbe.Pipelines](https://www.nuget.org/packages/Candoumbe.Pipelines/0.3.0-beta0001)
+- Moved build definition to [Candoumbe.Pipelines](https://www.nuget.org/packages/Candoumbe.Pipelines/0.6.0-rc0000)
 
 
 ## [0.12.0] / 2022-10-12

--- a/build/_build.csproj
+++ b/build/_build.csproj
@@ -13,7 +13,7 @@
 
   <ItemGroup>
     <PackageReference Include="Nuke.Common" Version="7.0.2" PrivateAssets="all" />
-    <PackageReference Include="Candoumbe.Pipelines" Version="0.5.0" />
+    <PackageReference Include="Candoumbe.Pipelines" Version="0.6.0-rc0000" />
     <PackageReference Include="ReportGenerator" Version="[5.1.23]" />
     <PackageDownload Include="GitVersion.Tool" Version="[5.10.3]" />
     <PackageDownload Include="Codecov.Tool" Version="[1.12.3]" />


### PR DESCRIPTION
### ⚠️ Breaking Changes
• Dropped net5.0 support
• Dropped netcoreapp3.1 support
### 🧹 Housekeeping
• Moved pipeline to Ubuntu agent
• Moved build definition to [Candoumbe.Pipelines](https://www.nuget.org/packages/Candoumbe.Pipelines/0.6.0-rc0000)

Full changelog at https://github.com/candoumbe/DataFilters/blob/feature/update-candoumbe-pipelines-to-0-6-x/CHANGELOG.md