### PR TITLE
🧹 Suppress Xunit 1042 Warning

### DIFF
--- a/src/DataFilters/OrderValidator.cs
+++ b/src/DataFilters/OrderValidator.cs
@@ -5,34 +5,33 @@
     using System.Text.RegularExpressions;
     using FluentValidation;
 
-
-/// <summary>
-/// Validates sort expression
-/// </summary>
-public class OrderValidator : AbstractValidator<string>
-{
-    private const string FieldPattern = Filter.ValidFieldNamePattern;
     /// <summary>
-    /// Order expression pattern.
+    /// Validates sort expression
     /// </summary>
-    public readonly static string Pattern = @$"^\s*(-|\+)?(({FieldPattern})\w*)+(\s*,\s*((-|\+)?(({FieldPattern})\w*)+)\s*)*$";
-    private readonly Regex _orderRegex = new(Pattern, RegexOptions.IgnoreCase, TimeSpan.FromSeconds(1));
-    private const char Separator = ',';
+    public class OrderValidator : AbstractValidator<string>
+    {
+        private const string FieldPattern = Filter.ValidFieldNamePattern;
+        /// <summary>
+        /// Order expression pattern.
+        /// </summary>
+        public readonly static string Pattern = @$"^\s*(-|\+)?(({FieldPattern})\w*)+(\s*,\s*((-|\+)?(({FieldPattern})\w*)+)\s*)*$";
+        private readonly Regex _orderRegex = new(Pattern, RegexOptions.IgnoreCase, TimeSpan.FromSeconds(1));
+        private const char Separator = ',';
 
-    /// <summary>
-    /// Builds a new <see cref="OrderValidator"/> instance.
-    /// </summary>
-    public OrderValidator() => RuleFor(x => x)
-            .Matches(Pattern)
-            .WithMessage(search =>
-            {
-                string[] incorrectExpresions = search.Split([Separator])
-                    .Where(x => !_orderRegex.IsMatch(x))
-                    .Select(x => $@"""{x}""")
-                    .ToArray();
+        /// <summary>
+        /// Builds a new <see cref="OrderValidator"/> instance.
+        /// </summary>
+        public OrderValidator() => RuleFor(x => x)
+                .Matches(Pattern)
+                .WithMessage(search =>
+                {
+                    string[] incorrectExpresions = search.Split([Separator])
+                        .Where(x => !_orderRegex.IsMatch(x))
+                        .Select(x => $@"""{x}""")
+                        .ToArray();
 
                     return $"Sort expression{(incorrectExpresions.Length == 1 ? string.Empty : "s")} {string.Join(", ", incorrectExpresions)} " +
-                    $@"do{(incorrectExpresions.Length == 1 ? "es" : string.Empty)} not match ""{Pattern}"".";
+                $@"do{(incorrectExpresions.Length == 1 ? "es" : string.Empty)} not match ""{Pattern}"".";
                 });
     }
 }

--- a/src/DataFilters/StringExtensions.cs
+++ b/src/DataFilters/StringExtensions.cs
@@ -34,7 +34,6 @@
     using System.Collections.Concurrent;
 #endif
 
-
 #if NET7_0_OR_GREATER
     using System.Diagnostics;
 #endif

--- a/test/DataFilters.Expressions.UnitTests/QueryableExtensionsTests.cs
+++ b/test/DataFilters.Expressions.UnitTests/QueryableExtensionsTests.cs
@@ -1,7 +1,6 @@
 ﻿namespace DataFilters.Expressions.UnitTests
 {
     using System;
-    using System.Collections.Generic;
     using System.Linq;
     using FluentAssertions;
     using Xunit;
@@ -11,23 +10,18 @@
     [UnitTest]
     public class QueryableExtensionsTests(ITestOutputHelper outputHelper)
     {
-        public static IEnumerable<object[]> ThrowsArgumentNullExceptionCases
-        {
-            get
+        public static TheoryData<IQueryable<Hero>, IOrder<Hero>> ThrowsArgumentNullExceptionCases
+            => new()
             {
-                yield return new object[]
                 {
                     null,
                     new Order<Hero>(nameof(Hero.Name))
-                };
-
-                yield return new object[]
+                },
                 {
                     Enumerable.Empty<Hero>().AsQueryable(),
                     null
-                };
-            }
-        }
+                }
+            };
 
         [Theory]
         [MemberData(nameof(ThrowsArgumentNullExceptionCases))]

--- a/test/DataFilters.Expressions.UnitTests/ToOrderClauseTests.cs
+++ b/test/DataFilters.Expressions.UnitTests/ToOrderClauseTests.cs
@@ -14,39 +14,33 @@
     [Feature("Expressions")]
     public class ToOrderClauseTests
     {
-        public static IEnumerable<object[]> ToOrderClauseCases
-        {
-            get
+        public static TheoryData<IReadOnlyList<Hero>, IOrder<Hero>, Expression<Func<IEnumerable<Hero>, bool>>> ToOrderClauseCases
+            => new()
             {
-                yield return new object[]
                 {
-                    new[]
-                    {
+                    [
                         new Hero { Name = "Batman"},
                         new Hero { Name = "Flash"}
-                    },
+                    ],
                     new Order<Hero>(nameof(Hero.Name)),
-                    (Expression<Func<IEnumerable<Hero>, bool>>)(heroes => heroes.Exactly(2)
+                    heroes => heroes.Exactly(2)
                         && heroes.First().Name == "Batman"
                         && heroes.Last().Name == "Flash"
-                    )
-                };
 
-                yield return new object[]
+                },
                 {
-                    new[]
-                    {
+                    [
                         new Hero { Name = "Batman"},
                         new Hero { Name = "Flash"}
-                    },
+                    ],
                     new Order<Hero>("name"),
-                    (Expression<Func<IEnumerable<Hero>, bool>>)(heroes => heroes.Exactly(2)
+                    heroes => heroes.Exactly(2)
                         && heroes.First().Name == "Batman"
                         && heroes.Last().Name == "Flash"
-                    )
-                };
 
-                yield return new object[]
+                },
+
+
                 {
                     new[]
                     {
@@ -54,13 +48,12 @@
                         new Hero { Name = "Flash"}
                     },
                     new Order<Hero>(" name"),
-                    (Expression<Func<IEnumerable<Hero>, bool>>)(heroes => heroes.Exactly(2)
+                    heroes => heroes.Exactly(2)
                         && heroes.First().Name == "Batman"
                         && heroes.Last().Name == "Flash"
-                    )
-                };
 
-                yield return new object[]
+                },
+
                 {
                     new[]
                     {
@@ -69,13 +62,13 @@
                     },
                     new Order<Hero>(nameof(Hero.Name), Descending),
 
-                    (Expression<Func<IEnumerable<Hero>, bool>>)(heroes => heroes.Exactly(2)
+                    heroes => heroes.Exactly(2)
                         && heroes.First().Name == "Flash"
                         && heroes.Last().Name == "Batman"
-                    )
-                };
 
-                yield return new object[]
+                },
+
+
                 {
                     new[]
                     {
@@ -88,13 +81,13 @@
                         new Order<Hero>(nameof(Hero.Age), Ascending),
                         new Order<Hero>(nameof(Hero.Name), Descending)
                     ),
-                    (Expression<Func<IEnumerable<Hero>, bool>>)(heroes => heroes.Exactly(3)
+                    heroes => heroes.Exactly(3)
                                                                           && heroes.First().Name == "Batman"
                                                                           && heroes.Last().Name == "Flash"
-                    )
-                };
 
-                yield return new object[]
+                },
+
+
                 {
                     new[]
                     {
@@ -107,13 +100,13 @@
                         new Order<Hero>(nameof(Hero.Name), Descending),
                         new Order<Hero>(nameof(Hero.Age), Ascending)
                     ),
-                    (Expression<Func<IEnumerable<Hero>, bool>>)(heroes => heroes.Exactly(3)
+                    heroes => heroes.Exactly(3)
                                                                           && heroes.First().Name == "Wonder Woman"
                                                                           && heroes.Last().Name == "Batman"
-                    )
-                };
 
-                yield return new object[]
+                },
+
+
                 {
                     new[]
                     {
@@ -122,13 +115,13 @@
                     },
                     new Order<Hero>(nameof(Hero.FirstAppearance), Descending),
 
-                    (Expression<Func<IEnumerable<Hero>, bool>>)(heroes => heroes.Exactly(2)
+                    heroes => heroes.Exactly(2)
                                                                           && heroes.First().Name == "Flash"
                                                                           && heroes.Last().Name == "Batman"
-                    )
-                };
 
-                yield return new object[]
+                },
+
+
                 {
                     new[]
                     {
@@ -156,10 +149,9 @@
                         new Order<Hero>($"{nameof(Hero.Acolyte)}.{nameof(Hero.Age)}", Ascending)
                     ),
 
-                    (Expression<Func<IEnumerable<Hero>, bool>>)(heroes => heroes.Select(x => x.Name).SequenceEqual(new []{ "Green Arrow", "Flash", "Batman"}))
-                };
-            }
-        }
+                    heroes => heroes.Select(x => x.Name).SequenceEqual(new []{ "Green Arrow", "Flash", "Batman"})
+                },
+            };
 
         [Theory]
         [MemberData(nameof(ToOrderClauseCases))]
@@ -167,8 +159,7 @@
         {
             // Act
             IEnumerable<Hero> actual = heroes.AsQueryable()
-                                             .OrderBy(order)
-                                             .ToList();
+                                             .OrderBy(order);
 
             // Assert
             actual.Should()

--- a/test/DataFilters.Queries.UnitTests/FilterToQueriesTests.cs
+++ b/test/DataFilters.Queries.UnitTests/FilterToQueriesTests.cs
@@ -1,7 +1,6 @@
 namespace DataFilters.Queries.UnitTests
 {
     using System;
-    using System.Collections.Generic;
     using FluentAssertions;
     using FluentAssertions.Extensions;
     using global::Queries.Core.Parts.Clauses;
@@ -11,40 +10,33 @@ namespace DataFilters.Queries.UnitTests
 
     public class FilterToQueriesTests(ITestOutputHelper outputHelper)
     {
-        public static IEnumerable<object[]> FilterToWhereCases
-        {
-            get
+        public static TheoryData<IFilter, IWhereClause> FilterToWhereCases
+            => new()
             {
-                yield return new object[]
                 {
                     new Filter(field: "Name",@operator: EqualTo, value: "Wayne"),
                     new WhereClause(column: "Name".Field(), @operator: ClauseOperator.EqualTo, constraint: "Wayne")
-                };
-
-                yield return new object[]
+                },
                 {
                     new Filter(field: "Name",@operator: NotEqualTo, value: "Wayne"),
                     new WhereClause(column: "Name".Field(), @operator: ClauseOperator.NotEqualTo, constraint: "Wayne")
-                };
+                },
 
-                yield return new object[]
                 {
                     new Filter(field: "Name",@operator: Contains, value: "W"),
                     new WhereClause(column: "Name".Field(), @operator: ClauseOperator.Like, constraint: "%W%")
-                };
+                },
 
-                yield return new object[]
                 {
                     new Filter(field: "Name",@operator: EndsWith, value: "W"),
                     new WhereClause(column: "Name".Field(), @operator: ClauseOperator.Like, constraint: "%W")
-                };
+                },
 
-                yield return new object[]
                 {
                     new Filter(field: "Name",@operator: NotEndsWith, value: "W"),
                     new WhereClause(column: "Name".Field(), @operator: ClauseOperator.NotLike, constraint: "%W")
-                };
-                yield return new object[]
+                },
+
                 {
                     new MultiFilter
                     {
@@ -62,89 +54,75 @@ namespace DataFilters.Queries.UnitTests
                             new WhereClause("Name".Field(),@operator: ClauseOperator.Like, constraint: "Bat%")
                         }
                     }
-                };
+                },
 
-                yield return new object[]
                 {
                     new Filter(field: "Name", @operator: EndsWith, "*"),
-                    new WhereClause(column: "Name".Field(), @operator: ClauseOperator.Like, "%*"),
-                };
+                    new WhereClause(column: "Name".Field(), @operator: ClauseOperator.Like, "%*")
+                },
 
-                yield return new object[]
                 {
                     new Filter(field: "Superpower", IsNull),
                     new WhereClause(column: "Superpower".Field(), @operator: ClauseOperator.IsNull)
-                };
+                },
 
-                yield return new object[]
                 {
                     new Filter(field: "Superpower", IsNotNull),
                     new WhereClause(column: "Superpower".Field(), @operator: ClauseOperator.IsNotNull)
-                };
+                },
 
-                yield return new object[]
                 {
                     new Filter(field: "Nickname", NotStartsWith, "Bat"),
                     new WhereClause(column: "Nickname".Field(), ClauseOperator.NotLike, "Bat%")
-                };
+                },
 
-                yield return new object[]
                 {
                     new Filter(field: "Nickname", NotContains, "man"),
                     new WhereClause(column: "Nickname".Field(), ClauseOperator.NotLike, "%man%")
-                };
+                },
 
-                yield return new object[]
                 {
                     new Filter(field: "XP", FilterOperator.LessThan, 10),
                     new WhereClause("XP".Field(), ClauseOperator.LessThan, 10)
-                };
+                },
 
-                yield return new object[]
                 {
                     new Filter(field: "XP", LessThanOrEqualTo, 10),
                     new WhereClause("XP".Field(), ClauseOperator.LessThanOrEqualTo, 10)
-                };
+                },
 
-                yield return new object[]
                 {
                     new Filter(field : "Height", GreaterThan, 6.4),
                     new WhereClause("Height".Field(), ClauseOperator.GreaterThan, 6.4.Literal())
-                };
+                },
 
-                yield return new object[]
                 {
                     new Filter(field : "Height", GreaterThan, 6m),
                     new WhereClause("Height".Field(), ClauseOperator.GreaterThan, 6m)
-                };
+                },
 
-                yield return new object[]
                 {
                     new Filter(field : "Height", GreaterThanOrEqual, 6),
                     new WhereClause("Height".Field(), ClauseOperator.GreaterThanOrEqualTo, 6)
-                };
+                },
 
-                yield return new object[]
                 {
                     new Filter("BirthDate", GreaterThan, 18.January(1983)),
                     new WhereClause("BirthDate".Field(), ClauseOperator.GreaterThan, 18.January(1983))
-                };
+                },
 
 #if NET6_0_OR_GREATER
-                yield return new object[]
                 {
                     new Filter("BirthDate", GreaterThan, DateOnly.FromDateTime(18.January(1983))),
                     new WhereClause("BirthDate".Field(), ClauseOperator.GreaterThan, DateOnly.FromDateTime(18.January(1983)))
-                };
+                },
 
-                yield return new object[]
                 {
                     new Filter("Time", GreaterThan, TimeOnly.FromDateTime(18.January(1983).Add(15.Hours().And(47.Minutes())))),
                     new WhereClause("Time".Field(), ClauseOperator.GreaterThan, TimeOnly.FromDateTime(18.January(1983).Add(15.Hours().And(47.Minutes()))))
-                };
+                }
 #endif
-            }
-        }
+            };
 
         [Theory]
         [MemberData(nameof(FilterToWhereCases))]

--- a/test/DataFilters.Queries.UnitTests/OrderToQueriesTests.cs
+++ b/test/DataFilters.Queries.UnitTests/OrderToQueriesTests.cs
@@ -19,33 +19,26 @@
             public string Lastname { get; set; }
         }
 
-        public static IEnumerable<object[]> OrderToOrderCases
-        {
-            get
+        public static TheoryData<IOrder<Person>, Expression<Func<IEnumerable<IOrder>, bool>>> OrderToOrderCases
+            => new()
             {
-                yield return new object[]
                 {
                     new Order<Person>("Name"),
-                    (Expression<Func<IEnumerable<IOrder>, bool>>) (sorts => sorts.Once()
-                        && sorts.First().Equals(new OrderExpression("Name".Field(), Ascending)))
-                };
+                     sorts => sorts.Once()
+                        && sorts.First().Equals(new OrderExpression("Name".Field(), Ascending))
+                },
 
                 {
-                    MultiOrder<Person> multiSort = new
+                    new MultiOrder<Person>
                     (
                         new Order<Person>(nameof(Person.Firstname)),
                         new Order<Person>(nameof(Person.Lastname))
-                    );
-                    yield return new object[]
-                    {
-                        multiSort,
-                        (Expression<Func<IEnumerable<IOrder>, bool>>) (sorts => sorts.Exactly(2)
+                    ),
+                         sorts => sorts.Exactly(2)
                             && sorts.First().Equals(new OrderExpression(nameof(Person.Firstname), Ascending))
-                            && sorts.Last().Equals(new OrderExpression(nameof(Person.Lastname), Ascending)))
-                    };
+                            && sorts.Last().Equals(new OrderExpression(nameof(Person.Lastname), Ascending))
                 }
-            }
-        }
+            };
 
         [Theory]
         [MemberData(nameof(OrderToOrderCases))]

--- a/test/DataFilters.UnitTests/Converters/DataFilterConvertersTests.cs
+++ b/test/DataFilters.UnitTests/Converters/DataFilterConvertersTests.cs
@@ -39,128 +39,131 @@ namespace DataFilters.UnitTests.Converters
         /// <summary>
         /// Deserialize tests cases
         /// </summary>
-        public static IEnumerable<object[]> SerializeCases
+        public static TheoryData<Filter, Expression<Func<string, bool>>> SerializeCases
         {
             get
             {
+                TheoryData<Filter, Expression<Func<string, bool>>> cases = [];
                 foreach (KeyValuePair<string, FilterOperator> item in Operators.Where(kv => !Filter.UnaryOperators.Any(op => op == kv.Value)))
                 {
-                    yield return new object[]
-                    {
-                        new Filter(field : "Firstname", @operator : item.Value, value : "Bruce"),
-                        (Expression<Func<string, bool>>) ((json) => json != null
+                    cases.Add
+                    (
+                        new Filter(field: "Firstname", @operator: item.Value, value: "Bruce"),
+                         (json) => json != null
                             && JToken.Parse(json).Type == JTokenType.Object
                             && JToken.Parse(json).IsValid(Filter.Schema(item.Value))
                             && "Firstname".Equals(JToken.Parse(json)[Filter.FieldJsonPropertyName].Value<string>())
                             && item.Key.Equals(JToken.Parse(json)[Filter.OperatorJsonPropertyName].Value<string>())
-                            && "Bruce".Equals(JToken.Parse(json)[Filter.ValueJsonPropertyName].Value<string>()))
-                    };
+                            && "Bruce".Equals(JToken.Parse(json)[Filter.ValueJsonPropertyName].Value<string>())
+                    );
                 }
 
                 foreach (KeyValuePair<string, FilterOperator> item in Operators.Where(kv => Filter.UnaryOperators.Any(op => op == kv.Value)))
                 {
-                    yield return new object[]{
-                        new Filter(field : "Firstname", @operator : item.Value),
-                        (Expression<Func<string, bool>>) ((json) => json != null
+                    cases.Add
+                    (
+                        new Filter(field: "Firstname", @operator: item.Value),
+                         (json) => json != null
                             && JToken.Parse(json).Type == JTokenType.Object
                             && JObject.Parse(json).Properties().Exactly(2)
                             && "Firstname".Equals(JObject.Parse(json)[Filter.FieldJsonPropertyName].Value<string>())
-                            && item.Key.Equals(JObject.Parse(json)[Filter.OperatorJsonPropertyName].Value<string>()))
-                    };
+                            && item.Key.Equals(JObject.Parse(json)[Filter.OperatorJsonPropertyName].Value<string>())
+                    );
                 }
+
+                return cases;
             }
         }
 
         /// <summary>
         /// Deserialize tests cases
         /// </summary>
