### PR TITLE
✨ Update Candoumbe Pipelines To 0 9 0

### DIFF
--- a/.nuke/build.schema.json
+++ b/.nuke/build.schema.json
@@ -110,8 +110,11 @@
           "description": "Shows the execution plan (HTML)"
         },
         "Profile": {
-          "type": "string",
-          "description": "Name of the profile where the current set of secrets"
+          "type": "array",
+          "description": "Defines the profiles to load",
+          "items": {
+            "type": "string"
+          }
         },
         "Root": {
           "type": "string",
@@ -131,7 +134,6 @@
               "Compile",
               "Feature",
               "Hotfix",
-              "ManageSecrets",
               "MutationTests",
               "Pack",
               "Publish",
@@ -165,7 +167,6 @@
               "Compile",
               "Feature",
               "Hotfix",
-              "ManageSecrets",
               "MutationTests",
               "Pack",
               "Publish",

--- a/.nuke/parameters.local.json
+++ b/.nuke/parameters.local.json
@@ -1,5 +1,5 @@
 {
-  "GitHubToken": "v1:OhvldXY34GSHTumJiuoWhDUnMA6Wk9x0TYGNqoZodJVVk1a9rG9VSy868zg4R8oxRw5emz8EevMbSeIHN8kTJgu4pZ44JS4FKnsvk0IaJOr8c+3vfIRE4DmM8wPVf/Eh",
+  "GitHubToken": "v1:OhvldXY34GSHTumJiuoWhHPHKwSoVb7B/X19pufOj7+Q2O5n0YnxMIowWmry2b4SbtIW2Ah4uwPP1HpOLvvfB9LO4QIggTf/dAVK00aG+Cp2ZeG/kqhbEsc9c6tV8lZn",
   "NugetApiKey": "v1:pqiQ7rGFSYoCihCFSrdaCRFpf0BoThUJFRbvzCqVjnWssX61zbm6Z7aZH9x1/fOg",
   "CodecovToken": "v1:fD+Tl5VfvzhiKcjphPlwB+e7w7Dj7N645OTAjSoEtozxIae0KhwkqvHBi7RChHK3"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### 🧹 Housekeeping
 
 - Moved pipeline to Ubuntu agent
-- Updated build definition to [Candoumbe.Pipelines 0.7.0-rc0003](https://www.nuget.org/packages/Candoumbe.Pipelines/0.7.0-rc0003)
+- Updated build definition to [Candoumbe.Pipelines 0.9.0](https://www.nuget.org/packages/Candoumbe.Pipelines/0.9.0)
 - Updated `build.sh` script by running `nuke :update` command
 - Removed explicit `Nuke.Common` dependency from the build project
 - Added local file to store encrypted secrets needed when running some CI targets locally

--- a/build/_build.csproj
+++ b/build/_build.csproj
@@ -12,7 +12,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Candoumbe.Pipelines" Version="0.7.0" />
+    <PackageReference Include="Candoumbe.Pipelines" Version="0.9.0" />
     <PackageReference Include="ReportGenerator" Version="[5.2.0]" />
     <PackageDownload Include="GitVersion.Tool" Version="[5.10.3]" />
     <PackageDownload Include="Codecov.Tool" Version="[1.12.3]" />


### PR DESCRIPTION
### ⚠️ Breaking Changes
• Dropped net5.0 support
• Dropped netcoreapp3.1 support
### 🧹 Housekeeping
• Moved pipeline to Ubuntu agent
• Updated build definition to [Candoumbe.Pipelines 0.9.0](https://www.nuget.org/packages/Candoumbe.Pipelines/0.9.0)
• Updated build.sh script by running nuke :update command
• Removed explicit Nuke.Common dependency from the build project
• Added local file to store encrypted secrets needed when running some CI targets locally
• Replaced property based testing with hand written test cases to validate DateTimeExpression.Equals implementation([#237](https://github.com/candoumbe/datafilters/issues/237))

Full changelog at https://github.com/candoumbe/DataFilters/blob/feature/update-candoumbe-pipelines-to-0-9-0/CHANGELOG.md