### PR TITLE
🧹[COLDFIX] Incorrect Path To Stryker Config File

### DIFF
--- a/.github/workflows/delivery.yml
+++ b/.github/workflows/delivery.yml
@@ -33,7 +33,7 @@ jobs:
     name: ubuntu-latest
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: 'Cache: .nuke/temp, ~/.nuget/packages'

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -32,7 +32,7 @@ jobs:
     name: ubuntu-latest
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: 'Cache: .nuke/temp, ~/.nuget/packages'

--- a/.github/workflows/nightly-manual.yml
+++ b/.github/workflows/nightly-manual.yml
@@ -23,7 +23,7 @@ jobs:
     name: ubuntu-latest
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: 'Cache: .nuke/temp, ~/.nuget/packages'

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -156,7 +156,7 @@ namespace DataFilters.ContinuousIntegration
             => new[] { "DataFilters", "DataFilters.Expressions", "DataFilters.Queries" }
                 .Select(projectName => new MutationProjectConfiguration(sourceProject: Solution.AllProjects.Single(csproj => string.Equals(csproj.Name, projectName, StringComparison.InvariantCultureIgnoreCase)),
                                                                         testProjects: Solution.AllProjects.Where(csproj => string.Equals(csproj.Name, $"{projectName}.UnitTests", StringComparison.InvariantCultureIgnoreCase)),
-                                                                        configurationFile: this.Get<IHaveTestDirectory>().TestDirectory / $"{projectName}" / "stryker-config.json"))
+                                                                        configurationFile: this.Get<IHaveTestDirectory>().TestDirectory / $"{projectName}.UnitTests" / "stryker-config.json"))
                 .ToArray();
 
         ///<inheritdoc/>


### PR DESCRIPTION
### ⚠️ Breaking Changes
• Dropped net5.0 support
• Dropped netcoreapp3.1 support
### 🧹 Housekeeping
• Moved pipeline to Ubuntu agent
• Updated build definition to [Candoumbe.Pipelines 0.7.0-rc0003](https://www.nuget.org/packages/Candoumbe.Pipelines/0.7.0-rc0003)
• Updated build.sh script by running nuke :update command
• Removed explicit Nuke.Common dependency from the build project

Full changelog at https://github.com/candoumbe/DataFilters/blob/coldfix/incorrect-path-to-stryker-config-file/CHANGELOG.md