### PR TITLE
🧹[COLDFIX] Incorrect Path To Stryker Config File

### DIFF
--- a/.nuke/parameters.local.json
+++ b/.nuke/parameters.local.json
@@ -1,0 +1,6 @@
+{
+  "GitHubToken": "v1:X+TaIezF0N9xQlCwcepHdIusH93m/AUozo7TlSQbRdB0HDPSIs5tfqSU1OvzaNFs3Yl9z2h56iRMrMxF71e2bDTCRbcvchGQ0ddP+xotThjyvo+VRgPVJ//0SN5YBMhh",
+  "StrykerDashboardApiKey": "v1:YrJps3un49adEV0pAgnRiYKiFwL2gyKG8r3jypARWsFp05XtpCMyDf7LUDkHXTZN",
+  "NugetApiKey": "v1:dC46dC8u7TcqVdm1Hnc4r6e1E4hV859Tgmnt7DG6Ijm5abOh21F/Tg37KUAK6+zk",
+  "CodecovToken": "v1:yalDsmUeg0quzflkLfcR0+1w2kXcK8FfdjILhEzOC0jJZhTtCeY7ORPJsrygfAr8"
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated build definition to [Candoumbe.Pipelines 0.7.0-rc0003](https://www.nuget.org/packages/Candoumbe.Pipelines/0.7.0-rc0003)
 - Updated `build.sh` script by running `nuke :update` command
 - Removed explicit `Nuke.Common` dependency from the build project
+- Added local file to store encrypted secrets needed when running some CI targets locally
 
 ## [0.12.0] / 2022-10-12
 ### 🚀 New features

--- a/test/DataFilters.Expressions.UnitTests/stryker-config.json
+++ b/test/DataFilters.Expressions.UnitTests/stryker-config.json
@@ -3,6 +3,6 @@
     "project-info": {
       "module": "DataFilters.Expressions"
     },
-    "concurrent": 4
+    "concurrency": 4
   }
 }

--- a/test/DataFilters.Queries.UnitTests/stryker-config.json
+++ b/test/DataFilters.Queries.UnitTests/stryker-config.json
@@ -3,6 +3,6 @@
     "project-info": {
       "module": "DataFilters.Queries"
     },
-    "concurrent": 4
+    "concurrency": 4
   }
 }

--- a/test/DataFilters.UnitTests/stryker-config.json
+++ b/test/DataFilters.UnitTests/stryker-config.json
@@ -3,6 +3,6 @@
     "project-info": {
       "module": "DataFilters"
     },
-    "concurrent": 4
+    "concurrency": 4
   }
 }


### PR DESCRIPTION
### ⚠️ Breaking Changes
• Dropped net5.0 support
• Dropped netcoreapp3.1 support
### 🧹 Housekeeping
• Moved pipeline to Ubuntu agent
• Updated build definition to [Candoumbe.Pipelines 0.7.0-rc0003](https://www.nuget.org/packages/Candoumbe.Pipelines/0.7.0-rc0003)
• Updated build.sh script by running nuke :update command
• Removed explicit Nuke.Common dependency from the build project
• Added local file to store encrypted secrets needed when running some CI targets locally

Full changelog at https://github.com/candoumbe/DataFilters/blob/coldfix/incorrect-path-to-stryker-config-file/CHANGELOG.md