### PR TITLE
🧹 Drop Net7 Support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `net8.0` support
 
 ### ⚠️ Breaking Changes
-
+- Dropped `net7.0` support
 - Dropped `net5.0` support
 - Dropped `netcoreapp3.1` support
 - Dropped `netstandard1.3` support
@@ -194,4 +194,3 @@ for a corresponding property ([#8](https://github.com/candoumbe/datafilters/issu
 [0.3.0]: https://github.com/candoumbe/DataFilters/compare/0.2.2...0.3.0
 [0.2.2]: https://github.com/candoumbe/DataFilters/compare/0.2.0...0.2.2
 [0.2.0]: https://github.com/candoumbe/DataFilters/tree/0.2.0
-

--- a/build/_build.csproj
+++ b/build/_build.csproj
@@ -3,7 +3,7 @@
   <Import Project="../core.props" />
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <RootNamespace></RootNamespace>
     <NoWarn>;CS0649;CS0169;CS1591;</NoWarn>
     <NukeRootDirectory>..</NukeRootDirectory>

--- a/src/DataFilters.Queries/DataFilters.Queries.csproj
+++ b/src/DataFilters.Queries/DataFilters.Queries.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\..\core.props" />
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net6.0;net8.0</TargetFrameworks>
     <Description>Provides extension methods to convert IFilter to IWhereClause and IOrder to ISort.</Description>
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\DataFilters.Queries.xml</DocumentationFile>
   </PropertyGroup>

--- a/src/DataFilters/DataFilters.csproj
+++ b/src/DataFilters/DataFilters.csproj
@@ -2,7 +2,7 @@
 
   <Import Project="..\..\core.props" />
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net6.0;net8.0</TargetFrameworks>
     <Description>Sets of classes to convert querystrings to strongly typed expressions.</Description>
     <PackageTags>expressions, querystring</PackageTags>
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\DataFilters.xml</DocumentationFile>
@@ -26,12 +26,6 @@
     <When Condition="'$(TargetFramework)' == 'net6.0'">
       <ItemGroup>
         <PackageReference Include="System.Collections.Immutable" Version="6.0.0" />
-        <PackageReference Include="DateOnlyTimeOnly.AspNet" Version="2.1.1" />
-      </ItemGroup>
-    </When>
-    <When Condition="'$(TargetFramework)' == 'net7.0'">
-      <ItemGroup>
-        <PackageReference Include="System.Collections.Immutable" Version="7.0.0" />
         <PackageReference Include="DateOnlyTimeOnly.AspNet" Version="2.1.1" />
       </ItemGroup>
     </When>

--- a/src/Datafilters.Expressions/DataFilters.Expressions.csproj
+++ b/src/Datafilters.Expressions/DataFilters.Expressions.csproj
@@ -2,7 +2,7 @@
 
   <Import Project="..\..\core.props" />
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net6.0;net8.0</TargetFrameworks>
     <Description>Converts IFilter instance to strongly typed expressions.</Description>
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\DataFilters.Expressions.xml</DocumentationFile>
   </PropertyGroup>

--- a/test/DataFilters.Expressions.UnitTests/DataFilters.Expressions.UnitTests.csproj
+++ b/test/DataFilters.Expressions.UnitTests/DataFilters.Expressions.UnitTests.csproj
@@ -2,7 +2,7 @@
 
   <Import Project="..\..\tests.props" />
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>
@@ -38,7 +38,6 @@
   </Choose>
   
   <ItemGroup>
-    <PackageReference Include="Bogus" Version="33.0.2" />
     <PackageReference Include="NodaTime.Testing" Version="3.0.5" />
   </ItemGroup>
   <ItemGroup>

--- a/test/DataFilters.PerformanceTests/DataFilters.PerformanceTests.csproj
+++ b/test/DataFilters.PerformanceTests/DataFilters.PerformanceTests.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <LangVersion>latest</LangVersion>
-    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/DataFilters.Queries.UnitTests/DataFilters.Queries.UnitTests.csproj
+++ b/test/DataFilters.Queries.UnitTests/DataFilters.Queries.UnitTests.csproj
@@ -3,7 +3,7 @@
   <Import Project="..\..\tests.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/DataFilters.TestObjects/DataFilters.TestObjects.csproj
+++ b/test/DataFilters.TestObjects/DataFilters.TestObjects.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net6.0;net8.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/test/DataFilters.UnitTests/DataFilters.UnitTests.csproj
+++ b/test/DataFilters.UnitTests/DataFilters.UnitTests.csproj
@@ -2,7 +2,7 @@
 
   <Import Project="..\..\tests.props" />
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <Compile Remove="Grammar\Parsing\Filtering\**" />


### PR DESCRIPTION
### 🚀 New features
• Added net8.0 support
### ⚠️ Breaking Changes
• Dropped net7.0 support
• Dropped net5.0 support
• Dropped netcoreapp3.1 support
• Dropped netstandard1.3 support
• Removed IFilterService and FilterService
### 🚨 Fixes
• NumericValueExpression and StringValueExpression can be equal when they wrap the same underlying value ([#80](https://github.com/candoumbe/datafilters/issues/80))
### 🧹 Housekeeping
• Moved CI pipeline to Ubuntu agent
• Updated build definition to [Candoumbe.Pipelines 0.9.0](https://www.nuget.org/packages/Candoumbe.Pipelines/0.9.0)
• Updated build.sh script by running nuke :update command
• Removed explicit Nuke.Common dependency from the build project
• Added local file to store encrypted secrets needed when running some CI targets locally
• Replaced property based testing with hand written test cases to validate DateTimeExpression.Equals implementation([#237](https://github.com/candoumbe/datafilters/issues/237))

Full changelog at https://github.com/candoumbe/DataFilters/blob/coldfix/drop-net7-support/CHANGELOG.md

Resolves #314