-        public static IEnumerable<object[]> DeserializeCases
+        public static TheoryData<string, Type, Expression<Func<object, bool>>> DeserializeCases
         {
             get
             {
+                TheoryData<string, Type, Expression<Func<object, bool>>> cases = [];
                 foreach ((string key, FilterOperator value) in Operators.Where(op => op.Value != IsNull
                                                                                      && op.Value != IsNotNull
                                                                                      && op.Value != IsEmpty
                                                                                      && op.Value != IsNotEmpty))
                 {
-                    yield return new object[]
-                    {
+                    cases.Add
+                    (
                         $@"{{""field"" :""Firstname"", ""op"":""{key}"", ""value"" : ""Bruce""}}",
                         typeof(Filter),
-                        (Expression<Func<object, bool>>) ((result) => new Filter("Firstname", value, "Bruce").Equals(result))
-                    };
+                        result => new Filter("Firstname", value, "Bruce").Equals(result)
+                    );
                 }
 
-                yield return new object[]
-                {
+                cases.Add
+                (
                     @"{""field"" :""Firstname"", ""op"":""isnull""}",
                     typeof(Filter),
-                    (Expression<Func<object, bool>>) ((result) => new Filter("Firstname", IsNull, null).Equals(result))
-                };
+                     (result) => new Filter("Firstname", IsNull, null).Equals(result)
+                );
 
-                yield return new object[]
-                {
+                cases.Add
+                (
                        @"{""field"" :""Firstname"", ""op"":""isnull"", ""value"" : 6}",
                        typeof(Filter),
-                       (Expression<Func<object, bool>>) ((result) => new Filter("Firstname", IsNull, null).Equals(result))
-                };
+                        (result) => new Filter("Firstname", IsNull, null).Equals(result)
+                );
 
-                yield return new object[]
-                {
+                cases.Add
+                (
                        @"{""field"" :""Firstname"", ""op"":""isnotnull"", ""value"" : 6}",
                        typeof(Filter),
-                       (Expression<Func<object, bool>>) ((result) => new Filter("Firstname", IsNotNull, null).Equals(result))
-                };
+                        (result) => new Filter("Firstname", IsNotNull, null).Equals(result)
+                );
 
-                yield return new object[]
-                {
+                cases.Add
+                (
                     @$"{{""field"" :""integer"", ""op"":""eq"", ""value"" : {long.MaxValue}}}",
                     typeof(Filter),
-                    (Expression<Func<object, bool>>) ((result) => new Filter("integer", EqualTo, long.MaxValue).Equals(result))
-                };
+                     (result) => new Filter("integer", EqualTo, long.MaxValue).Equals(result)
+                );
 
-                yield return new object[]
-                {
+                cases.Add
+                (
                     @"{""field"" :""bool"", ""op"":""eq"", ""value"" : true }",
                     typeof(Filter),
-                    (Expression<Func<object, bool>>) ((result) => new Filter("bool", EqualTo, true ).Equals(result))
-                };
+                     (result) => new Filter("bool", EqualTo, true).Equals(result)
+                );
 
-                yield return new object[]
-                {
+                cases.Add
+                (
                     @"{""field"" :""EqualNull"", ""op"":""eq"", ""value"" : null }",
                     typeof(Filter),
-                    (Expression<Func<object, bool>>) ((result) => new Filter("EqualNull", IsNull, null).Equals(result))
-                };
+                     (result) => new Filter("EqualNull", IsNull, null).Equals(result)
+                );
 
-                yield return new object[]
-                {
+                cases.Add
+                (
                     @"{""field"" :""NotEqualNull"", ""op"":""neq"", ""value"" : null }",
                     typeof(Filter),
-                    (Expression<Func<object, bool>>) ((result) => new Filter("NotEqualNull", IsNotNull, null).Equals(result))
-                };
+                     (result) => new Filter("NotEqualNull", IsNotNull, null).Equals(result)
+                );
 
                 {
                     Guid uuid = Guid.NewGuid();
-                    yield return new object[]
-                    {
+                    cases.Add
+                    (
                         $@"{{""field"" :""guid"", ""op"":""eq"", ""value"" : ""{uuid}"" }}",
                         typeof(Filter),
-                        (Expression<Func<object, bool>>) ((result) => new Filter("guid", EqualTo, uuid.ToString() ).Equals(result))
-                    };
+                         (result) => new Filter("guid", EqualTo, uuid.ToString()).Equals(result)
+                    );
                 }
 
-                {
-                    yield return new object[]
-                    {
-                        @"{""field"" :""date"", ""op"":""eq"", ""value"" : ""2019-8-23T00:00"" }",
-                        typeof(Filter),
-                        (Expression<Func<object, bool>>) ((result) => new Filter("date", EqualTo, "2019-8-23T00:00" ).Equals(result))
-                    };
-                }
+                cases.Add
+                (
+                    @"{""field"" :""date"", ""op"":""eq"", ""value"" : ""2019-8-23T00:00"" }",
+                    typeof(Filter),
+                     (result) => new Filter("date", EqualTo, "2019-8-23T00:00").Equals(result)
+                );
 
-                yield return new object[]
-                {
+                cases.Add
+                (
                     "{" +
                         @"""logic"": ""or""," +
                         @"""filters"": [" +
@@ -169,7 +172,7 @@ namespace DataFilters.UnitTests.Converters
                         "]" +
                     "}",
                     typeof(MultiFilter),
-                    (Expression<Func<object, bool>>) ((result) =>
+                     (result) =>
                         new MultiFilter
                         {
                             Logic = Or,
@@ -179,11 +182,11 @@ namespace DataFilters.UnitTests.Converters
                                 new Filter("Firstname", EqualTo, "Clark")
                             }
                         }.Equals(result)
-                    )
-                };
 
-                yield return new object[]
-                {
+                );
+
+                cases.Add
+                (
                     "{" +
                         @"""logic"": ""and""," +
                         @"""filters"": [" +
@@ -198,7 +201,7 @@ namespace DataFilters.UnitTests.Converters
                         "]" +
                     "}",
                     typeof(MultiFilter),
-                    (Expression<Func<object, bool>>) ((result) =>
+                     (result) =>
                         new MultiFilter
                         {
                             Logic = And,
@@ -216,8 +219,10 @@ namespace DataFilters.UnitTests.Converters
                                 }
                             }
                         }.Equals(result)
-                    )
-                };
+
+                );
+
+                return cases;
             }
         }
 

--- a/test/DataFilters.UnitTests/FilterExtensionsTests.cs
+++ b/test/DataFilters.UnitTests/FilterExtensionsTests.cs
@@ -1,7 +1,6 @@
 ﻿namespace DataFilters.UnitTests
 {
     using System;
-    using System.Collections.Generic;
     using DataFilters;
     using DataFilters.Casing;
     using DataFilters.TestObjects;
@@ -17,62 +16,52 @@
     [UnitTest]
     public class FilterExtensionsTests(ITestOutputHelper outputHelper)
     {
-        public static IEnumerable<object[]> ToFilterCases
-        {
-            get
-            {
-                yield return new object[]
+        public static TheoryData<string, IFilter> ToFilterCases
+        => new()
                 {
-                    $"{nameof(Person.Firstname)}=Hal&{nameof(Person.Lastname)}=Jordan",
-                    new MultiFilter{
-                        Logic = And,
-                        Filters = new IFilter[]
+                    {
+                        $"{nameof(Person.Firstname)}=Hal&{nameof(Person.Lastname)}=Jordan",
+                        new MultiFilter
+                        {
+                            Logic = And,
+                            Filters = new IFilter[]
                         {
                             new Filter(nameof(Person.Firstname), EqualTo, "Hal"),
                             new Filter(nameof(Person.Lastname), EqualTo, "Jordan")
                         }
-                    }
-                };
+                        }
+                    },
 
-                yield return new object[]
-                {
+                    {
                         "",
                         new Filter(field: null, @operator: EqualTo)
-                };
-
-                yield return new object[]
-                {
+                    },
+                    {
                         "",
                         Filter.True
-                };
-
-                yield return new object[]
-                {
-                    $"{nameof(Person.Firstname)}=!*wayne",
-                    new Filter(field: nameof(Person.Firstname), @operator: NotEndsWith, value: "wayne")
-                };
-
-                yield return new object[]
-                {
-                    $"{nameof(Person.Firstname)}=Vandal|Gengis",
-                    new MultiFilter
+                    },
                     {
-                        Logic = Or,
-                        Filters = new IFilter[]
+                        $"{nameof(Person.Firstname)}=!*wayne",
+                        new Filter(field: nameof(Person.Firstname), @operator: NotEndsWith, value: "wayne")
+                    },
+                    {
+                        $"{nameof(Person.Firstname)}=Vandal|Gengis",
+                        new MultiFilter
+                        {
+                            Logic = Or,
+                            Filters = new IFilter[]
                         {
                             new Filter(field: nameof(Person.Firstname), @operator: EqualTo, value: "Vandal"),
                             new Filter(field: nameof(Person.Firstname), @operator: EqualTo, value: "Gengis")
                         }
-                    }
-                };
-
-                yield return new object[]
-                {
-                    $"{nameof(Person.Firstname)}=(V*|G*),(*l|*s)",
-                    new MultiFilter
+                        }
+                    },
                     {
-                        Logic = And,
-                        Filters = new IFilter[]
+                        $"{nameof(Person.Firstname)}=(V*|G*),(*l|*s)",
+                        new MultiFilter
+                        {
+                            Logic = And,
+                            Filters = new IFilter[]
                         {
                             new MultiFilter
                             {
@@ -93,238 +82,216 @@
                                 }
                             }
                         }
-                    }
-                };
+                        }
+                    },
 
-                yield return new object[]
-               {
-                    string.Empty,
-                    Filter.True
-               };
-
-                yield return new object[]
-                {
-                    "Firstname=Bruce",
-                    new Filter("Firstname", EqualTo, "Bruce")
-                };
-
-                yield return new object[]
-                {
-                    "Firstname=!Bruce",
-                    new Filter("Firstname", NotEqualTo, "Bruce")
-                };
-
-                yield return new object[]
-                {
-                    "Firstname=!!Bruce",
-                    new Filter("Firstname", EqualTo, "Bruce")
-                };
-
-                yield return new object[]
-                {
-                    "Firstname=Bruce|Dick",
-                    new MultiFilter
                     {
-                        Logic = Or,
-                        Filters = new IFilter[]
+                        string.Empty,
+                        Filter.True
+                    },
+
+                    {
+                        "Firstname=Bruce",
+                        new Filter("Firstname", EqualTo, "Bruce")
+                    },
+
+                    {
+                        "Firstname=!Bruce",
+                        new Filter("Firstname", NotEqualTo, "Bruce")
+                    },
+
+                    {
+                        "Firstname=!!Bruce",
+                        new Filter("Firstname", EqualTo, "Bruce")
+                    },
+
+                    {
+                        "Firstname=Bruce|Dick",
+                        new MultiFilter
+                        {
+                            Logic = Or,
+                            Filters = new IFilter[]
                         {
                             new Filter("Firstname", EqualTo, "Bruce"),
                             new Filter("Firstname", EqualTo, "Dick")
                         }
-                    }
-                };
+                        }
+                    },
 
-                yield return new object[]
-                {
-                    "Firstname=Bru*",
-                    new Filter("Firstname", StartsWith, "Bru")
-                };
-
-                yield return new object[]
-                {
-                    "Firstname=*Bru",
-                    new Filter("Firstname", EndsWith, "Bru")
-                };
-
-                yield return new object[]
-                {
-                    "Height=[100 TO *[",
-                    new Filter("Height", GreaterThanOrEqual, 100)
-                };
-
-                yield return new object[]
-                {
-                    "Height=[100 TO 200]",
-                    new MultiFilter
                     {
-                        Logic = And,
-                        Filters = new IFilter[]
+                        "Firstname=Bru*",
+                        new Filter("Firstname", StartsWith, "Bru")
+                    },
+
+                    {
+                        "Firstname=*Bru",
+                        new Filter("Firstname", EndsWith, "Bru")
+                    },
+
+                    {
+                        "Height=[100 TO *[",
+                        new Filter("Height", GreaterThanOrEqual, 100)
+                    },
+
+                    {
+                        "Height=[100 TO 200]",
+                        new MultiFilter
+                        {
+                            Logic = And,
+                            Filters = new IFilter[]
                         {
                             new Filter("Height", GreaterThanOrEqual, 100),
                             new Filter("Height", LessThanOrEqualTo, 200)
                         }
-                    }
-                };
+                        }
+                    },
 
-                yield return new object[]
-                {
-                    "Height=]100 TO 200[",
-                    new MultiFilter
                     {
-                        Logic = And,
-                        Filters = new IFilter[]
+                        "Height=]100 TO 200[",
+                        new MultiFilter
+                        {
+                            Logic = And,
+                            Filters = new IFilter[]
                         {
                             new Filter("Height", GreaterThan, 100),
                             new Filter("Height", FilterOperator.LessThan, 200)
                         }
-                    }
-                };
+                        }
+                    },
 
-                yield return new object[]
-                {
-                    "Height=]* TO 200]",
-                     new Filter("Height", LessThanOrEqualTo, 200)
-                };
-
-                yield return new object[]
-                {
-                    "Nickname=Bat*,*man",
-                    new MultiFilter
                     {
-                        Logic = And,
-                        Filters = new IFilter[]
+                        "Height=]* TO 200]",
+                        new Filter("Height", LessThanOrEqualTo, 200)
+                    },
+
+                    {
+                        "Nickname=Bat*,*man",
+                        new MultiFilter
+                        {
+                            Logic = And,
+                            Filters = new IFilter[]
                         {
                             new Filter("Nickname", StartsWith, "Bat"),
                             new Filter("Nickname", EndsWith, "man"),
                         }
-                    }
-                };
+                        }
+                    },
 
-                yield return new object[]
-                {
-                    "Nickname=Bat*man",
-                    new MultiFilter
                     {
-                        Logic = And,
-                        Filters = new IFilter[]
+                        "Nickname=Bat*man",
+                        new MultiFilter
+                        {
+                            Logic = And,
+                            Filters = new IFilter[]
                         {
                             new Filter("Nickname", StartsWith, "Bat"),
                             new Filter("Nickname", EndsWith, "man"),
                         }
-                    }
-                };
+                        }
+                    },
 
-                yield return new object[]
-                {
-                    "Nickname=Bat*,*man*",
-                     new MultiFilter
                     {
-                        Logic = And,
-                        Filters = new IFilter[]
+                        "Nickname=Bat*,*man*",
+                        new MultiFilter
+                        {
+                            Logic = And,
+                            Filters = new IFilter[]
                         {
                             new Filter("Nickname", StartsWith, "Bat"),
                             new Filter("Nickname", Contains, "man"),
                         }
-                    }
-                };
+                        }
+                    },
 
-                yield return new object[]
-                {
-                    "Firstname=!Bru*",
-                    new Filter("Firstname", NotStartsWith, "Bru")
-                };
-
-                yield return new object[]
-                {
-                    "Nickname=!(Bat*man)",
-                    new MultiFilter
                     {
-                        Logic = Or,
-                        Filters = new IFilter[]
+                        "Firstname=!Bru*",
+                        new Filter("Firstname", NotStartsWith, "Bru")
+                    },
+
+                    {
+                        "Nickname=!(Bat*man)",
+                        new MultiFilter
+                        {
+                            Logic = Or,
+                            Filters = new IFilter[]
                         {
                             new Filter("Nickname", NotStartsWith, "Bat"),
                             new Filter("Nickname", NotEndsWith, "man"),
                         }
-                    }
-                };
+                        }
+                    },
 
-                yield return new object[]
-                {
-                    "Firstname=Bru*&Lastname=Wayne",
-                    new MultiFilter
                     {
-                        Logic = And,
-                        Filters = new IFilter[]
+                        "Firstname=Bru*&Lastname=Wayne",
+                        new MultiFilter
+                        {
+                            Logic = And,
+                            Filters = new IFilter[]
                         {
                             new Filter("Firstname", StartsWith, "Bru"),
                             new Filter("Lastname", EqualTo, "Wayne"),
                         }
-                    }
-                };
+                        }
+                    },
 
-                yield return new object[]
-                {
-                    "Firstname=Br[uU]ce",
-                    new MultiFilter
                     {
-                        Logic = Or,
-                        Filters = new IFilter[]
+                        "Firstname=Br[uU]ce",
+                        new MultiFilter
+                        {
+                            Logic = Or,
+                            Filters = new IFilter[]
                         {
                             new Filter("Firstname", EqualTo, "Bruce"),
                             new Filter("Firstname", EqualTo, "BrUce"),
                         }
-                    }
-                };
+                        }
+                    },
 
-                yield return new object[]
-                {
-                    "Firstname=*Br[uU]",
-                    new MultiFilter
                     {
-                        Logic = Or,
-                        Filters = new IFilter[]
+                        "Firstname=*Br[uU]",
+                        new MultiFilter
+                        {
+                            Logic = Or,
+                            Filters = new IFilter[]
                         {
                             new Filter("Firstname", EndsWith, "Bru"),
                             new Filter("Firstname", EndsWith, "BrU"),
                         }
-                    }
-                };
+                        }
+                    },
 
-                yield return new object[]
-                {
-                    "Firstname=!(Bruce|Wayne)",
-                    new MultiFilter
                     {
-                        Logic = And,
-                        Filters = new IFilter[]
+                        "Firstname=!(Bruce|Wayne)",
+                        new MultiFilter
+                        {
+                            Logic = And,
+                            Filters = new IFilter[]
                         {
                             new Filter("Firstname", NotEqualTo, "Bruce"),
                             new Filter("Firstname", NotEqualTo, "Wayne")
                         }
-                    }
-                };
+                        }
+                    },
 
-                yield return new object[]
-                {
-                    "Firstname=(Bruce|Wayne)",
-                    new MultiFilter
                     {
-                        Logic = Or,
-                        Filters = new IFilter[]
+                        "Firstname=(Bruce|Wayne)",
+                        new MultiFilter
+                        {
+                            Logic = Or,
+                            Filters = new IFilter[]
                         {
                             new Filter("Firstname", EqualTo, "Bruce"),
                             new Filter("Firstname", EqualTo, "Wayne")
                         }
-                    }
-                };
+                        }
+                    },
 
-                yield return new object[]
-                {
-                    "Firstname=(Bat*|Sup*)|(*man|*er)",
-                    new MultiFilter
                     {
-                        Logic = Or,
-                        Filters = new IFilter[]
+                        "Firstname=(Bat*|Sup*)|(*man|*er)",
+                        new MultiFilter
+                        {
+                            Logic = Or,
+                            Filters = new IFilter[]
                         {
                             new MultiFilter
                             {
@@ -345,47 +312,43 @@
                                 }
                             },
                         }
-                    }
-                };
+                        }
+                    },
 
-                yield return new object[]
-                {
-                    @"BattleCry=*\!",
-                    new Filter(field: "BattleCry", @operator: EndsWith, "!")
-                };
-
-                yield return new object[]
-                {
-                    @"BattleCry=\**",
-                    new Filter(field: "BattleCry", @operator: StartsWith, "*")
-                };
-
-                yield return new object[]
-                {
-                    "BirthDate=]2016-10-18 TO 2016-10-25[",
-                    new MultiFilter
                     {
-                        Logic = And,
-                        Filters = new IFilter[]
+                        @"BattleCry=*\!",
+                        new Filter(field: "BattleCry", @operator: EndsWith, "!")
+                    },
+
+                    {
+                        @"BattleCry=\**",
+                        new Filter(field: "BattleCry", @operator: StartsWith, "*")
+                    },
+
+                    {
+                        "BirthDate=]2016-10-18 TO 2016-10-25[",
+                        new MultiFilter
+                        {
+                            Logic = And,
+                            Filters = new IFilter[]
                         {
 #if NET6_0_OR_GREATER
-		                    new Filter(nameof(SuperHero.BirthDate), GreaterThan, DateOnly.FromDateTime(18.October(2016))),
+                            new Filter(nameof(SuperHero.BirthDate), GreaterThan, DateOnly.FromDateTime(18.October(2016))),
                             new Filter(nameof(SuperHero.BirthDate), FilterOperator.LessThan, DateOnly.FromDateTime(25.October(2016)))
 #else
                             new Filter(nameof(SuperHero.BirthDate), GreaterThan, 18.October(2016)),
                             new Filter(nameof(SuperHero.BirthDate), FilterOperator.LessThan, 25.October(2016))
 #endif
                         }
-                    }
-                };
+                        }
+                    },
 
