### PR TITLE
💪🏾 Refactor tests for Equals transitivity property

### DIFF
--- a/.nuke/parameters.local.json
+++ b/.nuke/parameters.local.json
@@ -1,6 +1,5 @@
 {
-  "GitHubToken": "v1:X+TaIezF0N9xQlCwcepHdIusH93m/AUozo7TlSQbRdB0HDPSIs5tfqSU1OvzaNFs3Yl9z2h56iRMrMxF71e2bDTCRbcvchGQ0ddP+xotThjyvo+VRgPVJ//0SN5YBMhh",
-  "StrykerDashboardApiKey": "v1:YrJps3un49adEV0pAgnRiYKiFwL2gyKG8r3jypARWsFp05XtpCMyDf7LUDkHXTZN",
-  "NugetApiKey": "v1:dC46dC8u7TcqVdm1Hnc4r6e1E4hV859Tgmnt7DG6Ijm5abOh21F/Tg37KUAK6+zk",
-  "CodecovToken": "v1:yalDsmUeg0quzflkLfcR0+1w2kXcK8FfdjILhEzOC0jJZhTtCeY7ORPJsrygfAr8"
+  "GitHubToken": "v1:OhvldXY34GSHTumJiuoWhDUnMA6Wk9x0TYGNqoZodJVVk1a9rG9VSy868zg4R8oxRw5emz8EevMbSeIHN8kTJgu4pZ44JS4FKnsvk0IaJOr8c+3vfIRE4DmM8wPVf/Eh",
+  "NugetApiKey": "v1:pqiQ7rGFSYoCihCFSrdaCRFpf0BoThUJFRbvzCqVjnWssX61zbm6Z7aZH9x1/fOg",
+  "CodecovToken": "v1:fD+Tl5VfvzhiKcjphPlwB+e7w7Dj7N645OTAjSoEtozxIae0KhwkqvHBi7RChHK3"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated `build.sh` script by running `nuke :update` command
 - Removed explicit `Nuke.Common` dependency from the build project
 - Added local file to store encrypted secrets needed when running some CI targets locally
+- Replaced property based testing with hand written test cases to validate `DateTimeExpression.Equals` implementation([#237](https://github.com/candoumbe/datafilters/issues/237))
 
 ## [0.12.0] / 2022-10-12
 ### 🚀 New features

--- a/DataFilters.lutconfig
+++ b/DataFilters.lutconfig
@@ -1,0 +1,6 @@
+<LUTConfig Version="1.0">
+  <Repository />
+  <ParallelBuilds>true</ParallelBuilds>
+  <ParallelTestRuns>true</ParallelTestRuns>
+  <TestCaseTimeout>180000</TestCaseTimeout>
+</LUTConfig>

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 A small library that allow to convert a string to a generic [`IFilter`][class-ifilter] object.
 Highly inspired by the elastic query syntax, it offers a powerful way to build and query data with a syntax that's not bound to a peculiar datasource.
 
-## **Disclaimer**
+## **Disclaimer** <!-- omit in toc -->
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
@@ -17,35 +17,32 @@ Major version zero (0.y.z) is for initial development. **Anything MAY change at 
 
 The public API SHOULD NOT be considered stable.
 
-## **Table of contents**
-
 - [Parsing](#parsing)
 - [Filters syntax](#filters-syntax)
-  - [Equals](#equals)
-  - [Starts with](#starts-with)
-  - [Ends with](#ends-with)
-  - [Contains](#contains)
-  - [Is null](#is-null)
-  - [Any of](#any-of)
-  - [Is null](#is-null-1)
-  - [Any of](#any-of-1)
-  - [Interval expressions](#interval-expressions)
-    - [Greater than or equal](#greater-than-or-equal)
-    - [Less than or equal](#less-than-or-equal)
-    - [Between](#between)
-  - [Regular expression](#regular-expression)
-  - [Logical operators](#logical-operators)
-    - [And](#and)
-    - [Or](#or)
-    - [Not](#not)
-  - [Special character handling](#special-character-handling)
-  - [Sorting](#sorting)
+- [Equals](#equals)
+- [Starts with](#starts-with)
+- [Ends with](#ends-with)
+- [Contains](#contains)
+- [Is null](#is-null)
+- [Any of](#any-of)
+- [Is not null](#is-not-null)
+- [Interval expressions](#interval-expressions)
+  - [Greater than or equal](#greater-than-or-equal)
+  - [Less than or equal](#less-than-or-equal)
+  - [Between](#between)
+- [Regular expression](#regular-expression)
+- [Logical operators](#logical-operators)
+  - [And](#and)
+  - [Or](#or)
+  - [Not](#not)
+- [Special character handling](#special-character-handling)
+- [Sorting](#sorting)
 - [How to install](#how-to-install)
 - [How to use](#how-to-use)
   - [On the client](#on-the-client)
   - [On the backend](#on-the-backend)
-      - [Building expression trees to filtering data from any datasource](#building-expression-trees-to-filtering-data-from-any-datasource)
-      - [Extending `IFIlter`s](#extending-ifilters)
+    - [Building expression trees to filtering data from any datasource](#building-expression-trees-to-filtering-data-from-any-datasource)
+    - [Extending `IFIlter`s](#extending-ifilters)
 
 
 The idea came to me when working on a set of REST APIs and trying to build `/search` endpoints.
@@ -122,7 +119,7 @@ Wouldn't it be nice to be able to search any resource like so
 This is exactly what this project is about : giving you an uniform syntax to query resources
 without having to think about the underlying datasource.
 
-# <a href='#' id='parsing'>Parsing</a>
+## Parsing
 
 This is the first step on filtering data. Thanks to [SuperPower](https://github.com/datalust/superpower/),
 the library supports a custom syntax that can be used to specified one or more criteria resources must fullfill.
@@ -134,23 +131,23 @@ The currently supported syntax mimic the query string syntax : a key-value pair 
 To parse an expression, simply call  `ToFilter<T>` extension method
 (see unit tests for more details on the syntax)
 
-# <a href='#' id='filtering'>Filters syntax</a>
+## Filters syntax
 
 Several expressions are supported and here's how you can start using them in your search queries.
 
-|                                         | `string` | numeric types (`int`, `short`, ...) | Date and time types (`DateTime`, `DateTimeOffset`, ...) |
-| --------------------------------------- | -------- | ----------------------------------- | ------------------------------------------------------- |
-| [EqualTo](#equals-expression)           | ✅        | ✅                                   | ✅                                                       |
-| [StartsWith](#starts-with-expression)   | ✅        | N/A                                 | N/A                                                     |
-| [Ends with](#ends-with-expression)      | ✅        | N/A                                 | N/A                                                     |
-| [Contains](#contains-expression)        | ✅        | N/A                                 | N/A                                                     |
-| [IsNull](#isnull-expression)            | ✅        | N/A                                 | N/A                                                     |
-| [IsNotNull](#isnull-expression)         | ✅        | N/A                                 | N/A                                                     |
-| [LessThanOrEqualTo](#lte-expression)    | N/A      | ✅                                   | ✅                                                       |
-| [GreaterThanOrEqualTo](#gte-expression) | N/A      | ✅                                   | ✅                                                       |
-| [bracket expression](#regex-expression) | N/A      | ✅                                   | ✅                                                       |
+|                                                | `string` | numeric types (`int`, `short`, ...) | Date and time types (`DateTime`, `DateTimeOffset`, ...) |
+| ---------------------------------------------- | -------- | ----------------------------------- | ------------------------------------------------------- |
+| [EqualTo](#equals)                             | ✅        | ✅                                   | ✅                                                       |
+| [StartsWith](#starts-with)                     | ✅        | N/A                                 | N/A                                                     |
+| [Ends with](#ends-with)                        | ✅        | N/A                                 | N/A                                                     |
+| [Contains](#contains)                          | ✅        | N/A                                 | N/A                                                     |
+| [IsNull](#is-null)                             | ✅        | N/A                                 | N/A                                                     |
+| [IsNotNull](#is-not-null)                      | ✅        | N/A                                 | N/A                                                     |
+| [LessThanOrEqualTo](#less-than-or-equal)       | N/A      | ✅                                   | ✅                                                       |
+| [GreaterThanOrEqualTo](#greater-than-or-equal) | N/A      | ✅                                   | ✅                                                       |
+| [bracket expression](#regular-expression)      | N/A      | ✅                                   | ✅                                                       |
 
-## <a href='#' id='equals-expression'>Equals</a>
+## Equals
 
 Search for any `vigilante` resources where the value of the property `nickname` is `manbat`
 
@@ -158,7 +155,7 @@ Search for any `vigilante` resources where the value of the property `nickname` 
 | ----------------- | ----------------------------------------------------- | -------------------------------------------------------------------------------------- |
 | `nickname=manbat` | `{ "field":"nickname", "op":"eq", "value":"manbat" }` | `new Filter(field: "nickname", @operator : FilterOperator.EqualsTo, value : "manbat")` |
 
-## <a href='#' id='starts-with-expression'>Starts with</a>
+## Starts with
 
 Search for any `vigilante` resources where the value of the property `nickname` starts with `"bat"`
 
@@ -166,7 +163,7 @@ Search for any `vigilante` resources where the value of the property `nickname` 
 | --------------- | ---------------------------------------------------------- | ------------------------------------------------------------------------------------- |
 | `nickname=bat*` | `{ "field":"nickname", "op":"startswith", "value":"bat" }` | `new Filter(field: "nickname", @operator : FilterOperator.StartsWith, value : "bat")` |
 
-## <a href='#' id='ends-with-expression'>Ends with</a>
+## Ends with
 
 Search for `vigilante` resources where the value of the property `nickname` ends with `man`.
 
@@ -174,7 +171,7 @@ Search for `vigilante` resources where the value of the property `nickname` ends
 | --------------- | -------------------------------------------------------- | ----------------------------------------------------------------------------------- |
 | `nickname=*man` | `{ "field":"nickname", "op":"endswith", "value":"man" }` | `new Filter(field: "nickname", @operator : FilterOperator.EndsWith, value : "man")` |
 
-## <a href='#' id='contains-expression'>Contains</a>
+## Contains
 
 Search for any `vigilante` resources where the value of the property `nickname` contains `"bat"`.
 
@@ -190,7 +187,7 @@ Search for `vigilante` resources that have no powers.
 | ------------ | -------------------------------------- | ----------------------------------------------------------------- |
 | `powers=!*`  | `{ "field":"powers", "op":"isempty" }` | `new Filter(field: "powers", @operator : FilterOperator.IsEmpty)` |
 
-## <a href='#' id='isnull-expression'>Is null</a>
+## Is null
 
 Search for `vigilante` resources that have no powers.
 
@@ -198,7 +195,7 @@ Search for `vigilante` resources that have no powers.
 | ------------ | ------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `N/A`        | `{ "field":"powers", "op":"isnull" }` | `new Filter(field: "powers", @operator : FilterOperator.IsNull)` or `new Filter(field: "powers", @operator : FilterOperator.EqualsTo, value: null)` |
 
-## <a href='#' id='any-of-expression'>Any of</a>
+## Any of
 
 Search for `vigilante` resources that have at least one of the specified powers.
 
@@ -221,38 +218,16 @@ IFilter filter = new MultiFilter
 };
 ```
 
-## <a href='#' id='isnull-expression'>Is null</a>
+## Is not null
 
 Search for `vigilante` resources that have no powers.
 
-| Query string | JSON                                  | C#                                                                                                                                                  |
-| ------------ | ------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `N/A`        | `{ "field":"powers", "op":"isnull" }` | `new Filter(field: "powers", @operator : FilterOperator.IsNull)` or `new Filter(field: "powers", @operator : FilterOperator.EqualsTo, value: null)` |
+| Query string | JSON                                     | C#                                                                                                                                                               |
+| ------------ | ---------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `N/A`        | `{ "field":"powers", "op":"isnotnull" }` | `(new Filter(field: "powers", @operator : FilterOperator.IsNull)).Negate()` or `new Filter(field: "powers", @operator : FilterOperator.NotEqualTo, value: null)` |
 
-## <a href='#' id='any-of-expression'>Any of</a>
 
-Search for `vigilante` resources that have at least one of the specified powers.
-
-| Query string                     | JSON |
-| -------------------------------- | ---- |
-| `powers={strength\|speed\|size}` | N/A  |
-
-will result in a [IFilter][class-ifilter] instance equivalent to
-
-```csharp
-IFilter filter = new MultiFilter
-{
-     Logic = Or,
-     Filters = new IFilter[]
-     {
-         new Filter("powers", EqualTo, "strength"),
-         new Filter("powers", EqualTo, "speed"),
-         new Filter("powers", EqualTo, "size")
-     }
-};
-```
-
-## <a href='#' id='interval-expressions'>Interval expressions</a>
+## Interval expressions
 
 Interval expressions are delimited by upper and a lower bound. The generic syntax is
 
@@ -264,7 +239,7 @@ where
 - `min` is the lowest bound of the interval
 - `max` is the highest bound of the interval
 
-### <a href='#' id='gte-expression'>Greater than or equal</a>
+### Greater than or equal
 
 Search for `vigilante` resources where the value of `age` property is greater than or equal to `18`
 
@@ -272,7 +247,7 @@ Search for `vigilante` resources where the value of `age` property is greater th
 | --------------- | ----------------------------------------- | --------------------------------------------------------------------------------------- |
 | `age=[18 TO *[` | `{"field":"age", "op":"gte", "value":18}` | `new Filter(field: "age", @operator : FilterOperator.GreaterThanOrEqualTo, value : 18)` |
 
-### <a href='#' id='lte-expression'>Less than or equal</a>
+### Less than or equal
 
 Search for `vigilante` resource where the value of `age` property is lower than `30`
 
@@ -280,7 +255,7 @@ Search for `vigilante` resource where the value of `age` property is lower than 
 | --------------- | ----------------------------------------- | ------------------------------------------------------------------------------------ |
 | `age=]* TO 30]` | `{"field":"age", "op":"lte", "value":30}` | `new Filter(field: "age", @operator : FilterOperator.LessThanOrEqualTo, value : 30)` |
 
-### <a href='#' id='btw-expression'>Between</a>
+### Between
 
 Search for vigilante resources where `age` property is between `20` and `35`
 
@@ -315,7 +290,7 @@ you can also use the dot character (`.`).
 `property["subproperty"]["subproperty-n"]=<expression>` and `property.subproperty["subproperty-n"]=<expression>`
 are equivalent
 
-## <a href="#" id="regex-expression">Regular expression</a>
+## Regular expression
 
 The library offers a limited support of regular expressions. To be more specific, only bracket expressions are currently supported.
 A bracket expression. Matches a single character that is contained within the brackets.
@@ -323,11 +298,11 @@ For example, `[abc]` matches `a`, `b`, or `c`. `[a-z]` specifies a range which m
 
 `BracketExpression`s can be, as any other expressions  combined with any other expressions to build more complex expressions.
 
-## <a href="#" id="logic-operators">Logical operators</a>
+## Logical operators
 
 Logicial operators can be used combine several instances of [IFilter][class-ifilter] together.
 
-### <a href='#' id='and-expression'>And</a>
+### And
 
 Use the coma character `,` to combine multiple expressions using logical AND operator
 
@@ -349,7 +324,7 @@ IFilter filter = new MultiFilter
 }
 ```
 
-### <a href='#' id='or-expression'>Or</a>
+### Or
 
 Use the pipe character `|`  to combine several expressions using logical OR operator
 Search for `vigilante` resources where the value of the `nickname` property either starts with `"Bat"` or
@@ -373,7 +348,7 @@ IFilter filter = new MultiFilter
 }
 ```
 
-### <a href='#' id='not-expression'>Not</a>
+### Not
 
 To negate a filter, simply put a `!` before the expression to negate
 
@@ -436,7 +411,7 @@ IFilter filter = new MultiFilter
 The `(` and `)` characters allows to group two expressions together so that this group can be used as a more complex
 expression unit.
 
-## <a href='#' id='special-character-handling'>Special character handling</a>
+## Special character handling
 
 Sometimes, you'll be looking for a filter that match exactly a text that contains a character which has a special meaning.
 
@@ -453,7 +428,7 @@ a special character.
 | -------------- | --------------------------------------------------- | ------------------------------------------------------------------------------- |
 | `comment=*"!"` | `{"field":"comment", "op":"endswith", "value":"!"}` | `new Filter(field: "comments", @operator: FilterOperator.EndsWith, value: "!")` |
 
-## <a href='#' id='sorting'>Sorting</a>
+## Sorting
 
 This library also supports a custom syntax to sort elements.
 
@@ -464,21 +439,21 @@ You can sort by several properties at once by separating them with a `,`.
 
 For example `sort=+nickname,-age` allows to sort by `nickname` ascending, then by `age` property descending.
 
-# <a href='#' id='how-to-install'>How to install</a>
+## How to install
 
 1. run `dotnet install DataFilters` : you can already start building [IFilter][class-ifilter] instances 😉 !
 2. install one or more `DataFilters.XXXX`  extension packages to convert [IFilter][class-ifilter] instances to various target.
 
-# <a href='#' id='how-to-use'>How to use</a>
+## How to use
 
 So you have your API and want provide a great search experience ?
 
-## <a href='#' id='how-to-use-client'>On the client</a>
+### On the client
 
 The client will have the responsability of building search criteria.
-Go to [filtering](#filtering) and [sorting](#sorting) sections to see example on how to get started.
+Go to [filtering](#filters-syntax) and [sorting](#sorting) sections to see example on how to get started.
 
-## <a href='#' id='how-to-use-backend'>On the backend</a>
+### On the backend
 
 One way to start could be by having a dedicated resource which properties match the resource's properties search will
 be performed onto.

--- a/test/DataFilters.UnitTests/Grammar/Syntax/DateTimeExpressionTests.cs
+++ b/test/DataFilters.UnitTests/Grammar/Syntax/DateTimeExpressionTests.cs
@@ -4,6 +4,7 @@
     using DataFilters.UnitTests.Helpers;
 
     using FluentAssertions;
+    using FluentAssertions.Extensions;
 
     using FsCheck;
     using FsCheck.Xunit;
@@ -184,15 +185,43 @@
         public void Equals_should_be_symetric(NonNull<DateTimeExpression> expression, NonNull<FilterExpression> otherExpression)
             => expression.Item.Equals(otherExpression.Item).Should().Be(otherExpression.Item.Equals(expression.Item));
 
-        [Property(Arbitrary = new[] { typeof(ExpressionsGenerators) })]
-        public void Equals_should_be_transitive(NonNull<DateTimeExpression> first, NonNull<DateTimeExpression> second, NonNull<DateTimeExpression> third)
+        public static IEnumerable<object[]> EqualsTransitivityCases
+        {
+            get
+            {
+                yield return new object[]
+                {
+                    new DateTimeExpression(1.January(2010)),
+                    new DateTimeExpression(1.January(2010)),
+                    new DateTimeExpression(1.January(2010))
+                };
+
+                yield return new object[]
+                {
+                    new DateTimeExpression(new TimeExpression(1)),
+                    new DateTimeExpression(new TimeExpression(minutes: 60)),
+                    new DateTimeExpression(new TimeExpression(seconds: 3600))
+                };
+
+                yield return new object[]
+                {
+                    new DateTimeExpression(new TimeExpression(1)),
+                    new TimeExpression(minutes: 60),
+                    new DateTimeExpression(new TimeExpression(seconds: 3600))
+                };
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(EqualsTransitivityCases))]
+        public void Equals_should_be_transitive(DateTimeExpression first, object second, object third)
         {
             // Arrange
-            bool firstEqualsSecond = first.Item.Equals(second.Item);
-            bool secondEqualsThird = second.Item.Equals(third.Item);
+            bool firstEqualsSecond = first.Equals(second);
+            bool secondEqualsThird = second.Equals(third);
 
             // Act
-            bool actual = first.Item.Equals(third.Item);
+            bool actual = first.Equals(third);
 
             // Assert
             actual.Should()

--- a/test/DataFilters.UnitTests/Grammar/Syntax/DateTimeExpressionTests.cs
+++ b/test/DataFilters.UnitTests/Grammar/Syntax/DateTimeExpressionTests.cs
@@ -206,7 +206,7 @@
                 yield return new object[]
                 {
                     new DateTimeExpression(new TimeExpression(1)),
-                    new TimeExpression(minutes: 60),
+                    new DateTimeExpression(new TimeExpression(minutes: 60)),
                     new DateTimeExpression(new TimeExpression(seconds: 3600))
                 };
             }


### PR DESCRIPTION
### ⚠️ Breaking Changes
• Dropped net5.0 support
• Dropped netcoreapp3.1 support
### 🧹 Housekeeping
• Moved pipeline to Ubuntu agent
• Updated build definition to [Candoumbe.Pipelines 0.7.0-rc0003](https://www.nuget.org/packages/Candoumbe.Pipelines/0.7.0-rc0003)
• Updated build.sh script by running nuke :update command
• Removed explicit Nuke.Common dependency from the build project
• Added local file to store encrypted secrets needed when running some CI targets locally
• Replaced property based testing with hand written test cases to validate DateTimeExpression.Equals implementation([#237](https://github.com/candoumbe/datafilters/issues/237))

Full changelog at https://github.com/candoumbe/DataFilters/blob/feature/refactor-equals-transitivity-tests/CHANGELOG.md

Resolves #237