-                yield return new object[]
-                {
-                    "BirthDate=]2016-10-18T18:00:00 TO 2016-10-25T19:00:00[",
-                    new MultiFilter
                     {
-                        Logic = And,
-                        Filters = new IFilter[]
+                        "BirthDate=]2016-10-18T18:00:00 TO 2016-10-25T19:00:00[",
+                        new MultiFilter
+                        {
+                            Logic = And,
+                            Filters = new IFilter[]
                         {
 #if NET6_0_OR_GREATER
                             new Filter(nameof(SuperHero.BirthDate), GreaterThan, DateOnly.FromDateTime(18.October(2016))),
@@ -395,55 +358,52 @@
                             new Filter(nameof(SuperHero.BirthDate), FilterOperator.LessThan, 25.October(2016).Add(19.Hours()))
 #endif
                         }
-                    }
-                };
+                        }
+                    },
 
-                yield return new object[]
-                {
-                    "DateTimeWithOffset=]2016-10-18T18:00:00Z TO 2016-10-18T23:00:00-02:00[",
-                    new MultiFilter
                     {
-                        Logic = And,
-                        Filters = new IFilter[]
+                        "DateTimeWithOffset=]2016-10-18T18:00:00Z TO 2016-10-18T23:00:00-02:00[",
+                        new MultiFilter
+                        {
+                            Logic = And,
+                            Filters = new IFilter[]
                         {
                             new Filter("DateTimeWithOffset", GreaterThan, 18.October(2016).Add(18.Hours()).ToDateTimeOffset()),
-                            new Filter("DateTimeWithOffset", FilterOperator.LessThan,  18.October(2016).Add(23.Hours()).ToDateTimeOffset(-2.Hours()))
+                            new Filter("DateTimeWithOffset", FilterOperator.LessThan, 18.October(2016).Add(23.Hours()).ToDateTimeOffset(-2.Hours()))
                         }
-                    }
-                };
+                        }
+                    },
 
-                yield return new object[]
-                {
-                    "Nickname={Bat|Sup|Wonder}*,*m[ae]n",
-                    new MultiFilter
                     {
-                        Logic = And,
-                        Filters = new[]
+                        "Nickname={Bat|Sup|Wonder}*,*m[ae]n",
+                        new MultiFilter
                         {
-                            new MultiFilter
-                            {
-                                Logic = Or,
-                                Filters = new[]
+                            Logic = And,
+                            Filters = new[]
+                        {
+                                new MultiFilter
                                 {
-                                    new Filter(nameof(SuperHero.Nickname), StartsWith, "Bat"),
-                                    new Filter(nameof(SuperHero.Nickname), StartsWith, "Sup"),
-                                    new Filter(nameof(SuperHero.Nickname), StartsWith, "Wonder")
-                                }
-                            },
-                            new MultiFilter
-                            {
-                                Logic = Or,
-                                Filters = new[]
+                                    Logic = Or,
+                                    Filters = new[]
                                 {
-                                    new Filter(nameof(SuperHero.Nickname), EndsWith, "man"),
-                                    new Filter(nameof(SuperHero.Nickname), EndsWith, "men")
+                                        new Filter(nameof(SuperHero.Nickname), StartsWith, "Bat"),
+                                        new Filter(nameof(SuperHero.Nickname), StartsWith, "Sup"),
+                                        new Filter(nameof(SuperHero.Nickname), StartsWith, "Wonder")
+                                    }
+                                },
+                                new MultiFilter
+                                {
+                                    Logic = Or,
+                                    Filters = new[]
+                                {
+                                        new Filter(nameof(SuperHero.Nickname), EndsWith, "man"),
+                                        new Filter(nameof(SuperHero.Nickname), EndsWith, "men")
+                                    }
                                 }
                             }
                         }
-                    }
+                    },
                 };
-            }
-        }
 
         [Theory]
         [MemberData(nameof(ToFilterCases))]
@@ -473,25 +433,20 @@
                 .NotBeNullOrWhiteSpace();
         }
 
-        public static IEnumerable<object[]> ToFilterWithPropertyNameResolutionStrategyCases
-        {
-            get
-            {
-                yield return new object[]
+        public static TheoryData<string, PropertyNameResolutionStrategy, Filter> ToFilterWithPropertyNameResolutionStrategyCases
+            => new()
                 {
-                    "SnakeCaseProperty=10",
-                    PropertyNameResolutionStrategy.SnakeCase,
-                    new Filter("snake_case_property", EqualTo, "10")
+                    {
+                        "SnakeCaseProperty=10",
+                        PropertyNameResolutionStrategy.SnakeCase,
+                        new Filter("snake_case_property", EqualTo, "10")
+                    },
+                    {
+                        "pascal_case_property=10",
+                        PropertyNameResolutionStrategy.PascalCase,
+                        new Filter("PascalCaseProperty", EqualTo, "10")
+                    }
                 };
-
-                yield return new object[]
-                {
-                    "pascal_case_property=10",
-                    PropertyNameResolutionStrategy.PascalCase,
-                    new Filter("PascalCaseProperty", EqualTo, "10")
-                };
-            }
-        }
 
         [Theory]
         [MemberData(nameof(ToFilterWithPropertyNameResolutionStrategyCases))]
@@ -505,18 +460,18 @@
                   .Be(expected);
         }
 
-        public static IEnumerable<object[]> ToFilterWithFilterOptionsCases
+        public static TheoryData<string, FilterOptions, MultiFilter> ToFilterWithFilterOptionsCases
         {
             get
             {
                 FilterLogic[] logics = [And, Or];
-
+                TheoryData<string, FilterOptions, MultiFilter> cases = [];
                 foreach (FilterLogic logic in logics)
                 {
-                    yield return new object[]
-                    {
+                    cases.Add
+                    (
                         "snake_case_property=10&PascalCaseProperty=value",
-                        new FilterOptions{ Logic = logic },
+                        new FilterOptions { Logic = logic },
                         new MultiFilter
                         {
                             Logic = logic,
@@ -526,12 +481,12 @@
                                 new Filter("PascalCaseProperty", EqualTo, "value"),
                             }
                         }
-                    };
+                    );
 
-                    yield return new object[]
-                    {
+                    cases.Add
+                    (
                         "snake_case_property=10&PascalCaseProperty=value",
-                        new FilterOptions{ Logic = logic },
+                        new FilterOptions { Logic = logic },
                         new MultiFilter
                         {
                             Logic = logic,
@@ -541,8 +496,10 @@
                                 new Filter("PascalCaseProperty", EqualTo, "value")
                             }
                         }
-                    };
+                    );
                 }
+
+                return cases;
             }
         }
 

--- a/test/DataFilters.UnitTests/Grammar/Parsing/FilterTokenParserTests.cs
+++ b/test/DataFilters.UnitTests/Grammar/Parsing/FilterTokenParserTests.cs
@@ -63,56 +63,48 @@
                                                            .HaveProperty<TokenListParser<FilterToken, GuidValueExpression>>("GlobalUniqueIdentifier").And
                                                            .HaveProperty<TokenListParser<FilterToken, FilterExpression>>("Or");
 
-        public static IEnumerable<object[]> AlphaNumericCases
-        {
-            get
-            {
-                yield return new object[]
+        public static TheoryData<string, ConstantValueExpression> AlphaNumericCases
+            => new()
                 {
-                    "Bruce",
-                    new StringValueExpression("Bruce")
-                };
+                    {
+                        "Bruce",
+                        new StringValueExpression("Bruce")
+                    },
 
-                yield return new object[]
-                {
-                    @"Vandal\*",
-                    new StringValueExpression("Vandal*")
-                };
+                    {
+                        @"Vandal\*",
+                        new StringValueExpression("Vandal*")
+                    },
 
-                yield return new object[]
-                {
-                    @"Van\*dal",
-                    new StringValueExpression("Van*dal")
-                };
-                yield return new object[]
-                {
-                    "1Bruce",
-                    new StringValueExpression("1Bruce")
-                };
+                    {
+                        @"Van\*dal",
+                        new StringValueExpression("Van*dal")
+                    },
 
-                yield return new object[]
-                {
-                    @"0\ \,i#y",
-                    new StringValueExpression("0 ,i#y")
-                };
+                    {
+                        "1Bruce",
+                        new StringValueExpression("1Bruce")
+                    },
 
-                yield return new object[]
-                {
-                    @"E
+                    {
+                        @"0\ \,i#y",
+                        new StringValueExpression("0 ,i#y")
+                    },
+
+                    {
+                        @"E
 I\&_Oj
 \.",
-                    new StringValueExpression(@"E
+                        new StringValueExpression(@"E
 I&_Oj
 .")
-                };
+                    },
 
-                yield return new object[]
-                {
-                    "39.95173047301258862",
-                    new NumericValueExpression("39.95173047301258862")
+                    {
+                        "39.95173047301258862",
+                        new NumericValueExpression("39.95173047301258862")
+                    },
                 };
-            }
-        }
 
         [Theory]
         [MemberData(nameof(AlphaNumericCases))]
@@ -216,38 +208,29 @@ I&_Oj
         private static string StringifyTokens(TokenList<FilterToken> tokens)
             => tokens.Select(token => new { token.Kind, Value = token.ToStringValue() }).Jsonify();
 
-        public static IEnumerable<object[]> ContainsCases
+        public static TheoryData<string, ContainsExpression> ContainsCases
         {
             get
             {
-                yield return new object[]
+                TheoryData<string, ContainsExpression> cases = new()
                 {
-                    "*bat*",
-                    new ContainsExpression("bat")
-                };
-
-                yield return new object[]
-                {
-                    @"*bat\*man*",
-                    new ContainsExpression("bat*man")
-                };
-
-                yield return new object[]
-                {
-                    "*d3aa022d-ec52-47aa-be13-6823c478c60a*",
-                    new ContainsExpression("d3aa022d-ec52-47aa-be13-6823c478c60a")
+                    { "*bat*", new ContainsExpression("bat")},
+                    { @"*bat\*man*", new ContainsExpression("bat*man")},
+                    {"*d3aa022d-ec52-47aa-be13-6823c478c60a*", new ContainsExpression("d3aa022d-ec52-47aa-be13-6823c478c60a")}
                 };
 
                 string[] punctuations = [".", "-", ":", "_"];
 
                 foreach (string punctuation in punctuations)
                 {
-                    yield return new object[]
-                    {
+                    cases.Add
+                    (
                         $"*{punctuation}*",
                         new ContainsExpression(punctuation)
-                    };
+                    );
                 }
+
+                return cases;
             }
         }
 
@@ -266,29 +249,21 @@ I&_Oj
             AssertThatShould_parse(expression, expectedContains);
         }
 
-        public static IEnumerable<object[]> OrExpressionCases
-        {
-            get
+        public static TheoryData<string, OrExpression> OrExpressionCases
+            => new()
             {
-                yield return new object[]
                 {
                     "Bruce|bat*",
                     new OrExpression(new StringValueExpression("Bruce"), new StartsWithExpression("bat"))
-                };
-
-                yield return new object[]
+                },
                 {
                     "Bruce|Wayne",
                     new OrExpression(new StringValueExpression("Bruce"), new StringValueExpression("Wayne"))
-                };
-
-                yield return new object[]
+                },
                 {
                     "Bru*|Di*",
                     new OrExpression(new StartsWithExpression("Bru"), new StartsWithExpression("Di"))
-                };
-
-                yield return new object[]
+                },
                 {
                     "!(Bat*|Sup*)|!*man",
                     new OrExpression(
@@ -299,17 +274,14 @@ I&_Oj
                             ),
                         right: new NotExpression(new EndsWithExpression("man"))
                     )
-                };
-
-                yield return new object[]
+                },
                 {
                     "Bat|Wonder|Sup",
                     new OrExpression(new OrExpression(new StringValueExpression("Bat"),
                                                       new StringValueExpression("Wonder")),
                                     new StringValueExpression("Sup"))
-                };
-            }
-        }
+                }
+            };
 
         [Theory]
         [MemberData(nameof(OrExpressionCases))]
@@ -326,17 +298,13 @@ I&_Oj
             AssertThatShould_parse(expression, expected);
         }
 
-        public static IEnumerable<object[]> AndExpressionCases
-        {
-            get
+        public static TheoryData<string, AndExpression> AndExpressionCases
+            => new()
             {
-                yield return new object[]
                 {
                     "bat*,man*",
                     new AndExpression(new StartsWithExpression("bat"), new StartsWithExpression("man"))
-                };
-
-                yield return new object[]
+                },
                 {
                     "!(Bat*|Sup*),!*man",
                     new AndExpression(
@@ -347,15 +315,12 @@ I&_Oj
                             ),
                         right: new NotExpression(new EndsWithExpression("man"))
                     )
-                };
-
-                yield return new object[]
+                },
                 {
                     "bat*man",
                     new AndExpression(new StartsWithExpression("bat"), new EndsWithExpression("man"))
-                };
-            }
-        }
+                }
+            };
 
         [Theory]
         [MemberData(nameof(AndExpressionCases))]
@@ -387,11 +352,9 @@ I&_Oj
             AssertThatShould_parse(expression, expected);
         }
 
-        public static IEnumerable<object[]> NotParsingCases
-        {
-            get
+        public static TheoryData<string, NotExpression> NotParsingCases
+            => new()
             {
-                yield return new object[]
                 {
                     "!!!!!(w%A*@,2088-08-10)",
                     new NotExpression(
@@ -411,18 +374,15 @@ I&_Oj
                                     )
                                 )
                             )
-                };
-
-                yield return new object[]
+                },
                 {
                     "!![50 TO 50]",
                     new NotExpression
                         (new NotExpression(
                                 new IntervalExpression(min: new (new NumericValueExpression("50"), true),
                                                                                new(new NumericValueExpression("60"), true))))
-                };
-            }
-        }
+                }
+            };
 
         [Theory]
         [MemberData(nameof(NotParsingCases))]
@@ -439,115 +399,98 @@ I&_Oj
             AssertThatShould_parse(expression, expected);
         }
 
-        public static IEnumerable<object[]> OneOfExpressionCases
-        {
-            get
+        public static TheoryData<string, OneOfExpression> OneOfExpressionCases
+            => new()
             {
-                yield return new object[]
                 {
                     "[Bb]",
                     new OneOfExpression(new StringValueExpression("B"), new StringValueExpression("b"))
-                };
+                },
 
-                yield return new object[]
                 {
                     "[Bb]ruce",
                     new OneOfExpression(new StringValueExpression("Bruce"), new StringValueExpression("bruce"))
-                };
+                },
 
-                yield return new object[]
                 {
                     "[Bb]at*",
                     new OneOfExpression(new StartsWithExpression("Bat"), new StartsWithExpression("bat"))
-                };
+                },
 
-                yield return new object[]
                 {
                     "Ma*[Nn]",
                     new OneOfExpression(
                         new AndExpression(new StartsWithExpression("Ma"), new EndsWithExpression("N")),
                         new AndExpression(new StartsWithExpression("Ma"), new EndsWithExpression("n"))
                     )
-                };
+                },
 
-                yield return new object[]
                 {
                     "cat[Ww]oman",
                     new OneOfExpression(new StringValueExpression("catWoman"), new StringValueExpression("catwoman"))
-                };
+                },
 
-                yield return new object[]
                 {
                     "*Br[Uu]",
                     new OneOfExpression(new EndsWithExpression("BrU"), new EndsWithExpression("Bru"))
-                };
+                },
 
-                yield return new object[]
                 {
                     "Bo[Bb]",
                     new OneOfExpression(new StringValueExpression("BoB"), new StringValueExpression("Bob"))
-                };
+                },
 
-                yield return new object[]
                 {
                     "[Bb]*ob",
                     new OneOfExpression(new AndExpression(new StartsWithExpression("B"), new EndsWithExpression("ob")),
                                         new AndExpression(new StartsWithExpression("b"), new EndsWithExpression("ob")))
-                };
+                },
 
-                yield return new object[]
                 {
                     "*[Mm]an",
                     new OneOfExpression(new EndsWithExpression("Man"), new EndsWithExpression("man"))
-                };
+                },
 
-                yield return new object[]
                 {
                     "*[Mm]",
                     new OneOfExpression(new EndsWithExpression("M"), new EndsWithExpression("m"))
-                };
+                },
 
-                yield return new object[]
                 {
                     "[a-z]",
                     new OneOfExpression(GetCharacters('a', 'z').Select(chr => new StringValueExpression(chr.ToString())).ToArray())
-                };
+                },
 
-                yield return new object[]
                 {
                     "[a-zA-Z0-9]",
                     new OneOfExpression(GetCharacters('a', 'z').Concat(GetCharacters('A', 'Z'))
                                                                .Concat(GetCharacters('0', '9'))
                                                                .Select(chr => new StringValueExpression(chr.ToString()))
                                                                .ToArray())
-                };
+                },
 
-                yield return new object[]
                 {
                     "{Bat|Sup|Wonder}*",
                     new OneOfExpression(new StartsWithExpression("Bat"),
                                         new StartsWithExpression("Sup"),
                                         new StartsWithExpression("Wonder"))
-                };
+                },
 
-                yield return new object[]
                 {
                     "[ab][cd]",
                     new OneOfExpression(new StringValueExpression("ac"),
                                         new StringValueExpression("ad"),
                                         new StringValueExpression("bc"),
                                         new StringValueExpression("bd"))
-                };
+                },
 
-                yield return new object[]
                 {
                     "{Bat|Sup|Wonder}",
                     new OneOfExpression(new StringValueExpression("Bat"),
                                         new StringValueExpression("Sup"),
                                         new StringValueExpression("Wonder"))
-                };
-            }
-        }
+                }
+            };
 
         private static IEnumerable<char> GetCharacters(char regexStart, char regexEnd)
             => Enumerable.Range(regexStart, regexEnd - regexStart + 1)
@@ -610,35 +553,38 @@ I&_Oj
             });
         }
 
-        public static IEnumerable<object[]> IntervalCases
+        public static TheoryData<string, string, IntervalExpression> IntervalCases
         {
             get
             {
+                TheoryData<string, string, IntervalExpression> cases = [];
                 string[] cultures = ["fr-FR", "en-GB", "en-US"];
                 foreach (string culture in cultures)
                 {
-                    yield return new object[]
-                    {
+                    cases.Add
+                    (
                         culture,
                         "[5 TO 5[",
-                        new IntervalExpression(new BoundaryExpression(new NumericValueExpression("5"), true) , new BoundaryExpression(new NumericValueExpression("5"), false))
-                    };
+                        new IntervalExpression(new BoundaryExpression(new NumericValueExpression("5"), true), new BoundaryExpression(new NumericValueExpression("5"), false))
+                    );
 
-                    yield return new object[]
-                    {
+                    cases.Add
+                    (
                         culture,
                         "[1993-08-04T00:25:05.155Z TO 1908-06-08T03:18:46.745-09:50[",
-                        new IntervalExpression(new BoundaryExpression(new DateTimeExpression(new (1993, 8, 4), new(0, 25, 5, 155), OffsetExpression.Zero), true),
-                                               new BoundaryExpression(new DateTimeExpression(new (1908, 6, 8), new(3, 18, 46,745), new(NumericSign.Minus, 9, 50)), false))
-                    };
+                        new IntervalExpression(new BoundaryExpression(new DateTimeExpression(new(1993, 8, 4), new(0, 25, 5, 155), OffsetExpression.Zero), true),
+                                               new BoundaryExpression(new DateTimeExpression(new(1908, 6, 8), new(3, 18, 46, 745), new(NumericSign.Minus, 9, 50)), false))
+                    );
 
-                    yield return new object[]
-                    {
+                    cases.Add
+                    (
                         culture,
                         "]* TO 1963-06-03T15:53:44.609Z]",
-                        new IntervalExpression(max:new BoundaryExpression(new DateTimeExpression(new (1963, 6, 3), new (15, 53, 44, 609), OffsetExpression.Zero), true))
-                    };
+                        new IntervalExpression(max: new BoundaryExpression(new DateTimeExpression(new(1963, 6, 3), new(15, 53, 44, 609), OffsetExpression.Zero), true))
+                    );
                 }
+
+                return cases;
             }
         }
 
@@ -680,41 +626,34 @@ I&_Oj
             });
         }
 
-        public static IEnumerable<object[]> PropertyNameCases
-        {
-            get
+        public static TheoryData<string, PropertyName> PropertyNameCases
+            => new()
             {
-                yield return new object[]
                 {
                     "Firstname=Bruce",
                     new PropertyName("Firstname")
-                };
+                },
 
-                yield return new object[]
                 {
                     @"Henchmen[""Name""]=*rob*",
                     new PropertyName(@"Henchmen[""Name""]")
-                };
+                },
 
-                yield return new object[]
                 {
                     @"Henchmen[""Powers""][""Description""]=*strength*",
                     new PropertyName(@"Henchmen[""Powers""][""Description""]")
-                };
+                },
 
-                yield return new object[]
                 {
                     @"Henchmen[""first_name""]=*rob*",
                     new PropertyName(@"Henchmen[""first_name""]")
-                };
+                },
 
-                yield return new object[]
                 {
                     "first_name=Bruce",
                     new PropertyName("first_name")
-                };
-            }
-        }
+                },
+            };
 
         [Theory]
         [MemberData(nameof(PropertyNameCases))]
@@ -733,73 +672,59 @@ I&_Oj
                       .Be(expected);
         }
 
-        public static IEnumerable<object[]> CriterionCases
-        {
-            get
+        public static TheoryData<string, (PropertyName prop, FilterExpression expression)> CriterionCases
+            => new()
             {
-                yield return new object[]
                 {
                     "Name=Vandal",
                     (
                         new PropertyName("Name"),
-                        (FilterExpression) new StringValueExpression("Vandal")
+                         new StringValueExpression("Vandal")
                     )
-                };
-
-                yield return new object[]
+                },
                 {
                     "first_name=Vandal",
                     (
                         new PropertyName("first_name"),
-                        (FilterExpression) new StringValueExpression("Vandal")
+                         new StringValueExpression("Vandal")
                     )
-                };
-
-                yield return new object[]
+                },
                 {
                     "Name=Vandal|Banner",
                     (
                         new PropertyName("Name"),
-                        (FilterExpression) new OrExpression(new StringValueExpression("Vandal"), new StringValueExpression("Banner"))
+                         new OrExpression(new StringValueExpression("Vandal"), new StringValueExpression("Banner"))
                     )
-                };
-
-                yield return new object[]
+                },
                 {
                     "Name=Vandal|Banner",
                     (
                         new PropertyName("Name"),
-                        (FilterExpression) new OrExpression(new StringValueExpression("Vandal"), new StringValueExpression("Banner"))
+                         new OrExpression(new StringValueExpression("Vandal"), new StringValueExpression("Banner"))
                     )
-                };
-
-                yield return new object[]
+                },
                 {
                     "Size=[10 TO 20]",
                     (
                         new PropertyName("Size"),
-                        (FilterExpression) new IntervalExpression(min: new BoundaryExpression(new NumericValueExpression("10"),
+                         new IntervalExpression(min: new BoundaryExpression(new NumericValueExpression("10"),
                                                                                            included: true),
                                                                max: new BoundaryExpression(new NumericValueExpression("20"),
                                                                                            included: true))
                     )
-                };
-
-                yield return new object[]
+                },
                 {
                     @"Acolytes[""Name""][""Superior""]=Vandal|Banner",
                     (
                         new PropertyName(@"Acolytes[""Name""][""Superior""]"),
-                        (FilterExpression) new OrExpression(new StringValueExpression("Vandal"), new StringValueExpression("Banner"))
+                         new OrExpression(new StringValueExpression("Vandal"), new StringValueExpression("Banner"))
                     )
-                };
-
-                yield return new object[]
+                },
                 {
                     @"Appointment[""Date""]=]2012-10-19T15:03:45Z TO 2012-10-19T15:30:45+01:00[",
                     (
                         new PropertyName(@"Appointment[""Date""]"),
-                        (FilterExpression) new IntervalExpression(min: new BoundaryExpression(new DateTimeExpression(new DateExpression(year: 2012, month: 10, day: 19 ),
+                         new IntervalExpression(min: new BoundaryExpression(new DateTimeExpression(new DateExpression(year: 2012, month: 10, day: 19 ),
                                                                                                                                new TimeExpression(hours : 15, minutes: 03, seconds: 45),
                                                                                                                                OffsetExpression.Zero),
                                                                                               included: false),
@@ -809,36 +734,30 @@ I&_Oj
                                                                                               included: false)
                         )
                     )
-                };
-
-                yield return new object[]
+                },
                 {
                     "Name=*[Mm]an",
                     (
                         new PropertyName("Name"),
-                        (FilterExpression) new OneOfExpression(new EndsWithExpression("Man"),
+                         new OneOfExpression(new EndsWithExpression("Man"),
                                                                new EndsWithExpression("man"))
                     )
-                };
-
-                yield return new object[]
+                },
                 {
                     "Name=[Bb]o[Bb]",
                     (
                         new PropertyName("Name"),
-                        (FilterExpression)new OneOfExpression(new StringValueExpression("BoB"),
+                        new OneOfExpression(new StringValueExpression("BoB"),
                                                               new StringValueExpression("Bob"),
                                                               new StringValueExpression("boB"),
                                                               new StringValueExpression("bob"))
                     )
-                };
-
-                yield return new object[]
+                },
                 {
                     "prop=!(((1908-09-30T00:31:33.127+05:13|2000-06-19)|(00:01:40.443|*))|((2003-05-27|89ae5244-2a98-16cc-6f99-d17658594604)|(s*|*0$)))",
                     (
                         new PropertyName("prop"),
-                        (FilterExpression) new NotExpression(
+                        new NotExpression(
                                 new OrExpression(
                                 new OrExpression(
 
@@ -855,20 +774,17 @@ I&_Oj
                                         )
                                 ))
                     )
-                };
-
-                yield return new object[]
+                },
                 {
                     "Nickname={Bat|Sup|Wonder}*",
                     (
                         new PropertyName("Nickname"),
-                        (FilterExpression) new OneOfExpression(new StartsWithExpression("Bat"),
+                        new OneOfExpression(new StartsWithExpression("Bat"),
                                             new StartsWithExpression("Sup"),
                                             new StartsWithExpression("Wonder"))
                     )
-                };
-            }
-        }
+                },
+            };
 
         /// <summary>
         /// Tests if <see cref="FilterTokenParser.Criteria"/> can parse a criteria
@@ -900,56 +816,52 @@ I&_Oj
             }
         }
 
-        public static IEnumerable<object[]> CriteriaCases
+        public static TheoryData<string, Expression<Func<IEnumerable<(PropertyName prop, FilterExpression expression)>, bool>>> CriteriaCases
         {
             get
             {
-                yield return new object[]
+                TheoryData<string, Expression<Func<IEnumerable<(PropertyName prop, FilterExpression expression)>, bool>>> cases = new()
                 {
-                    "Firstname=Vandal&Lastname=Savage",
-                    (Expression<Func<IEnumerable<(PropertyName prop, FilterExpression expression)>, bool>>)(
-                        expressions => expressions.Exactly(2)
-                        && expressions.Once(expr => expr.prop.Equals(new PropertyName("Firstname")) && expr.expression.Equals(new StringValueExpression("Vandal")))
-                        && expressions.Once(expr => expr.prop.Equals(new PropertyName("Lastname")) && expr.expression.Equals(new StringValueExpression("Savage")))
-                    )
-                };
+                    {
+                        "Firstname=Vandal&Lastname=Savage",
 
-                yield return new object[]
-                {
-                    "Firstname=[Vv]andal",
-                    (Expression<Func<IEnumerable<(PropertyName prop, FilterExpression expression)>, bool>>)(
+                            expressions => expressions.Exactly(2)
+                            && expressions.Once(expr => expr.prop.Equals(new PropertyName("Firstname")) && expr.expression.Equals(new StringValueExpression("Vandal")))
+                            && expressions.Once(expr => expr.prop.Equals(new PropertyName("Lastname")) && expr.expression.Equals(new StringValueExpression("Savage")))
+
+                    },
+                    {
+                        "Firstname=[Vv]andal",
                         expressions => expressions.Exactly(1)
-                        && expressions.Once(expr => expr.prop.Equals(new PropertyName("Firstname"))
-                            && expr.expression.Equals(new OneOfExpression(new StringValueExpression("Vandal"),
-                                                                              new StringValueExpression("vandal"))))
-                    )
+                            && expressions.Once(expr => expr.prop.Equals(new PropertyName("Firstname"))
+                                && expr.expression.Equals(new OneOfExpression(new StringValueExpression("Vandal"),
+                                                                                  new StringValueExpression("vandal"))))
+                    }
                 };
 
                 foreach (char c in FilterTokenizer.SpecialCharacters)
                 {
-                    yield return new object[]
-                    {
+                    cases.Add
+                    (
                         $@"Firstname=Vand\{c}al&Lastname=Savage",
-                        (Expression<Func<IEnumerable<(PropertyName prop, FilterExpression expression)>, bool>>)(
-                            expressions => expressions.Exactly(2)
+                        expressions => expressions.Exactly(2)
                                && expressions.Once(expr => expr.prop.Equals(new PropertyName("Firstname")) && expr.expression.Equals(new StringValueExpression($"Vand{c}al")))
                                && expressions.Once(expr => expr.prop.Equals(new PropertyName("Lastname")) && expr.expression.Equals(new StringValueExpression("Savage")))
-                        )
-                    };
+                    );
                 }
 
                 foreach (char c in FilterTokenizer.SpecialCharacters)
                 {
-                    yield return new object[]
-                    {
+                    cases.Add
+                    (
                         $@"first_name=Vand\{c}al&last_name=Savage",
-                        (Expression<Func<IEnumerable<(PropertyName prop, FilterExpression expression)>, bool>>)(
-                            expressions => expressions.Exactly(2)
+                        expressions => expressions.Exactly(2)
                                && expressions.Once(expr => expr.prop.Equals(new PropertyName("first_name")) && expr.expression.Equals(new StringValueExpression($"Vand{c}al")))
                                && expressions.Once(expr => expr.prop.Equals(new PropertyName("last_name")) && expr.expression.Equals(new StringValueExpression("Savage")))
-                        )
-                    };
+                    );
                 }
+
+                return cases;
             }
         }
 
@@ -988,18 +900,6 @@ I&_Oj
             AssertThatShould_parse(actual, expected);
         }
 
-        public static IEnumerable<object[]> DateCases
-        {
-            get
-            {
-                yield return new object[]
-                {
-                    "2019-01-12",
-                    new DateExpression(year : 2019, month: 01, day: 12)
-                };
-            }
-        }
-
         [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
         public void Should_parse_DateCases(DateExpression expected)
         {
@@ -1028,25 +928,28 @@ I&_Oj
             AssertThatShould_parse(actual, expected);
         }
 
-        public static IEnumerable<object[]> ParseGroupCases
+        public static TheoryData<GroupExpression, string> ParseGroupCases
         {
             get
             {
+                TheoryData<GroupExpression, string> cases = [];
                 string[] cultures = ["fr-FR", "en-GB", "en-US"];
                 foreach (string culture in cultures)
                 {
-                    yield return new object[]
-                    {
+                    cases.Add
+                    (
                         new GroupExpression(new DateTimeExpression(new(2090, 10, 10), new(3, 0, 40, 583), OffsetExpression.Zero)),
                         culture
-                    };
+                    );
 
-                    yield return new object[]
-                    {
+                    cases.Add
+                    (
                         new GroupExpression(new DateTimeExpression(new(2010, 06, 02), new(23, 45, 54, 331), OffsetExpression.Zero)),
                         culture
-                    };
+                    );
                 }
+
+                return cases;
             }
         }
 

--- a/test/DataFilters.UnitTests/Grammar/Parsing/FilterTokenizerTests.cs
+++ b/test/DataFilters.UnitTests/Grammar/Parsing/FilterTokenizerTests.cs
@@ -18,345 +18,329 @@
     [Feature(nameof(FilterTokenizer))]
     public class FilterTokenizerTests(ITestOutputHelper outputHelper)
     {
-        private readonly FilterTokenizer _sut = new FilterTokenizer();
+        private readonly FilterTokenizer _sut = new();
 
         [Fact]
         public void IsTokenizer() => typeof(FilterTokenizer).Should()
                                                             .HaveDefaultConstructor().And
                                                             .BeAssignableTo<Tokenizer<FilterToken>>();
 
-        public static IEnumerable<object[]> RecognizeTokensCases
+        public static TheoryData<string, Expression<Func<TokenList<FilterToken>, bool>>> RecognizeTokensCases
         {
             get
             {
-                yield return new object[]
+                TheoryData<string, Expression<Func<TokenList<FilterToken>, bool>>> cases = new()
+                {
                 {
                     "Firstname=Bruce",
-                    (Expression<Func<TokenList<FilterToken>, bool>>)(results => results.Exactly(15)
-                                                                                && results.Once(result => result.Kind == Letter && result.Span.EqualsValue("F") && result.Span.Position.Column == 1)
-                                                                                && results.Once(result => result.Kind == Letter && result.Span.EqualsValue("i") && result.Span.Position.Column == 2)
-                                                                                && results.Once(result => result.Kind == Letter && result.Span.EqualsValue("r") && result.Span.Position.Column == 3)
-                                                                                && results.Once(result => result.Kind == Letter && result.Span.EqualsValue("s") && result.Span.Position.Column == 4)
-                                                                                && results.Once(result => result.Kind == Letter && result.Span.EqualsValue("t") && result.Span.Position.Column == 5)
-                                                                                && results.Once(result => result.Kind == Letter && result.Span.EqualsValue("n") && result.Span.Position.Column == 6)
-                                                                                && results.Once(result => result.Kind == Letter && result.Span.EqualsValue("a") && result.Span.Position.Column == 7)
-                                                                                && results.Once(result => result.Kind == Letter && result.Span.EqualsValue("m") && result.Span.Position.Column == 8)
-                                                                                && results.Once(result => result.Kind == Letter && result.Span.EqualsValue("e") && result.Span.Position.Column == 9)
-                                                                                && results.Once(result => result.Kind == Equal && result.Span.EqualsValue("=")  && result.Span.Position.Column == 10)
-                                                                                && results.Once(result => result.Kind == Letter && result.Span.EqualsValue("B") && result.Span.Position.Column == 11)
-                                                                                && results.Once(result => result.Kind == Letter && result.Span.EqualsValue("r") && result.Span.Position.Column == 12)
-                                                                                && results.Once(result => result.Kind == Letter && result.Span.EqualsValue("u") && result.Span.Position.Column == 13)
-                                                                                && results.Once(result => result.Kind == Letter && result.Span.EqualsValue("c") && result.Span.Position.Column == 14)
-                                                                                && results.Once(result => result.Kind == Letter && result.Span.EqualsValue("e") && result.Span.Position.Column == 15)
-                    )
-                };
+                    results => results.Exactly(15)
+                               && results.Once(result => result.Kind == Letter && result.Span.EqualsValue("F") && result.Span.Position.Column == 1)
+                               && results.Once(result => result.Kind == Letter && result.Span.EqualsValue("i") && result.Span.Position.Column == 2)
+                               && results.Once(result => result.Kind == Letter && result.Span.EqualsValue("r") && result.Span.Position.Column == 3)
+                               && results.Once(result => result.Kind == Letter && result.Span.EqualsValue("s") && result.Span.Position.Column == 4)
+                               && results.Once(result => result.Kind == Letter && result.Span.EqualsValue("t") && result.Span.Position.Column == 5)
+                               && results.Once(result => result.Kind == Letter && result.Span.EqualsValue("n") && result.Span.Position.Column == 6)
+                               && results.Once(result => result.Kind == Letter && result.Span.EqualsValue("a") && result.Span.Position.Column == 7)
+                               && results.Once(result => result.Kind == Letter && result.Span.EqualsValue("m") && result.Span.Position.Column == 8)
+                               && results.Once(result => result.Kind == Letter && result.Span.EqualsValue("e") && result.Span.Position.Column == 9)
+                               && results.Once(result => result.Kind == Equal && result.Span.EqualsValue("=")  && result.Span.Position.Column == 10)
+                               && results.Once(result => result.Kind == Letter && result.Span.EqualsValue("B") && result.Span.Position.Column == 11)
+                               && results.Once(result => result.Kind == Letter && result.Span.EqualsValue("r") && result.Span.Position.Column == 12)
+                               && results.Once(result => result.Kind == Letter && result.Span.EqualsValue("u") && result.Span.Position.Column == 13)
+                               && results.Once(result => result.Kind == Letter && result.Span.EqualsValue("c") && result.Span.Position.Column == 14)
+                               && results.Once(result => result.Kind == Letter && result.Span.EqualsValue("e") && result.Span.Position.Column == 15)
 
-                yield return new object[]
+                },
                 {
                     "_Firstname=Bruce",
-                    (Expression<Func<TokenList<FilterToken>, bool>>)(results => results.Exactly(16)
-                                                                                && results.Once(result => result.Kind == Underscore && result.Span.EqualsValue("_") && result.Span.Position.Column == 1)
-                                                                                && results.Once(result => result.Kind == Letter && result.Span.EqualsValue("F") && result.Span.Position.Column == 2)
-                                                                                && results.Once(result => result.Kind == Letter && result.Span.EqualsValue("i") && result.Span.Position.Column == 3)
-                                                                                && results.Once(result => result.Kind == Letter && result.Span.EqualsValue("r") && result.Span.Position.Column == 4)
-                                                                                && results.Once(result => result.Kind == Letter && result.Span.EqualsValue("s") && result.Span.Position.Column == 5)
-                                                                                && results.Once(result => result.Kind == Letter && result.Span.EqualsValue("t") && result.Span.Position.Column == 6)
-                                                                                && results.Once(result => result.Kind == Letter && result.Span.EqualsValue("n") && result.Span.Position.Column == 7)
-                                                                                && results.Once(result => result.Kind == Letter && result.Span.EqualsValue("a") && result.Span.Position.Column == 8)
-                                                                                && results.Once(result => result.Kind == Letter && result.Span.EqualsValue("m") && result.Span.Position.Column == 9)
-                                                                                && results.Once(result => result.Kind == Letter && result.Span.EqualsValue("e") && result.Span.Position.Column == 10)
-                                                                                && results.Once(result => result.Kind == Equal && result.Span.EqualsValue("=")  && result.Span.Position.Column == 11)
-                                                                                && results.Once(result => result.Kind == Letter && result.Span.EqualsValue("B") && result.Span.Position.Column == 12)
-                                                                                && results.Once(result => result.Kind == Letter && result.Span.EqualsValue("r") && result.Span.Position.Column == 13)
-                                                                                && results.Once(result => result.Kind == Letter && result.Span.EqualsValue("u") && result.Span.Position.Column == 14)
-                                                                                && results.Once(result => result.Kind == Letter && result.Span.EqualsValue("c") && result.Span.Position.Column == 15)
-                                                                                && results.Once(result => result.Kind == Letter && result.Span.EqualsValue("e") && result.Span.Position.Column == 16)
-                    )
-                };
+                    results => results.Exactly(16)
+                               && results.Once(result => result.Kind == Underscore && result.Span.EqualsValue("_") && result.Span.Position.Column == 1)
+                               && results.Once(result => result.Kind == Letter && result.Span.EqualsValue("F") && result.Span.Position.Column == 2)
+                               && results.Once(result => result.Kind == Letter && result.Span.EqualsValue("i") && result.Span.Position.Column == 3)
+                               && results.Once(result => result.Kind == Letter && result.Span.EqualsValue("r") && result.Span.Position.Column == 4)
+                               && results.Once(result => result.Kind == Letter && result.Span.EqualsValue("s") && result.Span.Position.Column == 5)
+                               && results.Once(result => result.Kind == Letter && result.Span.EqualsValue("t") && result.Span.Position.Column == 6)
+                               && results.Once(result => result.Kind == Letter && result.Span.EqualsValue("n") && result.Span.Position.Column == 7)
+                               && results.Once(result => result.Kind == Letter && result.Span.EqualsValue("a") && result.Span.Position.Column == 8)
+                               && results.Once(result => result.Kind == Letter && result.Span.EqualsValue("m") && result.Span.Position.Column == 9)
+                               && results.Once(result => result.Kind == Letter && result.Span.EqualsValue("e") && result.Span.Position.Column == 10)
+                               && results.Once(result => result.Kind == Equal && result.Span.EqualsValue("=")  && result.Span.Position.Column == 11)
+                               && results.Once(result => result.Kind == Letter && result.Span.EqualsValue("B") && result.Span.Position.Column == 12)
+                               && results.Once(result => result.Kind == Letter && result.Span.EqualsValue("r") && result.Span.Position.Column == 13)
+                               && results.Once(result => result.Kind == Letter && result.Span.EqualsValue("u") && result.Span.Position.Column == 14)
+                               && results.Once(result => result.Kind == Letter && result.Span.EqualsValue("c") && result.Span.Position.Column == 15)
+                               && results.Once(result => result.Kind == Letter && result.Span.EqualsValue("e") && result.Span.Position.Column == 16)
 
-                yield return new object[]
+                },
+
                 {
                     "Firstname=Bru*",
-                    (Expression<Func<TokenList<FilterToken>, bool>>)(results => results.Exactly(14)
-                                                                                && results.Once(result => result.Kind == Letter && result.Span.EqualsValue("F") && result.Span.Position.Column == 1)
-                                                                                && results.Once(result => result.Kind == Letter && result.Span.EqualsValue("i") && result.Span.Position.Column == 2)
-                                                                                && results.Once(result => result.Kind == Letter && result.Span.EqualsValue("r") && result.Span.Position.Column == 3)
-                                                                                && results.Once(result => result.Kind == Letter && result.Span.EqualsValue("s") && result.Span.Position.Column == 4)
-                                                                                && results.Once(result => result.Kind == Letter && result.Span.EqualsValue("t") && result.Span.Position.Column == 5)
-                                                                                && results.Once(result => result.Kind == Letter && result.Span.EqualsValue("n") && result.Span.Position.Column == 6)
-                                                                                && results.Once(result => result.Kind == Letter && result.Span.EqualsValue("a") && result.Span.Position.Column == 7)
-                                                                                && results.Once(result => result.Kind == Letter && result.Span.EqualsValue("m") && result.Span.Position.Column == 8)
-                                                                                && results.Once(result => result.Kind == Letter && result.Span.EqualsValue("e") && result.Span.Position.Column == 9)
-                                                                                && results.Once(result => result.Kind == Equal && result.Span.EqualsValue("=")  && result.Span.Position.Column == 10)
-                                                                                && results.Once(result => result.Kind == Letter && result.Span.EqualsValue("B") && result.Span.Position.Column == 11)
-                                                                                && results.Once(result => result.Kind == Letter && result.Span.EqualsValue("r") && result.Span.Position.Column == 12)
-                                                                                && results.Once(result => result.Kind == Letter && result.Span.EqualsValue("u") && result.Span.Position.Column == 13)
-                                                                                && results.Once(result => result.Kind == Asterisk && result.Span.EqualsValue("*") && result.Span.Position.Column == 14)
-                    )
-                };
+                    results => results.Exactly(14)
+                               && results.Once(result => result.Kind == Letter && result.Span.EqualsValue("F") && result.Span.Position.Column == 1)
+                               && results.Once(result => result.Kind == Letter && result.Span.EqualsValue("i") && result.Span.Position.Column == 2)
+                               && results.Once(result => result.Kind == Letter && result.Span.EqualsValue("r") && result.Span.Position.Column == 3)
+                               && results.Once(result => result.Kind == Letter && result.Span.EqualsValue("s") && result.Span.Position.Column == 4)
+                               && results.Once(result => result.Kind == Letter && result.Span.EqualsValue("t") && result.Span.Position.Column == 5)
+                               && results.Once(result => result.Kind == Letter && result.Span.EqualsValue("n") && result.Span.Position.Column == 6)
+                               && results.Once(result => result.Kind == Letter && result.Span.EqualsValue("a") && result.Span.Position.Column == 7)
+                               && results.Once(result => result.Kind == Letter && result.Span.EqualsValue("m") && result.Span.Position.Column == 8)
+                               && results.Once(result => result.Kind == Letter && result.Span.EqualsValue("e") && result.Span.Position.Column == 9)
+                               && results.Once(result => result.Kind == Equal && result.Span.EqualsValue("=")  && result.Span.Position.Column == 10)
+                               && results.Once(result => result.Kind == Letter && result.Span.EqualsValue("B") && result.Span.Position.Column == 11)
+                               && results.Once(result => result.Kind == Letter && result.Span.EqualsValue("r") && result.Span.Position.Column == 12)
+                               && results.Once(result => result.Kind == Letter && result.Span.EqualsValue("u") && result.Span.Position.Column == 13)
+                               && results.Once(result => result.Kind == Asterisk && result.Span.EqualsValue("*") && result.Span.Position.Column == 14)
 
-                yield return new object[]
+                },
+
                 {
                     "prop1=Bruce",
-                    (Expression<Func<TokenList<FilterToken>, bool>>)(results => results.Exactly(11)
-                                                                                && results.Once(result => result.Kind == Letter && result.Span.EqualsValue("p") && result.Span.Position.Column == 1)
-                                                                                && results.Once(result => result.Kind == Letter && result.Span.EqualsValue("r") && result.Span.Position.Column == 2)
-                                                                                && results.Once(result => result.Kind == Letter && result.Span.EqualsValue("o") && result.Span.Position.Column == 3)
-                                                                                && results.Once(result => result.Kind == Letter && result.Span.EqualsValue("p") && result.Span.Position.Column == 4)
-                                                                                && results.Once(result => result.Kind == Digit && result.Span.EqualsValue("1") && result.Span.Position.Column == 5)
-                                                                                && results.Once(result => result.Kind == Equal && result.Span.EqualsValue("=")  && result.Span.Position.Column == 6)
-                                                                                && results.Once(result => result.Kind == Letter && result.Span.EqualsValue("B") && result.Span.Position.Column == 7)
-                                                                                && results.Once(result => result.Kind == Letter && result.Span.EqualsValue("r") && result.Span.Position.Column == 8)
-                                                                                && results.Once(result => result.Kind == Letter && result.Span.EqualsValue("u") && result.Span.Position.Column == 9)
-                                                                                && results.Once(result => result.Kind == Letter && result.Span.EqualsValue("c") && result.Span.Position.Column == 10)
-                                                                                && results.Once(result => result.Kind == Letter && result.Span.EqualsValue("e") && result.Span.Position.Column == 11)
-                    )
-                };
+                    results => results.Exactly(11)
+                               && results.Once(result => result.Kind == Letter && result.Span.EqualsValue("p") && result.Span.Position.Column == 1)
+                               && results.Once(result => result.Kind == Letter && result.Span.EqualsValue("r") && result.Span.Position.Column == 2)
+                               && results.Once(result => result.Kind == Letter && result.Span.EqualsValue("o") && result.Span.Position.Column == 3)
+                               && results.Once(result => result.Kind == Letter && result.Span.EqualsValue("p") && result.Span.Position.Column == 4)
+                               && results.Once(result => result.Kind == Digit && result.Span.EqualsValue("1") && result.Span.Position.Column == 5)
+                               && results.Once(result => result.Kind == Equal && result.Span.EqualsValue("=")  && result.Span.Position.Column == 6)
+                               && results.Once(result => result.Kind == Letter && result.Span.EqualsValue("B") && result.Span.Position.Column == 7)
+                               && results.Once(result => result.Kind == Letter && result.Span.EqualsValue("r") && result.Span.Position.Column == 8)
+                               && results.Once(result => result.Kind == Letter && result.Span.EqualsValue("u") && result.Span.Position.Column == 9)
+                               && results.Once(result => result.Kind == Letter && result.Span.EqualsValue("c") && result.Span.Position.Column == 10)
+                               && results.Once(result => result.Kind == Letter && result.Span.EqualsValue("e") && result.Span.Position.Column == 11)
 
-                yield return new object[]
+                },
+
                 {
                     "val1|val2",
-                    (Expression<Func<TokenList<FilterToken>, bool>>)(results => results.Exactly(9)
-                                                                                && results.Once(result => result.Kind == Letter && result.Span.EqualsValue("v") && result.Span.Position.Column == 1)
-                                                                                && results.Once(result => result.Kind == Letter && result.Span.EqualsValue("a") && result.Span.Position.Column == 2)
-                                                                                && results.Once(result => result.Kind == Letter && result.Span.EqualsValue("l") && result.Span.Position.Column == 3)
-                                                                                && results.Once(result => result.Kind == Digit && result.Span.EqualsValue("1") && result.Span.Position.Column == 4)
-                                                                                && results.Once(result => result.Kind == Or && result.Span.EqualsValue("|") && result.Span.Position.Column == 5)
-                                                                                && results.Once(result => result.Kind == Letter && result.Span.EqualsValue("v")  && result.Span.Position.Column == 6)
-                                                                                && results.Once(result => result.Kind == Letter && result.Span.EqualsValue("a") && result.Span.Position.Column == 7)
-                                                                                && results.Once(result => result.Kind == Letter && result.Span.EqualsValue("l") && result.Span.Position.Column == 8)
-                                                                                && results.Once(result => result.Kind == Digit && result.Span.EqualsValue("2") && result.Span.Position.Column == 9)
-                    )
-                };
+                    results => results.Exactly(9)
+                               && results.Once(result => result.Kind == Letter && result.Span.EqualsValue("v") && result.Span.Position.Column == 1)
+                               && results.Once(result => result.Kind == Letter && result.Span.EqualsValue("a") && result.Span.Position.Column == 2)
+                               && results.Once(result => result.Kind == Letter && result.Span.EqualsValue("l") && result.Span.Position.Column == 3)
+                               && results.Once(result => result.Kind == Digit && result.Span.EqualsValue("1") && result.Span.Position.Column == 4)
+                               && results.Once(result => result.Kind == Or && result.Span.EqualsValue("|") && result.Span.Position.Column == 5)
+                               && results.Once(result => result.Kind == Letter && result.Span.EqualsValue("v")  && result.Span.Position.Column == 6)
+                               && results.Once(result => result.Kind == Letter && result.Span.EqualsValue("a") && result.Span.Position.Column == 7)
+                               && results.Once(result => result.Kind == Letter && result.Span.EqualsValue("l") && result.Span.Position.Column == 8)
+                               && results.Once(result => result.Kind == Digit && result.Span.EqualsValue("2") && result.Span.Position.Column == 9)
 
-                yield return new object[]
+                },
+
                 {
                     "val1,val2",
-                    (Expression<Func<TokenList<FilterToken>, bool>>)(results => results.Exactly(9)
-                                                                                && results.Once(result => result.Kind == Letter && result.Span.EqualsValue("v") && result.Span.Position.Column == 1)
-                                                                                && results.Once(result => result.Kind == Letter && result.Span.EqualsValue("a") && result.Span.Position.Column == 2)
-                                                                                && results.Once(result => result.Kind == Letter && result.Span.EqualsValue("l") && result.Span.Position.Column == 3)
-                                                                                && results.Once(result => result.Kind == Digit && result.Span.EqualsValue("1") && result.Span.Position.Column == 4)
-                                                                                && results.Once(result => result.Kind == And && result.Span.EqualsValue(",") && result.Span.Position.Column == 5)
-                                                                                && results.Once(result => result.Kind == Letter && result.Span.EqualsValue("v")  && result.Span.Position.Column == 6)
-                                                                                && results.Once(result => result.Kind == Letter && result.Span.EqualsValue("a") && result.Span.Position.Column == 7)
-                                                                                && results.Once(result => result.Kind == Letter && result.Span.EqualsValue("l") && result.Span.Position.Column == 8)
-                                                                                && results.Once(result => result.Kind == Digit && result.Span.EqualsValue("2") && result.Span.Position.Column == 9)
-                    )
-                };
+                    results => results.Exactly(9)
+                               && results.Once(result => result.Kind == Letter && result.Span.EqualsValue("v") && result.Span.Position.Column == 1)
+                               && results.Once(result => result.Kind == Letter && result.Span.EqualsValue("a") && result.Span.Position.Column == 2)
+                               && results.Once(result => result.Kind == Letter && result.Span.EqualsValue("l") && result.Span.Position.Column == 3)
+                               && results.Once(result => result.Kind == Digit && result.Span.EqualsValue("1") && result.Span.Position.Column == 4)
+                               && results.Once(result => result.Kind == And && result.Span.EqualsValue(",") && result.Span.Position.Column == 5)
+                               && results.Once(result => result.Kind == Letter && result.Span.EqualsValue("v")  && result.Span.Position.Column == 6)
+                               && results.Once(result => result.Kind == Letter && result.Span.EqualsValue("a") && result.Span.Position.Column == 7)
+                               && results.Once(result => result.Kind == Letter && result.Span.EqualsValue("l") && result.Span.Position.Column == 8)
+                               && results.Once(result => result.Kind == Digit && result.Span.EqualsValue("2") && result.Span.Position.Column == 9)
 
-                yield return new object[]
+                },
+
                 {
                     "!Bruce",
-                    (Expression<Func<TokenList<FilterToken>, bool>>)(results => results.Exactly(6)
-                                                                                && results.Once(result => result.Kind == Bang && result.Span.EqualsValue("!") && result.Span.Position.Column == 1)
-                                                                               && results.Once(result => result.Kind == Letter && result.Span.EqualsValue("B") && result.Span.Position.Column == 2)
-                                                                                && results.Once(result => result.Kind == Letter && result.Span.EqualsValue("r") && result.Span.Position.Column == 3)
-                                                                                && results.Once(result => result.Kind == Letter && result.Span.EqualsValue("u") && result.Span.Position.Column == 4)
-                                                                                && results.Once(result => result.Kind == Letter && result.Span.EqualsValue("c") && result.Span.Position.Column == 5)
-                                                                                && results.Once(result => result.Kind == Letter && result.Span.EqualsValue("e") && result.Span.Position.Column == 6)
-                    )
-                };
+                    results => results.Exactly(6)
+                               && results.Once(result => result.Kind == Bang && result.Span.EqualsValue("!") && result.Span.Position.Column == 1)
+                               && results.Once(result => result.Kind == Letter && result.Span.EqualsValue("B") && result.Span.Position.Column == 2)
+                               && results.Once(result => result.Kind == Letter && result.Span.EqualsValue("r") && result.Span.Position.Column == 3)
+                               && results.Once(result => result.Kind == Letter && result.Span.EqualsValue("u") && result.Span.Position.Column == 4)
+                               && results.Once(result => result.Kind == Letter && result.Span.EqualsValue("c") && result.Span.Position.Column == 5)
+                               && results.Once(result => result.Kind == Letter && result.Span.EqualsValue("e") && result.Span.Position.Column == 6)
 
-                yield return new object[]
+                },
+
                 {
                     "[",
-                    (Expression<Func<TokenList<FilterToken>, bool>>)(results => results.Once()
-                                                                                && results.Once(result => result.Kind == OpenSquaredBracket && result.Span.EqualsValue("["))
-                    )
-                };
+                    results => results.Once()
+                               && results.Once(result => result.Kind == OpenSquaredBracket && result.Span.EqualsValue("["))
 
-                yield return new object[]
+                },
+
                 {
                     "]",
-                    (Expression<Func<TokenList<FilterToken>, bool>>)(results => results.Once()
-                                                                                && results.Once(result => result.Kind == CloseSquaredBracket && result.Span.EqualsValue("]"))
-                    )
-                };
+                    results => results.Once()
+                               && results.Once(result => result.Kind == CloseSquaredBracket && result.Span.EqualsValue("]"))
 
-                yield return new object[]
+                },
+
                 {
                     "10-20",
-                    (Expression<Func<TokenList<FilterToken>, bool>>)(results => results.Exactly(5)
-                                                                                && results.Once(result => result.Kind == Digit && result.Span.EqualsValue("1") && result.Position.Column == 1)
-                                                                                && results.Once(result => result.Kind == Digit && result.Span.EqualsValue("0") && result.Position.Column == 2)
-                                                                                && results.Once(result => result.Kind == Dash  && result.Span.EqualsValue("-"))
-                                                                                && results.Once(result => result.Kind == Digit && result.Span.EqualsValue("2")  && result.Position.Column == 4)
-                                                                                && results.Once(result => result.Kind == Digit && result.Span.EqualsValue("0") && result.Position.Column == 5)
-                    )
-                };
+                    results => results.Exactly(5)
+                               && results.Once(result => result.Kind == Digit && result.Span.EqualsValue("1") && result.Position.Column == 1)
+                               && results.Once(result => result.Kind == Digit && result.Span.EqualsValue("0") && result.Position.Column == 2)
+                               && results.Once(result => result.Kind == Dash  && result.Span.EqualsValue("-"))
+                               && results.Once(result => result.Kind == Digit && result.Span.EqualsValue("2")  && result.Position.Column == 4)
+                               && results.Once(result => result.Kind == Digit && result.Span.EqualsValue("0") && result.Position.Column == 5)
 
-                yield return new object[]
+                },
+
                 {
                     " ",
-                    (Expression<Func<TokenList<FilterToken>, bool>>)(results => results.Once()
+                    results => results.Once()
                                                                                 && results.Once(result => result.Kind == Whitespace && result.Span.EqualsValue(" "))
-                    )
-                };
 
-                yield return new object[]
+                },
+
                 {
                     ":",
-                    (Expression<Func<TokenList<FilterToken>, bool>>)(results =>
-                        results.Exactly(1)
-                        && results.Once(result => result.Kind == Colon && result.Span.EqualsValue(":"))
-                    )
-                };
+                    results => results.Exactly(1)
+                               && results.Once(result => result.Kind == Colon && result.Span.EqualsValue(":"))
 
-                yield return new object[]
+                },
+
                 {
                     "2019-10-22",
-                     (Expression<Func<TokenList<FilterToken>, bool>>)(results =>
-                        results.Exactly(10)
-                        && results.Once(result => result.Kind == Digit && result.Span.EqualsValue("2") && result.Position.Column == 1)
-                        && results.Once(result => result.Kind == Digit && result.Span.EqualsValue("0") && result.Position.Column == 2)
-                        && results.Once(result => result.Kind == Digit && result.Span.EqualsValue("1") && result.Position.Column == 3)
-                        && results.Once(result => result.Kind == Digit && result.Span.EqualsValue("9") && result.Position.Column == 4)
-                        && results.Once(result => result.Kind == Dash  && result.Span.EqualsValue("-") && result.Position.Column == 5)
-                        && results.Once(result => result.Kind == Digit && result.Span.EqualsValue("1") && result.Position.Column == 6)
-                        && results.Once(result => result.Kind == Digit && result.Span.EqualsValue("0") && result.Position.Column == 7)
-                        && results.Once(result => result.Kind == Dash  && result.Span.EqualsValue("-") && result.Position.Column == 8)
-                        && results.Once(result => result.Kind == Digit && result.Span.EqualsValue("2") && result.Position.Column == 9)
-                        && results.Once(result => result.Kind == Digit && result.Span.EqualsValue("2") && result.Position.Column == 10)
-                    )
-                };
+                     results => results.Exactly(10)
+                                && results.Once(result => result.Kind == Digit && result.Span.EqualsValue("2") && result.Position.Column == 1)
+                                && results.Once(result => result.Kind == Digit && result.Span.EqualsValue("0") && result.Position.Column == 2)
+                                && results.Once(result => result.Kind == Digit && result.Span.EqualsValue("1") && result.Position.Column == 3)
+                                && results.Once(result => result.Kind == Digit && result.Span.EqualsValue("9") && result.Position.Column == 4)
+                                && results.Once(result => result.Kind == Dash  && result.Span.EqualsValue("-") && result.Position.Column == 5)
+                                && results.Once(result => result.Kind == Digit && result.Span.EqualsValue("1") && result.Position.Column == 6)
+                                && results.Once(result => result.Kind == Digit && result.Span.EqualsValue("0") && result.Position.Column == 7)
+                                && results.Once(result => result.Kind == Dash  && result.Span.EqualsValue("-") && result.Position.Column == 8)
+                                && results.Once(result => result.Kind == Digit && result.Span.EqualsValue("2") && result.Position.Column == 9)
+                                && results.Once(result => result.Kind == Digit && result.Span.EqualsValue("2") && result.Position.Column == 10)
 
-                yield return new object[]
+                },
+
                 {
                     "*",
-                    (Expression<Func<TokenList<FilterToken>, bool>>)(results =>
-                        results.Exactly(1)
-                        && results.Exactly(result => result.Kind == Asterisk && result.Span.EqualsValue("*"), 1)
-                    )
-                };
+                    results => results.Exactly(1)
+                               && results.Exactly(result => result.Kind == Asterisk && result.Span.EqualsValue("*"), 1)
 
-                yield return new object[]
+                },
+
                 {
                     "_a",
-                    (Expression<Func<TokenList<FilterToken>, bool>>)(results =>
-                        results.Exactly(2)
+                    results => results.Exactly(2)
                         && results.Exactly(result => result.Kind == Underscore && result.Span.EqualsValue("_"), 1)
                         && results.Exactly(result => result.Kind == Letter && result.Span.EqualsValue("a"), 1)
-                    )
+
+                }
                 };
 
                 foreach (char c in FilterTokenizer.SpecialCharacters)
                 {
-                    yield return new object[]
-                    {
+                    cases.Add
+                    (
                         $"Firstname=Bru{FilterTokenizer.BackSlash}{c}",
-                        (Expression<Func<TokenList<FilterToken>, bool>>) (results => results.Exactly(14)
-                                                                                     && results.Once(result => result.Kind == Letter && result.Span.EqualsValue("F") && result.Span.Position.Column == 1)
-                                                                                     && results.Once(result => result.Kind == Letter && result.Span.EqualsValue("i") && result.Span.Position.Column == 2)
-                                                                                     && results.Once(result => result.Kind == Letter && result.Span.EqualsValue("r") && result.Span.Position.Column == 3)
-                                                                                     && results.Once(result => result.Kind == Letter && result.Span.EqualsValue("s") && result.Span.Position.Column == 4)
-                                                                                     && results.Once(result => result.Kind == Letter && result.Span.EqualsValue("t") && result.Span.Position.Column == 5)
-                                                                                     && results.Once(result => result.Kind == Letter && result.Span.EqualsValue("n") && result.Span.Position.Column == 6)
-                                                                                     && results.Once(result => result.Kind == Letter && result.Span.EqualsValue("a") && result.Span.Position.Column == 7)
-                                                                                     && results.Once(result => result.Kind == Letter && result.Span.EqualsValue("m") && result.Span.Position.Column == 8)
-                                                                                     && results.Once(result => result.Kind == Letter && result.Span.EqualsValue("e") && result.Span.Position.Column == 9)
-                                                                                     && results.Once(result => result.Kind == Equal && result.Span.EqualsValue("=")  && result.Span.Position.Column == 10)
-                                                                                     && results.Once(result => result.Kind == Letter && result.Span.EqualsValue("B") && result.Span.Position.Column == 11)
-                                                                                     && results.Once(result => result.Kind == Letter && result.Span.EqualsValue("r") && result.Span.Position.Column == 12)
-                                                                                     && results.Once(result => result.Kind == Letter && result.Span.EqualsValue("u") && result.Span.Position.Column == 13)
-                                                                                     && results.Once(result => result.Kind == Escaped && result.Span.EqualsValue(c.ToString()) && result.Span.Position.Column == 15)
-                        )
-                    };
+                        results => results.Exactly(14)
+                                   && results.Once(result => result.Kind == Letter && result.Span.EqualsValue("F") && result.Span.Position.Column == 1)
+                                   && results.Once(result => result.Kind == Letter && result.Span.EqualsValue("i") && result.Span.Position.Column == 2)
+                                   && results.Once(result => result.Kind == Letter && result.Span.EqualsValue("r") && result.Span.Position.Column == 3)
+                                   && results.Once(result => result.Kind == Letter && result.Span.EqualsValue("s") && result.Span.Position.Column == 4)
+                                   && results.Once(result => result.Kind == Letter && result.Span.EqualsValue("t") && result.Span.Position.Column == 5)
+                                   && results.Once(result => result.Kind == Letter && result.Span.EqualsValue("n") && result.Span.Position.Column == 6)
+                                   && results.Once(result => result.Kind == Letter && result.Span.EqualsValue("a") && result.Span.Position.Column == 7)
+                                   && results.Once(result => result.Kind == Letter && result.Span.EqualsValue("m") && result.Span.Position.Column == 8)
+                                   && results.Once(result => result.Kind == Letter && result.Span.EqualsValue("e") && result.Span.Position.Column == 9)
+                                   && results.Once(result => result.Kind == Equal && result.Span.EqualsValue("=") && result.Span.Position.Column == 10)
+                                   && results.Once(result => result.Kind == Letter && result.Span.EqualsValue("B") && result.Span.Position.Column == 11)
+                                   && results.Once(result => result.Kind == Letter && result.Span.EqualsValue("r") && result.Span.Position.Column == 12)
+                                   && results.Once(result => result.Kind == Letter && result.Span.EqualsValue("u") && result.Span.Position.Column == 13)
+                                   && results.Once(result => result.Kind == Escaped && result.Span.EqualsValue(c.ToString()) && result.Span.Position.Column == 15)
+
+                    );
                 }
 
-                yield return new object[]
-                {
+                cases.Add
+                (
                     @"\",
-                    (Expression<Func<TokenList<FilterToken>, bool>>)(results =>
+                    results =>
                         results.Exactly(1)
                         && results.Once(result => result.Kind == Letter && result.Span.EqualsValue(@"\"))
-                    )
-                };
 
-                yield return new object[]
-                {
+                );
+
+                cases.Add
+                (
                     @"\\t",
-                    (Expression<Func<TokenList<FilterToken>, bool>>)(results =>
+                    results =>
                         results.Exactly(2)
                         && results.Once(result => result.Kind == Escaped && result.Span.EqualsValue("\\"))
                         && results.Once(result => result.Kind == Letter && result.Span.EqualsValue("t"))
-                    )
-                };
 
-                yield return new object[]
-                {
+                );
+
+                cases.Add
+                (
                     @"""",
-                    (Expression<Func<TokenList<FilterToken>, bool>>)(results =>
+                    results =>
                         results.Exactly(1)
                         && results.Once(result => result.Kind == DoubleQuote && result.Span.EqualsValue(@""""))
-                    )
-                };
 
-                yield return new object[]
-                {
+                );
+
+                cases.Add
+                (
                     "+",
-                    (Expression<Func<TokenList<FilterToken>, bool>>)(results => results.Once()
+                    results => results.Once()
                                                                                 && results.Once(result => result.Kind == None && result.Span.EqualsValue("+"))
-                    )
-                };
+
+                );
 
                 foreach (char chr in FilterTokenizer.SpecialCharacters)
                 {
                     switch (chr)
                     {
                         case FilterTokenizer.DoubleQuote:
-                            yield return new object[]
-                            {
+                            cases.Add
+                            (
                                 @$"""\{chr}""",
-                                (Expression<Func<TokenList<FilterToken>, bool>>)(results => results.Exactly(3)
-                                                                                            && results.Once(result => result.Kind == DoubleQuote
-                                                                                                                         && result.Position.Column == 1)
-                                                                                            && results.Once(result => result.Kind == Escaped
-                                                                                                                      && result.Position.Column == 3
-                                                                                                                      && result.Span.EqualsValue(@""""))
-                                                                                            && results.Once(result => result.Kind == DoubleQuote
-                                                                                                                      && result.Position.Column == 4)
-                                )
-                            };
+                                results => results.Exactly(3) && results.Once(result => result.Kind == DoubleQuote
+                                                                                              && result.Position.Column == 1)
+                                                                    && results.Once(result => result.Kind == Escaped
+                                                                                                && result.Position.Column == 3
+                                                                                                && result.Span.EqualsValue(@""""))
+                                                                    && results.Once(result => result.Kind == DoubleQuote
+                                                                                                && result.Position.Column == 4)
+
+                            );
                             break;
                         case FilterTokenizer.BackSlash:
-                            yield return new object[]
-                            {
+                            cases.Add
+                            (
                                 @$"""\{chr}""",
-                                (Expression<Func<TokenList<FilterToken>, bool>>)(results => results.Exactly(3)
-                                                                                            && results.Once(result => result.Kind == DoubleQuote && result.Position.Column == 1)
-                                                                                            && results.Once(result => result.Kind == Escaped
-                                                                                                                      && result.Position.Column == 3
-                                                                                                                      && result.Span.EqualsValue(@"\"))
-                                                                                            && results.Once(result => result.Kind == DoubleQuote
-                                                                                                                      && result.Position.Column == 4)
-                                )
-                            };
+                                results => results.Exactly(3)
+                                            && results.Once(result => result.Kind == DoubleQuote && result.Position.Column == 1)
+                                            && results.Once(result => result.Kind == Escaped
+                                                                        && result.Position.Column == 3
+                                                                        && result.Span.EqualsValue(@"\"))
+                                            && results.Once(result => result.Kind == DoubleQuote
+                                                                        && result.Position.Column == 4)
+
+                            );
                             break;
                         default:
-                            yield return new object[]
-                            {
+                            cases.Add
+                            (
                                 @$"""\{chr}""",
-                                (Expression<Func<TokenList<FilterToken>, bool>>)(results => results.Exactly(4)
-                                                                                            && results.Once(result => result.Kind == DoubleQuote && result.Position.Column == 1)
-                                                                                            && results.Once(result => result.Kind == Escaped && result.Position.Column == 2 && result.Span.EqualsValue("\\"))
-                                                                                            && results.Once(result => result.Kind == Escaped && result.Position.Column == 3 && result.Span.EqualsValue($"{chr}"))
-                                                                                            && results.Once(result => result.Kind == DoubleQuote && result.Position.Column == 4)
-                                )
-                            };
+                                results => results.Exactly(4)
+                                           && results.Once(result => result.Kind == DoubleQuote && result.Position.Column == 1)
+                                           && results.Once(result => result.Kind == Escaped && result.Position.Column == 2 && result.Span.EqualsValue("\\"))
+                                           && results.Once(result => result.Kind == Escaped && result.Position.Column == 3 && result.Span.EqualsValue($"{chr}"))
+                                           && results.Once(result => result.Kind == DoubleQuote && result.Position.Column == 4)
+
+                            );
                             break;
                     }
                 }
 
-                yield return new object[]
-                {
+                cases.Add
+                (
                     @"""\[",
-                    (Expression<Func<TokenList<FilterToken>, bool>>)(results => results.Exactly(3)
-                                                                                && results.Once(result => result.Kind == DoubleQuote && result.Span.EqualsValue(@""""))
-                                                                                && results.Once(result => result.Kind == Escaped && result.Span.EqualsValue(@"\"))
-                                                                                && results.Once(result => result.Kind == Escaped && result.Span.EqualsValue("["))
-                    )
-                };
+                    results => results.Exactly(3)
+                               && results.Once(result => result.Kind == DoubleQuote && result.Span.EqualsValue(@""""))
+                               && results.Once(result => result.Kind == Escaped && result.Span.EqualsValue(@"\"))
+                               && results.Once(result => result.Kind == Escaped && result.Span.EqualsValue("["))
+
+                );
+
+                return cases;
             }
         }
 

--- a/test/DataFilters.UnitTests/Grammar/Syntax/AsteriskExpressionTests.cs
+++ b/test/DataFilters.UnitTests/Grammar/Syntax/AsteriskExpressionTests.cs
@@ -1,7 +1,6 @@
 ﻿namespace DataFilters.UnitTests.Grammar.Syntax
 {
     using System;
-    using System.Collections.Generic;
 
     using DataFilters.Grammar.Syntax;
     using DataFilters.UnitTests.Helpers;
@@ -25,14 +24,12 @@
             .Implement<IEquatable<AsteriskExpression>>().And
             .HaveDefaultConstructor();
 
-        public static IEnumerable<object[]> EqualsCases
-        {
-            get
+        public static TheoryData<AsteriskExpression, object, bool, string> EqualsCases
+            => new()
             {
-                yield return new object[] { AsteriskExpression.Instance, null, false, "Comparing to null" };
-                yield return new object[] { AsteriskExpression.Instance, AsteriskExpression.Instance, true, "Comparing to null" };
-            }
-        }
+                { AsteriskExpression.Instance, null, false, "Comparing to null" },
+                { AsteriskExpression.Instance, AsteriskExpression.Instance, true, "Comparing to null" }
+            };
 
         [Theory]
         [MemberData(nameof(EqualsCases))]
@@ -48,16 +45,14 @@
             // Assert
             actual.Should()
                 .Be(expected, reason);
-            if (expected)
+
+            _ = expected switch
             {
-                actualHashCode.Should()
-                    .Be(other?.GetHashCode(), reason);
-            }
-            else
-            {
-                actualHashCode.Should()
-                    .NotBe(other?.GetHashCode(), reason);
-            }
+                true => actualHashCode.Should()
+                    .Be(other?.GetHashCode(), reason),
+                _ => actualHashCode.Should()
+                    .NotBe(other?.GetHashCode(), reason)
+            };
         }
 
         [Property(Arbitrary = [typeof(ExpressionsGenerators)])]

--- a/test/DataFilters.UnitTests/Grammar/Syntax/BoundaryExpressionTests.cs
+++ b/test/DataFilters.UnitTests/Grammar/Syntax/BoundaryExpressionTests.cs
@@ -1,7 +1,6 @@
 ﻿namespace DataFilters.UnitTests.Grammar.Syntax
 {
     using System;
-    using System.Collections.Generic;
     using DataFilters.Grammar.Syntax;
     using DataFilters.UnitTests.Helpers;
     using FluentAssertions;
@@ -84,27 +83,22 @@
             groupEqualOtherExpression.Should().Be(otherExpressionEqualGroup, "'equals' impelemntation must be symetric");
         }
 
-        public static IEnumerable<object[]> EqualsBehaviourCases
-        {
-            get
+        public static TheoryData<BoundaryExpression, object, bool, string> EqualsBehaviourCases
+            => new()
             {
-                yield return new object[]
                 {
                     new BoundaryExpression(new DateExpression(), true),
                     new BoundaryExpression(new DateExpression(), true),
                     true,
                     $"Two instances with {nameof(DateExpression)} that are equal"
-                };
-
-                yield return new object[]
+                },
                 {
                     new BoundaryExpression(new DateTimeExpression(new (), new (), new()), true),
                     new BoundaryExpression(new DateTimeExpression(new (), new (), new()), true),
                     true,
                     $"Two instances with {nameof(DateExpression)} that are equal"
-                };
-            }
-        }
+                }
+            };
 
         [Theory]
         [MemberData(nameof(EqualsBehaviourCases))]

--- a/test/DataFilters.UnitTests/Grammar/Syntax/BracketExpressionTests.cs
+++ b/test/DataFilters.UnitTests/Grammar/Syntax/BracketExpressionTests.cs
@@ -1,7 +1,6 @@
 ﻿namespace DataFilters.UnitTests.Grammar.Syntax
 {
     using System;
-    using System.Collections.Generic;
     using System.Linq;
     using DataFilters.Grammar.Syntax;
     using DataFilters.UnitTests.Helpers;
@@ -31,27 +30,22 @@
                 .ThrowExactly<ArgumentNullException>($"{nameof(BracketExpression)}.{nameof(BracketExpression.Values)} cannot be null");
         }
 
-        public static IEnumerable<object[]> EqualsCases
-        {
-            get
+        public static TheoryData<BracketExpression, object, bool, string> EqualsCases
+            => new()
             {
-                yield return new object[]
                 {
                     new BracketExpression(new ConstantBracketValue("aBc")),
                     new BracketExpression(new ConstantBracketValue("aBc")),
                     true,
                     $"Two {nameof(BracketExpression)} instances built with inputs that are equals"
-                };
-
-                yield return new object[]
+                },
                 {
                     new BracketExpression(new ConstantBracketValue("aBc")),
                     new BracketExpression(new ConstantBracketValue("aBc")),
                     true,
                     $"Two {nameof(BracketExpression)} instances built with inputs that are equals"
-                };
-            }
-        }
+                }
+            };
 
         [Theory]
         [MemberData(nameof(EqualsCases))]
@@ -91,11 +85,9 @@
             complexity.Should().Be(expected);
         }
 
-        public static IEnumerable<object[]> ComplexityCases
-        {
-            get
+        public static TheoryData<BracketExpression, double> ComplexityCases
+            => new()
             {
-                yield return new object[]
                 {
                     new BracketExpression
                     (
@@ -103,9 +95,8 @@
                         new RangeBracketValue('a', 'c')
                     ),
                     new ConstantBracketValue("aa").Complexity * new RangeBracketValue('a', 'c').Complexity
-                };
-            }
-        }
+                }
+            };
 
         [Theory]
         [MemberData(nameof(ComplexityCases))]

--- a/test/DataFilters.UnitTests/Grammar/Syntax/ContainsExpressionTests.cs
+++ b/test/DataFilters.UnitTests/Grammar/Syntax/ContainsExpressionTests.cs
@@ -1,7 +1,6 @@
 ﻿namespace DataFilters.UnitTests.Grammar.Syntax
 {
     using System;
-    using System.Collections.Generic;
     using DataFilters.Grammar.Syntax;
     using DataFilters.UnitTests.Helpers;
     using FluentAssertions;
@@ -65,27 +64,22 @@
                 .NotThrow("The parameter of the constructor can be whitespace only");
         }
 
-        public static IEnumerable<object[]> EqualsCases
-        {
-            get
+        public static TheoryData<ContainsExpression, object, bool, string> EqualsCases
+            => new()
             {
-                yield return new object[]
                 {
                     new ContainsExpression("prop1"),
                     new ContainsExpression("prop1"),
                     true,
                     "comparing two different instances with same property name"
-                };
-
-                yield return new object[]
+                },
                 {
                     new ContainsExpression("prop1"),
                     new ContainsExpression("prop2"),
                     false,
                     "comparing two different instances with different property name"
-                };
-            }
-        }
+                }
+            };
 
         [Theory]
         [MemberData(nameof(EqualsCases))]

--- a/test/DataFilters.UnitTests/Grammar/Syntax/DateExpressionTests.cs
+++ b/test/DataFilters.UnitTests/Grammar/Syntax/DateExpressionTests.cs
@@ -8,9 +8,8 @@
     using FsCheck.Fluent;
     using FsCheck.Xunit;
     using Xunit;
-    using Xunit.Abstractions;
 
-    public class DateExpressionTests(ITestOutputHelper outputHelper)
+    public class DateExpressionTests
     {
         [Fact]
         public void IsFilterExpression() => typeof(DateExpression).Should()

--- a/test/DataFilters.UnitTests/Grammar/Syntax/DateTimeExpressionTests.cs
+++ b/test/DataFilters.UnitTests/Grammar/Syntax/DateTimeExpressionTests.cs
@@ -1,7 +1,6 @@
 ﻿namespace DataFilters.UnitTests.Grammar.Syntax
 {
     using System;
-    using System.Collections.Generic;
     using DataFilters.Grammar.Syntax;
     using DataFilters.UnitTests.Helpers;
     using FluentAssertions;
@@ -123,35 +122,28 @@
             dateTimeExpression.Complexity.Should().BeGreaterThan(timeExpression.Item.Complexity);
         }
 
-        public static IEnumerable<object[]> EqualsCases
-        {
-            get
+        public static TheoryData<DateTimeExpression, object, bool, string> EqualsCases
+            => new()
             {
-                yield return new object[]
                 {
                     new DateTimeExpression(new TimeExpression()),
                     new TimeExpression(),
                     true,
                     $"{nameof(DateTimeExpression.Date)} and {nameof(DateTimeExpression.Date)} are null and TimeExpression are equal"
-                };
-
-                yield return new object[]
+                },
                 {
                     new DateTimeExpression(new (), new (), new()),
                     new DateTimeExpression(new (), new (), new()),
                     true,
                     $"Two instances with {nameof(DateTimeExpression)} that are equal"
-                };
-
-                yield return new object[]
+                },
                 {
                     new DateTimeExpression(new(2090, 10, 10), new (03,00,40, 583), OffsetExpression.Zero),
                     new DateTimeExpression(new(2090, 10, 10), new (03,00,40, 583), OffsetExpression.Zero),
                     true,
                     $"Two instances with {nameof(DateTimeExpression.Date)}, {nameof(DateTimeExpression.Time)}, {nameof(DateTimeExpression.Offset)} are equal and not null"
-                };
-            }
-        }
+                }
+            };
 
         [Theory]
         [MemberData(nameof(EqualsCases))]
@@ -177,32 +169,25 @@
         public void Equals_should_be_symetric(NonNull<DateTimeExpression> expression, NonNull<FilterExpression> otherExpression)
             => expression.Item.Equals(otherExpression.Item).Should().Be(otherExpression.Item.Equals(expression.Item));
 
-        public static IEnumerable<object[]> EqualsTransitivityCases
-        {
-            get
+        public static TheoryData<DateTimeExpression, object, object> EqualsTransitivityCases
+            => new()
             {
-                yield return new object[]
                 {
                     new DateTimeExpression(1.January(2010)),
                     new DateTimeExpression(1.January(2010)),
                     new DateTimeExpression(1.January(2010))
-                };
-
-                yield return new object[]
+                },
                 {
                     new DateTimeExpression(new TimeExpression(1)),
                     new DateTimeExpression(new TimeExpression(minutes: 60)),
                     new DateTimeExpression(new TimeExpression(seconds: 3600))
-                };
-
-                yield return new object[]
+                },
                 {
                     new DateTimeExpression(new TimeExpression(1)),
                     new DateTimeExpression(new TimeExpression(minutes: 60)),
                     new DateTimeExpression(new TimeExpression(seconds: 3600))
-                };
-            }
-        }
+                }
+            };
 
         [Theory]
         [MemberData(nameof(EqualsTransitivityCases))]

--- a/test/DataFilters.UnitTests/Grammar/Syntax/DurationExpressionTests.cs
+++ b/test/DataFilters.UnitTests/Grammar/Syntax/DurationExpressionTests.cs
@@ -1,7 +1,6 @@
 namespace DataFilters.UnitTests.Grammar.Syntax
 {
     using System;
-    using System.Collections.Generic;
     using DataFilters.Grammar.Syntax;
     using DataFilters.UnitTests.Helpers;
     using FluentAssertions;
@@ -146,11 +145,9 @@ namespace DataFilters.UnitTests.Grammar.Syntax
             }
         }
 
-        public static IEnumerable<object[]> IsEquivalentToCases
-        {
-            get
+        public static TheoryData<DurationExpression, FilterExpression, FilterExpression, (bool expected, string reason)> IsEquivalentToCases
+            => new()
             {
-                yield return new object[]
                 {
                     new DurationExpression(),
                     new StartsWithExpression("a"),
@@ -159,9 +156,8 @@ namespace DataFilters.UnitTests.Grammar.Syntax
                         expected: false,
                         reason: "A is not equivalent to B and B is equivalent to C => A is not equivalent to C"
                     )
-                };
-            }
-        }
+                }
+            };
 
         [Theory]
         [MemberData(nameof(IsEquivalentToCases))]

--- a/test/DataFilters.UnitTests/Grammar/Syntax/EndsWithExpressionTests.cs
+++ b/test/DataFilters.UnitTests/Grammar/Syntax/EndsWithExpressionTests.cs
@@ -1,7 +1,6 @@
 ﻿namespace DataFilters.UnitTests.Grammar.Syntax
 {
     using System;
-    using System.Collections.Generic;
     using DataFilters.Grammar.Syntax;
     using DataFilters.UnitTests.Helpers;
     using FluentAssertions;
@@ -53,52 +52,44 @@
                 .ThrowExactly<ArgumentOutOfRangeException>($"The value of {nameof(EndsWithExpression)}'s constructor cannot be empty");
         }
 
-        public static IEnumerable<object[]> EqualsCases
-        {
-            get
+        public static TheoryData<EndsWithExpression, object, bool, string> EqualsCases
+            => new()
             {
-                yield return new object[]
                 {
                     new EndsWithExpression("prop1"),
                     new EndsWithExpression("prop1"),
                     true,
                     "comparing two different instances with same property name"
-                };
-
-                yield return new object[]
+                },
                 {
                     new EndsWithExpression("prop1"),
                     new EndsWithExpression("prop2"),
                     false,
                     "comparing two different instances with different property name"
-                };
-            }
-        }
+                }
+            };
 
         [Theory]
         [MemberData(nameof(EqualsCases))]
-        public void ImplementsEqualsCorrectly(EndsWithExpression first, object other, bool expected, string reason)
+        public void ImplementsEqualsCorrectly(EndsWithExpression current, object other, bool expected, string reason)
         {
-            outputHelper.WriteLine($"First instance : {first}");
+            outputHelper.WriteLine($"First instance : {current}");
             outputHelper.WriteLine($"Second instance : {other}");
 
             // Act
-            bool actual = first.Equals(other);
-            int actualHashCode = first.GetHashCode();
+            bool actual = current.Equals(other);
+            int actualHashCode = current.GetHashCode();
 
             // Assert
             actual.Should()
                 .Be(expected, reason);
-            if (expected)
+
+            object _ = expected switch
             {
-                actualHashCode.Should()
-                    .Be(other?.GetHashCode(), reason);
-            }
-            else
-            {
-                actualHashCode.Should()
-                    .NotBe(other?.GetHashCode(), reason);
-            }
+                true => actualHashCode.Should()
+                    .Be(other?.GetHashCode(), reason),
+                _ => true
+            };
         }
 
         [Property(Arbitrary = [typeof(ExpressionsGenerators)])]

--- a/test/DataFilters.UnitTests/Grammar/Syntax/GroupExpressionTests.cs
+++ b/test/DataFilters.UnitTests/Grammar/Syntax/GroupExpressionTests.cs
@@ -1,7 +1,6 @@
 ﻿namespace DataFilters.UnitTests.Grammar.Syntax
 {
     using System;
-    using System.Collections.Generic;
     using DataFilters.Grammar.Syntax;
     using DataFilters.UnitTests.Helpers;
     using FluentAssertions;
@@ -105,35 +104,28 @@
             actual.Should().BeTrue();
         }
 
-        public static IEnumerable<object[]> EqualsCases
-        {
-            get
+        public static TheoryData<GroupExpression, object, bool, string> EqualsCases
+            => new()
             {
-                yield return new object[]
                 {
                     new GroupExpression(new StartsWithExpression("prop1")),
                     new GroupExpression(new StartsWithExpression("prop1")),
                     true,
                     "comparing two different instances with same property name"
-                };
-
-                yield return new object[]
+                },
                 {
                     new GroupExpression(new StartsWithExpression("prop1")),
                     new GroupExpression(new StartsWithExpression("prop2")),
                     false,
                     "comparing two different instances with different inner expressions"
-                };
-
-                yield return new object[]
+                },
                 {
                     new GroupExpression(new DateTimeExpression(new(2090, 10, 10), new (03,00,40, 583), OffsetExpression.Zero)),
                     new GroupExpression(new DateTimeExpression(new(2090, 10, 10), new (03,00,40, 583), OffsetExpression.Zero)),
                     true,
                     "Two instances with inner expressions that are equal"
-                };
-            }
-        }
+                }
+            };
 
         [Theory]
         [MemberData(nameof(EqualsCases))]

--- a/test/DataFilters.UnitTests/Grammar/Syntax/NotExpressionTests.cs
+++ b/test/DataFilters.UnitTests/Grammar/Syntax/NotExpressionTests.cs
@@ -1,7 +1,6 @@
 ﻿namespace DataFilters.UnitTests.Grammar.Syntax
 {
     using System;
-    using System.Collections.Generic;
     using DataFilters.Grammar.Syntax;
     using DataFilters.UnitTests.Helpers;
     using FluentAssertions;
@@ -9,9 +8,8 @@
     using FsCheck.Fluent;
     using FsCheck.Xunit;
     using Xunit;
-    using Xunit.Abstractions;
 
-    public class NotExpressionTests(ITestOutputHelper outputHelper)
+    public class NotExpressionTests
     {
         [Fact]
         public void IsFilterExpression() => typeof(NotExpression).Should()
@@ -71,11 +69,9 @@
                           .BeOfType<GroupExpression>("the parameter is a BinaryFilterExpression");
         }
 
-        public static IEnumerable<object[]> EscapedParseableStringCases
-        {
-            get
+        public static TheoryData<NotExpression, string> EscapedParseableStringCases
+            => new()
             {
-                yield return new object[]
                 {
                     new NotExpression(
                         new OrExpression(new DateTimeExpression(new TimeExpression(2, 53, 39, 827)),
@@ -85,9 +81,7 @@
                         ),
 
                     "!(T02:53:39.827|1901-06-17T09:13:44.17Z)"
-                };
-
-                yield return new object[]
+                },
                 {
                     new NotExpression(
                        new OrExpression(new TimeExpression(2, 53, 39, 827),
@@ -97,9 +91,8 @@
                         ),
 
                     "!(02:53:39.827|1901-06-17T09:13:44.17Z)"
-                };
-            }
-        }
+                }
+            };
 
         [Theory]
         [MemberData(nameof(EscapedParseableStringCases))]
@@ -113,11 +106,9 @@
                   .Be(expected);
         }
 
-        public static IEnumerable<object[]> EqualsCases
-        {
-            get
+        public static TheoryData<NotExpression, object, bool, string> EqualsCases
+            => new()
             {
-                yield return new object[]
                 {
                      new NotExpression(
                         new OrExpression(new DateTimeExpression(new TimeExpression(2, 53, 39, 827)),
@@ -133,9 +124,8 @@
                         ),
                     true,
                     $"{nameof(DateTimeExpression.Date)} and {nameof(DateTimeExpression.Date)} are null and TimeExpression are equal"
-                };
-            }
-        }
+                }
+            };
 
         [Theory]
         [MemberData(nameof(EqualsCases))]

--- a/test/DataFilters.UnitTests/Grammar/Syntax/OneOfExpressionTests.cs
+++ b/test/DataFilters.UnitTests/Grammar/Syntax/OneOfExpressionTests.cs
@@ -42,35 +42,28 @@
                               .ThrowExactly<InvalidOperationException>($"The parameter {nameof(OneOfExpression)}'s constructor cannot be a empty array");
         }
 
-        public static IEnumerable<object[]> EqualsCases
-        {
-            get
+        public static TheoryData<OneOfExpression, object, bool, string> EqualsCases
+            => new()
             {
-                yield return new object[]
                 {
                     new OneOfExpression(new StringValueExpression("prop1"), new StringValueExpression("prop2")),
                     new OneOfExpression(new StringValueExpression("prop1"), new StringValueExpression("prop2")),
                     true,
                     "comparing two different instances with same data in same order"
-                };
-
-                yield return new object[]
+                },
                 {
                     new OneOfExpression(new StringValueExpression("prop1"), new StringValueExpression("prop2")),
                     new OneOfExpression(new StringValueExpression("prop2"), new StringValueExpression("prop1")),
                     false,
                     "comparing two different instances with same data but the order does not matter"
-                };
-
-                yield return new object[]
+                },
                 {
                     new OneOfExpression(new StringValueExpression("prop1"), new StringValueExpression("prop2")),
                     new OneOfExpression(new StringValueExpression("prop1"), new StringValueExpression("prop3")),
                     false,
                     "comparing two different instances with different data"
-                };
-            }
-        }
+                }
+            };
 
         [Theory]
         [MemberData(nameof(EqualsCases))]
@@ -86,71 +79,54 @@
             // Assert
             actual.Should()
                 .Be(expected, reason);
-            if (expected)
+
+            object _ = expected switch
             {
-                actualHashCode.Should()
-                    .Be(other?.GetHashCode(), reason);
-            }
-            else
-            {
-                actualHashCode.Should()
-                    .NotBe(other?.GetHashCode(), reason);
-            }
+                true => actualHashCode.Should()
+                    .Be(other?.GetHashCode(), reason),
+                _ => true
+            };
         }
 
-        public static IEnumerable<object[]> IsEquivalentToCases
-        {
-            get
+        public static TheoryData<OneOfExpression, FilterExpression, bool, string> IsEquivalentToCases
+            => new()
             {
-                yield return new object[]
                 {
                     new OneOfExpression(new StringValueExpression("prop1"), new StringValueExpression("prop2")),
                     new OneOfExpression(new StringValueExpression("prop1"), new StringValueExpression("prop2")),
                     true,
                     "comparing two different instances with same data in same order"
-                };
-
-                yield return new object[]
+                },
                 {
                     new OneOfExpression(new StringValueExpression("prop1"), new StringValueExpression("prop2")),
                     new OneOfExpression(new StringValueExpression("prop2"), new StringValueExpression("prop1")),
                     true,
                     "comparing two different instances with same data but the order does not matter"
-                };
-
-                yield return new object[]
+                },
                 {
                     new OneOfExpression(new StringValueExpression("prop1"), new StringValueExpression("prop2")),
                     new OneOfExpression(new StringValueExpression("prop1"), new StringValueExpression("prop3")),
                     false,
                     "comparing two different instances with different data"
-                };
-
-                yield return new object[]
+                },
                 {
                     new OneOfExpression(new StringValueExpression("prop1"), new StringValueExpression("prop2")),
                     new OneOfExpression(new StringValueExpression("prop1"), new StringValueExpression("prop2"), new StringValueExpression("prop3")),
                     false,
                     "the other instance contains all data of the first instance and one item that is not in the current instance"
-                };
-
-                yield return new object[]
+                },
                 {
                     new OneOfExpression(new StringValueExpression("prop1"), new StringValueExpression("prop1"), new StringValueExpression("prop2")),
                     new OneOfExpression(new StringValueExpression("prop1"), new StringValueExpression("prop2")),
                     true,
                     $"a {nameof(OneOfExpression)} instance that holds duplicates is equivalent a {nameof(OneOfExpression)} with no duplicate"
-                };
-
-                yield return new object[]
+                },
                 {
                     new OneOfExpression(new StringValueExpression("prop1"), new StringValueExpression("prop2")),
                     new OrExpression(new StringValueExpression("prop1"), new StringValueExpression("prop2")),
                     true,
                     $"a {nameof(OneOfExpression)} instance that holds two distinct value is equivalent to an {nameof(OrExpression)} with the same values"
-                };
-
-                yield return new object[]
+                },
                 {
                     new OneOfExpression(new IntervalExpression(new BoundaryExpression(new NumericValueExpression("-1"), true),
                                                                 new BoundaryExpression(new NumericValueExpression("-1"), true)),
@@ -159,9 +135,8 @@
                     new NumericValueExpression("-1"),
                     true,
                     $"a {nameof(OneOfExpression)} instance that holds two distinct value is equivalent to its simplified version"
-                };
-            }
-        }
+                }
+            };
 
         [Theory]
         [MemberData(nameof(IsEquivalentToCases))]
@@ -234,38 +209,29 @@
             simplifiedExpression.Complexity.Should().BeLessThanOrEqualTo(complexityBeforeCallingSimplify);
         }
 
-        public static IEnumerable<object[]> SimplifyCases
-        {
-            get
+        public static TheoryData<OneOfExpression, FilterExpression> SimplifyCases
+            => new()
             {
-                yield return new object[]
                 {
                     new OneOfExpression(new StringValueExpression("val1"), new StringValueExpression("val2")),
                     new OrExpression(new StringValueExpression("val1"), new StringValueExpression("val2"))
-                };
-
-                yield return new object[]
+                },
                 {
                     new OneOfExpression(new StringValueExpression("val1"), new StringValueExpression("val1")),
                     new StringValueExpression("val1")
-                };
-
-                yield return new object[]
+                },
                 {
                     new OneOfExpression(new StringValueExpression("val1"), new OrExpression(new StringValueExpression("val1"), new StringValueExpression("val1"))),
                     new StringValueExpression("val1")
-                };
-
-                yield return new object[]
+                },
                 {
                     new OneOfExpression(new IntervalExpression(new BoundaryExpression(new NumericValueExpression("-1"), true),
                                                                 new BoundaryExpression(new NumericValueExpression("-1"), true)),
                                                new IntervalExpression(new BoundaryExpression(new NumericValueExpression("-1"), true),
                                                                 new BoundaryExpression(new NumericValueExpression("-1"), true))),
-                    new NumericValueExpression("-1"),
-                };
-            }
-        }
+                    new NumericValueExpression("-1")
+                }
+            };
 
         [Theory]
         [MemberData(nameof(SimplifyCases))]

--- a/test/DataFilters.UnitTests/Grammar/Syntax/OrExpressionTests.cs
+++ b/test/DataFilters.UnitTests/Grammar/Syntax/OrExpressionTests.cs
@@ -238,23 +238,18 @@
                         .BeTrue("the meaning of the expression should remain the same even after being simplified");
         }
 
-        public static IEnumerable<object[]> SimplifyCases
-        {
-            get
+        public static TheoryData<OrExpression, FilterExpression> SimplifyCases
+            => new()
             {
-                yield return new object[]
                 {
                     new OrExpression(new NumericValueExpression("1"), new OrExpression(new NumericValueExpression("1"), new NumericValueExpression("1"))),
                     new NumericValueExpression("1")
-                };
-
-                yield return new object[]
+                },
                 {
                     new OrExpression(new OrExpression(new StringValueExpression("prop1"), new StringValueExpression("prop1")), new OrExpression(new StringValueExpression("prop1"), new StringValueExpression("prop1"))),
                     new StringValueExpression("prop1")
-                };
-            }
-        }
+                }
+            };
 
         [Theory]
         [MemberData(nameof(SimplifyCases))]

--- a/test/DataFilters.UnitTests/Grammar/Syntax/PropertyNameExpressionTests.cs
+++ b/test/DataFilters.UnitTests/Grammar/Syntax/PropertyNameExpressionTests.cs
@@ -1,7 +1,6 @@
 ﻿namespace DataFilters.UnitTests.Grammar.Syntax
 {
     using System;
-    using System.Collections.Generic;
     using DataFilters.Grammar.Syntax;
     using FluentAssertions;
     using Xunit;
@@ -38,27 +37,22 @@
                 .ThrowExactly<ArgumentOutOfRangeException>("The parameter of the constructor cannot be empty or whitespace only");
         }
 
-        public static IEnumerable<object[]> EqualsCases
-        {
-            get
+        public static TheoryData<PropertyName, object, bool, string> EqualsCases
+            => new()
             {
-                yield return new object[]
                 {
                     new PropertyName("prop1"),
                     new PropertyName("prop1"),
                     true,
                     "comparing two different instances with same property name"
-                };
-
-                yield return new object[]
+                },
                 {
                     new PropertyName("prop1"),
                     new PropertyName("prop2"),
                     false,
                     "comparing two different instances with different property name"
-                };
-            }
-        }
+                }
+            };
 
         [Theory]
         [MemberData(nameof(EqualsCases))]
@@ -74,16 +68,13 @@
             // Assert
             actual.Should()
                 .Be(expected, reason);
-            if (expected)
+
+            object _ = expected switch
             {
-                actualHashCode.Should()
-                    .Be(other?.GetHashCode(), reason);
-            }
-            else
-            {
-                actualHashCode.Should()
-                    .NotBe(other?.GetHashCode(), reason);
-            }
+                true => actualHashCode.Should()
+                    .Be(other?.GetHashCode(), reason),
+                _ => true
+            };
         }
     }
 }

--- a/test/DataFilters.UnitTests/Grammar/Syntax/StartsWithExpressionTests.cs
+++ b/test/DataFilters.UnitTests/Grammar/Syntax/StartsWithExpressionTests.cs
@@ -8,11 +8,10 @@
     using FsCheck.Fluent;
     using FsCheck.Xunit;
     using Xunit;
-    using Xunit.Abstractions;
     using Xunit.Categories;
 
     [UnitTest("StartsWith")]
-    public class StartsWithExpressionTests(ITestOutputHelper outputHelper)
+    public class StartsWithExpressionTests
     {
         [Fact]
         public void IsFilterExpression() => typeof(StartsWithExpression).Should()

--- a/test/DataFilters.UnitTests/Grammar/Syntax/StringValueExpressionTests.cs
+++ b/test/DataFilters.UnitTests/Grammar/Syntax/StringValueExpressionTests.cs
@@ -1,7 +1,6 @@
 ﻿namespace DataFilters.UnitTests.Grammar.Syntax
 {
     using System;
-    using System.Collections.Generic;
     using DataFilters.Grammar.Syntax;
     using DataFilters.UnitTests.Helpers;
     using FluentAssertions;
@@ -68,18 +67,15 @@
                   .BeTrue();
         }
 
-        public static IEnumerable<object[]> EqualsCases
-        {
-            get
+        public static TheoryData<StringValueExpression, object, bool> EqualsCases
+            => new()
             {
-                yield return new object[]
                 {
                     new StringValueExpression("True"),
                     new OrExpression(new StringValueExpression("True"), new StringValueExpression("True")),
                     false
-                };
-            }
-        }
+                }
+            };
 
         [Theory]
         [MemberData(nameof(EqualsCases))]

--- a/test/DataFilters.UnitTests/Helpers/FilterGenerators.cs
+++ b/test/DataFilters.UnitTests/Helpers/FilterGenerators.cs
@@ -1,9 +1,9 @@
-﻿using System;
+﻿using FsCheck.Fluent;
+using FsCheck;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Bogus;
-using FsCheck;
-using FsCheck.Fluent;
 
 namespace DataFilters.UnitTests.Helpers
 {
@@ -14,7 +14,7 @@ namespace DataFilters.UnitTests.Helpers
     /// </summary>
     internal static class FilterGenerators
     {
-        private readonly static Faker Faker = new();
+        private readonly static Faker Faker = new ();
 
         /// <summary>
         /// Generates a <see cref="Arbitrary{Filter}"/> where the value of the filter is a string
@@ -29,7 +29,7 @@ namespace DataFilters.UnitTests.Helpers
             Gen<FilterOperator> genOperator = Gen.OneOf(operators.Select(op => Gen.Constant(op)));
 
             return genOperator.Zip(GetArbitraryFor<string>().Generator)
-                              .Select(tuple => (Op: tuple.Item1, Value: tuple.Item2))
+                              .Select(tuple => (Op : tuple.Item1, Value: tuple.Item2))
                               .Select(tuple => new Filter(Faker.Hacker.Noun(), tuple.Op, tuple.Value))
                               .ToArbitrary();
         }
@@ -84,7 +84,7 @@ namespace DataFilters.UnitTests.Helpers
         public static Arbitrary<IFilter> GenerateFilters()
         {
             Gen<IFilter>[] generators =
-            [
+            {
                 EndsWithFilter().Generator.Select(filter => (IFilter) filter),
                 StartsWithFilter().Generator.Select(filter => (IFilter) filter),
                 ContainsFilter().Generator.Select(filter => (IFilter) filter),
@@ -95,7 +95,7 @@ namespace DataFilters.UnitTests.Helpers
                 LessThanFilter<DateTime>(),
                 LessThanOrEqualFilter<DateTime>(),
                 FiltersOverNumericValues().Generator.Select(filter => (IFilter)filter)
-            ];
+            };
 
             return Gen.OneOf(generators).ToArbitrary();
         }
@@ -123,9 +123,9 @@ namespace DataFilters.UnitTests.Helpers
                 case 0:
                     {
                         gen = GenerateFilters().Generator.Two()
-                                               .Select(tuple => new[] { tuple.Item1, tuple.Item2 })
+                                               .Select(tuple => new[] {tuple.Item1, tuple.Item2})
                                                .Zip(generateLogic)
-                                               .Select(tuple => new MultiFilter { Logic = tuple.Item2, Filters = tuple.Item1 });
+                                               .Select(tuple => new MultiFilter { Logic = tuple.Item2, Filters = tuple.Item1});
                         break;
                     }
 
@@ -150,15 +150,15 @@ namespace DataFilters.UnitTests.Helpers
 
         private static Gen<IFilter> GreaterThanOrEqualFilter<TValue>()
             => GenerateFilterWithSpecifiedOperatorAndValue<TValue>(FilterOperator.GreaterThanOrEqual);
-
+        
         private static Gen<IFilter> LessThanOrEqualFilter<TValue>()
             => GenerateFilterWithSpecifiedOperatorAndValue<TValue>(FilterOperator.LessThanOrEqualTo);
-
+        
         private static Gen<IFilter> LessThanFilter<TValue>()
             => GenerateFilterWithSpecifiedOperatorAndValue<TValue>(FilterOperator.LessThanOrEqualTo);
 
         private static Gen<IFilter> GenerateFilterWithSpecifiedOperatorAndValue<TValue>(FilterOperator op)
             => GetArbitraryFor<TValue>().Generator
-                                        .Select(value => (IFilter)new Filter(Faker.Hacker.Noun(), op, value));
+                                        .Select(value => (IFilter) new Filter(Faker.Hacker.Noun(), op, value));
     }
 }

--- a/test/DataFilters.UnitTests/Helpers/FilterGenerators.cs
+++ b/test/DataFilters.UnitTests/Helpers/FilterGenerators.cs
@@ -1,9 +1,9 @@
-﻿using FsCheck.Fluent;
-using FsCheck;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using Bogus;
+using FsCheck;
+using FsCheck.Fluent;
 
 namespace DataFilters.UnitTests.Helpers
 {
@@ -14,7 +14,7 @@ namespace DataFilters.UnitTests.Helpers
     /// </summary>
     internal static class FilterGenerators
     {
-        private readonly static Faker Faker = new ();
+        private readonly static Faker Faker = new();
 
         /// <summary>
         /// Generates a <see cref="Arbitrary{Filter}"/> where the value of the filter is a string
@@ -29,7 +29,7 @@ namespace DataFilters.UnitTests.Helpers
             Gen<FilterOperator> genOperator = Gen.OneOf(operators.Select(op => Gen.Constant(op)));
 
             return genOperator.Zip(GetArbitraryFor<string>().Generator)
-                              .Select(tuple => (Op : tuple.Item1, Value: tuple.Item2))
+                              .Select(tuple => (Op: tuple.Item1, Value: tuple.Item2))
                               .Select(tuple => new Filter(Faker.Hacker.Noun(), tuple.Op, tuple.Value))
                               .ToArbitrary();
         }
@@ -123,9 +123,9 @@ namespace DataFilters.UnitTests.Helpers
                 case 0:
                     {
                         gen = GenerateFilters().Generator.Two()
-                                               .Select(tuple => new[] {tuple.Item1, tuple.Item2})
+                                               .Select(tuple => new[] { tuple.Item1, tuple.Item2 })
                                                .Zip(generateLogic)
-                                               .Select(tuple => new MultiFilter { Logic = tuple.Item2, Filters = tuple.Item1});
+                                               .Select(tuple => new MultiFilter { Logic = tuple.Item2, Filters = tuple.Item1 });
                         break;
                     }
 
@@ -150,15 +150,15 @@ namespace DataFilters.UnitTests.Helpers
 
         private static Gen<IFilter> GreaterThanOrEqualFilter<TValue>()
             => GenerateFilterWithSpecifiedOperatorAndValue<TValue>(FilterOperator.GreaterThanOrEqual);
-        
+
         private static Gen<IFilter> LessThanOrEqualFilter<TValue>()
             => GenerateFilterWithSpecifiedOperatorAndValue<TValue>(FilterOperator.LessThanOrEqualTo);
-        
+
         private static Gen<IFilter> LessThanFilter<TValue>()
             => GenerateFilterWithSpecifiedOperatorAndValue<TValue>(FilterOperator.LessThanOrEqualTo);
 
         private static Gen<IFilter> GenerateFilterWithSpecifiedOperatorAndValue<TValue>(FilterOperator op)
             => GetArbitraryFor<TValue>().Generator
-                                        .Select(value => (IFilter) new Filter(Faker.Hacker.Noun(), op, value));
+                                        .Select(value => (IFilter)new Filter(Faker.Hacker.Noun(), op, value));
     }
 }

--- a/test/DataFilters.UnitTests/MultiOrderTests.cs
+++ b/test/DataFilters.UnitTests/MultiOrderTests.cs
@@ -1,6 +1,5 @@
 ﻿namespace DataFilters.UnitTests
 {
-    using System.Collections.Generic;
     using DataFilters.TestObjects;
     using FluentAssertions;
     using Xunit;
@@ -9,24 +8,24 @@
 
     public class MultiOrderTests(ITestOutputHelper outputHelper)
     {
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Minor Code Smell", "S1199:Nested code blocks should not be used")]
-        public static IEnumerable<object[]> EqualsCases
+        public static TheoryData<MultiOrder<SuperHero>, object, bool, string> EqualsCases
         {
             get
             {
+                TheoryData<MultiOrder<SuperHero>, object, bool, string> cases = [];
                 {
                     MultiOrder<SuperHero> first = new(
                         new Order<SuperHero>(expression: nameof(SuperHero.Nickname)),
                         new Order<SuperHero>(expression: nameof(SuperHero.Age), direction: Descending)
                     );
 
-                    yield return new object[]
-                    {
+                    cases.Add
+                    (
                         first,
                         first,
                         true,
                         $"A {nameof(MultiOrder<SuperHero>)} instance is equal to itself"
-                    };
+                    );
                 }
                 {
                     MultiOrder<SuperHero> first = new(
@@ -40,13 +39,13 @@
                         new Order<SuperHero>(expression: nameof(SuperHero.Age), direction: Descending)
                     );
 
-                    yield return new object[]
-                    {
+                    cases.Add
+                    (
                         first,
                         second,
                         true,
                         $"Two distinct {nameof(MultiOrder<SuperHero>)} instances holding same data in same order"
-                    };
+                    );
                 }
 
                 {
@@ -62,14 +61,16 @@
                         new Order<SuperHero>(expression: nameof(SuperHero.Nickname))
                     );
 
-                    yield return new object[]
-                    {
+                    cases.Add
+                    (
                         first,
                         second,
                         false,
                         $"Two distinct {nameof(MultiOrder<SuperHero>)} instances holding same data but not same order"
-                    };
+                    );
                 }
+
+                return cases;
             }
         }
 
@@ -87,16 +88,6 @@
             // Assert
             actual.Should()
                 .Be(expected, reason);
-            if (actual)
-            {
-                actualHashCode.Should()
-                    .Be(second?.GetHashCode(), reason);
-            }
-            else
-            {
-                actualHashCode.Should()
-                    .NotBe(second?.GetHashCode(), reason);
-            }
         }
     }
 }

--- a/test/DataFilters.UnitTests/OrderTests.cs
+++ b/test/DataFilters.UnitTests/OrderTests.cs
@@ -1,7 +1,6 @@
 ﻿namespace DataFilters.UnitTests
 {
     using System;
-    using System.Collections.Generic;
     using DataFilters.TestObjects;
     using FluentAssertions;
     using Xunit;
@@ -26,34 +25,37 @@
                 .Where(ex => !string.IsNullOrWhiteSpace(ex.Message), "Message cannot be null");
         }
 
-        public static IEnumerable<object[]> EqualsCases
+        public static TheoryData<Order<SuperHero>, object, bool, string> EqualsCases
         {
             get
             {
-                yield return new object[]
-                {
+                TheoryData<Order<SuperHero>, object, bool, string> cases = [];
+                cases.Add
+                (
                     new Order<SuperHero>("Name"),
                     new Order<SuperHero>("Name"),
                     true,
                     $"Two distinct {nameof(Order<SuperHero>)} instances with same properties must be equal"
-                };
+                );
 
                 Order<SuperHero> sort = new("Name");
-                yield return new object[]
-                {
+                cases.Add
+                (
                     sort,
                     sort,
                     true,
                     $"A {nameof(Order<SuperHero>)} instance is equal to itself"
-                };
+                );
 
-                yield return new object[]
-                {
+                cases.Add
+                (
                     new Order<SuperHero>("Name", Descending),
                     new Order<SuperHero>("Name"),
                     false,
                     $"Two distinct {nameof(Order<SuperHero>)} instances with same {nameof(Order<SuperHero>.Expression)} but different {nameof(Order<SuperHero>.Direction)} must not be equal"
-                };
+                );
+
+                return cases;
             }
         }
 
@@ -66,22 +68,10 @@
 
             // Act
             bool actual = first.Equals(second);
-            int actualHashCode = first.GetHashCode();
 
             // Assert
             actual.Should()
                 .Be(expected, reason);
-
-            if (expected)
-            {
-                actualHashCode.Should()
-                    .Be(second?.GetHashCode(), reason);
-            }
-            else
-            {
-                actualHashCode.Should()
-                    .NotBe(second?.GetHashCode(), reason);
-            }
         }
     }
 }

--- a/test/DataFilters.UnitTests/StringExtensionsTests.cs
+++ b/test/DataFilters.UnitTests/StringExtensionsTests.cs
@@ -1,7 +1,6 @@
 ﻿namespace DataFilters.UnitTests
 {
     using System;
-    using System.Collections.Generic;
     using DataFilters.Casing;
     using DataFilters.TestObjects;
     using FluentAssertions;
@@ -42,55 +41,38 @@
                 .Where(ex => !string.IsNullOrWhiteSpace(ex.Message), $"{nameof(ArgumentOutOfRangeException.Message)} must not be null");
         }
 
-        public static IEnumerable<object[]> ToSortCases
-        {
-            get
+        public static TheoryData<string, IOrder<SuperHero>> ToSortCases
+            => new()
             {
-                yield return new object[]
                 {
                     nameof(SuperHero.Nickname),
                     new Order<SuperHero>(expression : nameof(SuperHero.Nickname), direction : Ascending)
-                };
-                yield return new object[]
+                },
                 {
                     $"+{nameof(SuperHero.Nickname)}",
                     new Order<SuperHero>(expression : nameof(SuperHero.Nickname), direction : Ascending)
-                };
-
-                yield return new object[]
+                },
                 {
                     $"-{nameof(SuperHero.Nickname)}",
                     new Order<SuperHero>(expression : nameof(SuperHero.Nickname), direction : Descending)
-                };
-
+                },
                 {
-                    MultiOrder<SuperHero> multiSort = new
+                    $"{nameof(SuperHero.Nickname)},{nameof(SuperHero.Age)}",
+                    new MultiOrder<SuperHero>
                     (
                         new Order<SuperHero>(expression: nameof(SuperHero.Nickname)),
                         new Order<SuperHero>(expression: nameof(SuperHero.Age))
-                    );
-
-                    yield return new object[]
-                    {
-                        $"{nameof(SuperHero.Nickname)},{nameof(SuperHero.Age)}",
-                        multiSort
-                    };
-                }
+                    )
+                },
                 {
-                    MultiOrder<SuperHero> multiSort = new
+                    $"+{nameof(SuperHero.Nickname)},-{nameof(SuperHero.Age)}",
+                    new MultiOrder<SuperHero>
                     (
                         new Order<SuperHero>(expression: nameof(SuperHero.Nickname)),
                         new Order<SuperHero>(expression: nameof(SuperHero.Age), direction: Descending)
-                    );
-
-                    yield return new object[]
-                    {
-                        $"+{nameof(SuperHero.Nickname)},-{nameof(SuperHero.Age)}",
-                        multiSort
-                    };
+                    )
                 }
-            }
-        }
+            };
 
         [Theory]
         [MemberData(nameof(ToSortCases))]
@@ -108,53 +90,40 @@
                   .Be(expected);
         }
 
-        public static IEnumerable<object[]> ToSortWithPropertyNameResolutionStrategyCases
-        {
-            get
+        public static TheoryData<string, PropertyNameResolutionStrategy, IOrder<Model>> ToSortWithPropertyNameResolutionStrategyCases
+            => new()
             {
-                yield return new object[]
                 {
                     "-SnakeCaseProperty",
                     PropertyNameResolutionStrategy.SnakeCase,
                     new Order<Model>("snake_case_property", Descending)
-                };
-
-                yield return new object[]
+                },
                 {
                     "SnakeCaseProperty",
                     PropertyNameResolutionStrategy.SnakeCase,
                     new Order<Model>("snake_case_property", Ascending)
-                };
-
-                yield return new object[]
+                },
                 {
                     "-SnakeCaseProperty",
                     PropertyNameResolutionStrategy.SnakeCase,
                     new Order<Model>("snake_case_property", Descending)
-                };
-
-                yield return new object[]
+                },
                 {
                     "pascal_case_property",
                     PropertyNameResolutionStrategy.PascalCase,
                     new Order<Model>("PascalCaseProperty", Ascending)
-                };
-
-                yield return new object[]
+                },
                 {
                     "+pascal_case_property",
                     PropertyNameResolutionStrategy.PascalCase,
                     new Order<Model>("PascalCaseProperty", Ascending)
-                };
-
-                yield return new object[]
+                },
                 {
                     "-pascal_case_property",
                     PropertyNameResolutionStrategy.PascalCase,
                     new Order<Model>("PascalCaseProperty", Descending)
-                };
-            }
-        }
+                }
+            };
 
         [Theory]
         [MemberData(nameof(ToSortWithPropertyNameResolutionStrategyCases))]


### PR DESCRIPTION
### 🚀 New features
• Added net8.0 support
### ⚠️ Breaking Changes
• Dropped net5.0 support
• Dropped netcoreapp3.1 support
• Dropped netstandard1.3 support
• Removed IFilterService and FilterService
### 🧹 Housekeeping
• Moved pipeline to Ubuntu agent
• Updated build definition to [Candoumbe.Pipelines 0.9.0](https://www.nuget.org/packages/Candoumbe.Pipelines/0.9.0)
• Updated build.sh script by running nuke :update command
• Removed explicit Nuke.Common dependency from the build project
• Added local file to store encrypted secrets needed when running some CI targets locally
• Replaced property based testing with hand written test cases to validate DateTimeExpression.Equals implementation([#237](https://github.com/candoumbe/datafilters/issues/237))

Full changelog at https://github.com/candoumbe/DataFilters/blob/coldfix/suppress-xunit-1042-warning/CHANGELOG.md

Resolves #285