### PR TITLE
🧹 Code Cleanup

### DIFF
--- a/.github/workflows/delivery.yml
+++ b/.github/workflows/delivery.yml
@@ -36,6 +36,9 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - uses: actions/setup-dotnet@v4
+        with: 
+          global-json-file: 'global.json'
       - name: 'Cache: .nuke/temp, ~/.nuget/packages'
         uses: actions/cache@v4
         with:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -35,6 +35,9 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - uses: actions/setup-dotnet@v4
+        with:
+          global-json-file: 'global.json'
       - name: 'Cache: .nuke/temp, ~/.nuget/packages'
         uses: actions/cache@v4
         with:

--- a/.github/workflows/nightly-manual.yml
+++ b/.github/workflows/nightly-manual.yml
@@ -26,6 +26,9 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - uses: actions/setup-dotnet@v4
+        with:
+          global-json-file: 'global.json'
       - name: 'Cache: .nuke/temp, ~/.nuget/packages'
         uses: actions/cache@v4
         with:

--- a/README.md
+++ b/README.md
@@ -7,7 +7,8 @@
 [![](https://img.shields.io/nuget/vpre/datafilters?label=Datafilters "DataFilters latest nuget package version (including beta)")](https://nuget.org/packages/datafilters)
 
 A small library that allow to convert a string to a generic [`IFilter`][class-ifilter] object.
-Highly inspired by the elastic query syntax, it offers a powerful way to build and query data with a syntax that's not bound to a peculiar datasource.
+Highly inspired by the elastic query syntax, it offers a powerful way to build and query data with a syntax that's not
+bound to a peculiar datasource.
 
 ## **Disclaimer** <!-- omit in toc -->
 
@@ -27,23 +28,22 @@ The public API SHOULD NOT be considered stable.
 - [Any of](#any-of)
 - [Is not null](#is-not-null)
 - [Interval expressions](#interval-expressions)
-  - [Greater than or equal](#greater-than-or-equal)
-  - [Less than or equal](#less-than-or-equal)
-  - [Between](#between)
+    - [Greater than or equal](#greater-than-or-equal)
+    - [Less than or equal](#less-than-or-equal)
+    - [Between](#between)
 - [Regular expression](#regular-expression)
 - [Logical operators](#logical-operators)
-  - [And](#and)
-  - [Or](#or)
-  - [Not](#not)
+    - [And](#and)
+    - [Or](#or)
+    - [Not](#not)
 - [Special character handling](#special-character-handling)
 - [Sorting](#sorting)
 - [How to install](#how-to-install)
 - [How to use](#how-to-use)
-  - [On the client](#on-the-client)
-  - [On the backend](#on-the-backend)
-    - [Building expression trees to filtering data from any datasource](#building-expression-trees-to-filtering-data-from-any-datasource)
-    - [Extending `IFIlter`s](#extending-ifilters)
-
+    - [On the client](#on-the-client)
+    - [On the backend](#on-the-backend)
+        - [Building expression trees to filtering data from any datasource](#building-expression-trees-to-filtering-data-from-any-datasource)
+        - [Extending `IFIlter`s](#extending-ifilters)
 
 The idea came to me when working on a set of REST APIs and trying to build `/search` endpoints.
 I wanted to have a uniform way to query a collection of resources whilst abstracting away underlying datasources.
@@ -67,45 +67,45 @@ JSON Schema
 
 ```json
 {
-  "id": "vigilante_root",
-  "title": "Vigilante",
-  "type": "object",
-  "properties": {
-    "firstname": {
-      "required": true,
-      "type": "string"
-    },
-    "lastname": {
-      "required": true,
-      "type": "string"
-    },
-    "nickname": {
-      "required": true,
-      "type": "string"
-    },
-    "age": {
-      "required": true,
-      "type": "integer"
-    },
-    "description": {
-      "required": true,
-      "type": "string"
-    },
-    "powers": {
-      "required": true,
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "acolytes": {
-      "required": true,
-      "type": "array",
-      "items": {
-        "$ref": "vigilante_root"
-      }
+    "id": "vigilante_root",
+    "title": "Vigilante",
+    "type": "object",
+    "properties": {
+        "firstname": {
+            "required": true,
+            "type": "string"
+        },
+        "lastname": {
+            "required": true,
+            "type": "string"
+        },
+        "nickname": {
+            "required": true,
+            "type": "string"
+        },
+        "age": {
+            "required": true,
+            "type": "integer"
+        },
+        "description": {
+            "required": true,
+            "type": "string"
+        },
+        "powers": {
+            "required": true,
+            "type": "array",
+            "items": {
+                "type": "string"
+            }
+        },
+        "acolytes": {
+            "required": true,
+            "type": "array",
+            "items": {
+                "$ref": "vigilante_root"
+            }
+        }
     }
-  }
 }
 ```
 
@@ -123,10 +123,12 @@ without having to think about the underlying datasource.
 
 This is the first step on filtering data. Thanks to [SuperPower](https://github.com/datalust/superpower/),
 the library supports a custom syntax that can be used to specified one or more criteria resources must fullfill.
-The currently supported syntax mimic the query string syntax : a key-value pair separated by _ampersand_ (`&` character) where :
+The currently supported syntax mimic the query string syntax : a key-value pair separated by _ampersand_ (`&` character)
+where :
 
 - `field` is the name of a property of the resource to filter
-- `value` is an expression which syntax is highly inspired by the [Lucene syntax](http://www.lucenetutorial.com/lucene-query-syntax.html)
+- `value` is an expression which syntax is highly inspired by
+  the [Lucene syntax](http://www.lucenetutorial.com/lucene-query-syntax.html)
 
 To parse an expression, simply call  `ToFilter<T>` extension method
 (see unit tests for more details on the syntax)
@@ -136,7 +138,7 @@ To parse an expression, simply call  `ToFilter<T>` extension method
 Several expressions are supported and here's how you can start using them in your search queries.
 
 |                                                | `string` | numeric types (`int`, `short`, ...) | Date and time types (`DateTime`, `DateTimeOffset`, ...) |
-| ---------------------------------------------- | -------- | ----------------------------------- | ------------------------------------------------------- |
+|------------------------------------------------|----------|-------------------------------------|---------------------------------------------------------|
 | [EqualTo](#equals)                             | ✅        | ✅                                   | ✅                                                       |
 | [StartsWith](#starts-with)                     | ✅        | N/A                                 | N/A                                                     |
 | [Ends with](#ends-with)                        | ✅        | N/A                                 | N/A                                                     |
@@ -152,7 +154,7 @@ Several expressions are supported and here's how you can start using them in you
 Search for any `vigilante` resources where the value of the property `nickname` is `manbat`
 
 | Query string      | JSON                                                  | C#                                                                                     |
-| ----------------- | ----------------------------------------------------- | -------------------------------------------------------------------------------------- |
+|-------------------|-------------------------------------------------------|----------------------------------------------------------------------------------------|
 | `nickname=manbat` | `{ "field":"nickname", "op":"eq", "value":"manbat" }` | `new Filter(field: "nickname", @operator : FilterOperator.EqualsTo, value : "manbat")` |
 
 ## Starts with
@@ -160,7 +162,7 @@ Search for any `vigilante` resources where the value of the property `nickname` 
 Search for any `vigilante` resources where the value of the property `nickname` starts with `"bat"`
 
 | Query string    | JSON                                                       | C#                                                                                    |
-| --------------- | ---------------------------------------------------------- | ------------------------------------------------------------------------------------- |
+|-----------------|------------------------------------------------------------|---------------------------------------------------------------------------------------|
 | `nickname=bat*` | `{ "field":"nickname", "op":"startswith", "value":"bat" }` | `new Filter(field: "nickname", @operator : FilterOperator.StartsWith, value : "bat")` |
 
 ## Ends with
@@ -168,7 +170,7 @@ Search for any `vigilante` resources where the value of the property `nickname` 
 Search for `vigilante` resources where the value of the property `nickname` ends with `man`.
 
 | Query string    | JSON                                                     | C#                                                                                  |
-| --------------- | -------------------------------------------------------- | ----------------------------------------------------------------------------------- |
+|-----------------|----------------------------------------------------------|-------------------------------------------------------------------------------------|
 | `nickname=*man` | `{ "field":"nickname", "op":"endswith", "value":"man" }` | `new Filter(field: "nickname", @operator : FilterOperator.EndsWith, value : "man")` |
 
 ## Contains
@@ -176,7 +178,7 @@ Search for `vigilante` resources where the value of the property `nickname` ends
 Search for any `vigilante` resources where the value of the property `nickname` contains `"bat"`.
 
 | Query string     | JSON                                                     | C#                                                                                  |
-| ---------------- | -------------------------------------------------------- | ----------------------------------------------------------------------------------- |
+|------------------|----------------------------------------------------------|-------------------------------------------------------------------------------------|
 | `nickname=*bat*` | `{ "field":"nickname", "op":"contains", "value":"bat" }` | `new Filter(field: "nickname", @operator : FilterOperator.Contains, value : "bat")` |
 
 💡 `contains` also work on arrays. `powers=*strength*` will search for `vigilante`s who have `strength` related powers.
@@ -184,7 +186,7 @@ Search for any `vigilante` resources where the value of the property `nickname` 
 Search for `vigilante` resources that have no powers.
 
 | Query string | JSON                                   | C#                                                                |
-| ------------ | -------------------------------------- | ----------------------------------------------------------------- |
+|--------------|----------------------------------------|-------------------------------------------------------------------|
 | `powers=!*`  | `{ "field":"powers", "op":"isempty" }` | `new Filter(field: "powers", @operator : FilterOperator.IsEmpty)` |
 
 ## Is null
@@ -192,7 +194,7 @@ Search for `vigilante` resources that have no powers.
 Search for `vigilante` resources that have no powers.
 
 | Query string | JSON                                  | C#                                                                                                                                                  |
-| ------------ | ------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
+|--------------|---------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------|
 | `N/A`        | `{ "field":"powers", "op":"isnull" }` | `new Filter(field: "powers", @operator : FilterOperator.IsNull)` or `new Filter(field: "powers", @operator : FilterOperator.EqualsTo, value: null)` |
 
 ## Any of
@@ -200,7 +202,7 @@ Search for `vigilante` resources that have no powers.
 Search for `vigilante` resources that have at least one of the specified powers.
 
 | Query string                     | JSON |
-| -------------------------------- | ---- |
+|----------------------------------|------|
 | `powers={strength\|speed\|size}` | N/A  |
 
 will result in a [IFilter][class-ifilter] instance equivalent to
@@ -223,9 +225,8 @@ IFilter filter = new MultiFilter
 Search for `vigilante` resources that have no powers.
 
 | Query string | JSON                                     | C#                                                                                                                                                               |
-| ------------ | ---------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|--------------|------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `N/A`        | `{ "field":"powers", "op":"isnotnull" }` | `(new Filter(field: "powers", @operator : FilterOperator.IsNull)).Negate()` or `new Filter(field: "powers", @operator : FilterOperator.NotEqualTo, value: null)` |
-
 
 ## Interval expressions
 
@@ -244,7 +245,7 @@ where
 Search for `vigilante` resources where the value of `age` property is greater than or equal to `18`
 
 | Query string    | JSON                                      | C#                                                                                      |
-| --------------- | ----------------------------------------- | --------------------------------------------------------------------------------------- |
+|-----------------|-------------------------------------------|-----------------------------------------------------------------------------------------|
 | `age=[18 TO *[` | `{"field":"age", "op":"gte", "value":18}` | `new Filter(field: "age", @operator : FilterOperator.GreaterThanOrEqualTo, value : 18)` |
 
 ### Less than or equal
@@ -252,7 +253,7 @@ Search for `vigilante` resources where the value of `age` property is greater th
 Search for `vigilante` resource where the value of `age` property is lower than `30`
 
 | Query string    | JSON                                      | C#                                                                                   |
-| --------------- | ----------------------------------------- | ------------------------------------------------------------------------------------ |
+|-----------------|-------------------------------------------|--------------------------------------------------------------------------------------|
 | `age=]* TO 30]` | `{"field":"age", "op":"lte", "value":30}` | `new Filter(field: "age", @operator : FilterOperator.LessThanOrEqualTo, value : 30)` |
 
 ### Between
@@ -260,7 +261,7 @@ Search for `vigilante` resource where the value of `age` property is lower than 
 Search for vigilante resources where `age` property is between `20` and `35`
 
 | Query string     | JSON                                                                                                          | C#                                                                                                                                                    |
-| ---------------- | ------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
+|------------------|---------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `age=[20 TO 35]` | `{"logic": "and", filters[{"field":"age", "op":"gte", "value":20}, {"field":"age", "op":"lte", "value":35}]}` | `new MultiFilter { Logic = And, Filters = new IFilter[] { new Filter ("age", GreaterThanOrEqualTo, 20), new Filter("age", LessThanOrEqualTo, 35) } }` |
 
 ---
@@ -269,7 +270,7 @@ Search for vigilante resources where `age` property is between `20` and `35`
 - `age=]20 TO 35[` means `age` strictly greater than `20` and strictly less than`35`
 - `age=[20 TO 35[` means `age` greater than or equal to `20` and strictly less than`35`
 - `age=]20 TO 35]` means `age` greater than `20` and less than or equal to `35`
-  
+
 💡 Dates, times and durations must be specified in [ISO 8601 format](https://en.wikipedia.org/wiki/ISO_8601)
 
 Examples :
@@ -281,7 +282,8 @@ Examples :
 💡 You can apply filters to any sub-property of a given collection
 
 Example :
-`acolytes["name"]='robin'` will filter any `vigilante` resource where at least one item in `acolytes` array with `name` equals to `robin`.
+`acolytes["name"]='robin'` will filter any `vigilante` resource where at least one item in `acolytes` array with `name`
+equals to `robin`.
 
 The generic syntax for filtering on in a hierarchical tree
 `property["subproperty"]...["subproperty-n"]=<expression>`
@@ -292,7 +294,8 @@ are equivalent
 
 ## Regular expression
 
-The library offers a limited support of regular expressions. To be more specific, only bracket expressions are currently supported.
+The library offers a limited support of regular expressions. To be more specific, only bracket expressions are currently
+supported.
 A bracket expression. Matches a single character that is contained within the brackets.
 
 For example:
@@ -300,7 +303,8 @@ For example:
 - `[abc]` matches `a`, `b`, or `c`
 - `[a-z]` specifies a range which matches any lowercase letter from `a` to `z`.
 
-[`BracketExpression`](src/DataFilters/Grammar/Syntax/BracketExpression.cs)s can be, as any other expressions, combined with any other expressions to build more complex expressions.
+[`BracketExpression`](src/DataFilters/Grammar/Syntax/BracketExpression.cs)s can be, as any other expressions, combined
+with any other expressions to build more complex expressions.
 
 ## Logical operators
 
@@ -311,7 +315,7 @@ Logicial operators can be used combine several instances of [IFilter][class-ifil
 Use the coma character `,` to combine multiple expressions using logical AND operator
 
 | Query string         | JSON                                                                                                                                     |
-| -------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
+|----------------------|------------------------------------------------------------------------------------------------------------------------------------------|
 | `nickname=Bat*,*man` | `{"logic": "and", filters[{"field":"nickname", "op":"startswith", "value":"Bat"}, {"field":"nckname", "op":"endswith", "value":"man"}]}` |
 
 will result in a [IFilter][class-ifilter] instance equivalent to
@@ -335,7 +339,7 @@ Search for `vigilante` resources where the value of the `nickname` property eith
 ends with `"man"`
 
 | Query string          | JSON                                                                                                                                    |
-| --------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
+|-----------------------|-----------------------------------------------------------------------------------------------------------------------------------------|
 | `nickname=Bat*\|*man` | `{"logic": "or", filters[{"field":"nickname", "op":"startswith", "value":"Bat"}, {"field":"nckname", "op":"endswith", "value":"man"}]}` |
 
 will result in
@@ -359,7 +363,7 @@ To negate a filter, simply put a `!` before the expression to negate
 Search for `vigilante` resources where the value of `nickname` property does not starts with `"B"`
 
 | Query string   | JSON                                                    |
-| -------------- | ------------------------------------------------------- |
+|----------------|---------------------------------------------------------|
 | `nickname=!B*` | `{"field":"nickname", "op":"nstartswith", "value":"B"}` |
 
 will be parsed into a [IFilter][class-ifilter] instance equivalent to
@@ -376,10 +380,9 @@ Expressions can be arbitrarily complex.
 
 Explanation :
 
-The criteria under construction will be applied to the value of `nickname` property and can be read as follow :
+The criteria under construction will be applied to the value of `nickname` property and can be read as follows :
 
-Searchs for `vigilante` resources that starts with `Bat` or `Sup` and ends with `man` or
-`er`.
+Searches for `vigilante` resources that starts with `Bat` or `Sup` and ends with `man` or `er`.
 
 will be parsed into a
 
@@ -412,32 +415,35 @@ IFilter filter = new MultiFilter
 
 ```
 
-The `(` and `)` characters allows to group two expressions together so that this group can be used as a more complex
+The `(` and `)` characters allow you to group two or more expressions together so that this group can be used as a more complex
 expression unit.
 
 ## Special character handling
 
-Sometimes, you'll be looking for a filter that match exactly a text that contains a character which has a special meaning.
+Sometimes, you'll be looking for a filter that match exactly a text that contains a character which has a special
+meaning.
 
 The backslash character (`\`) can be used to escape characters that will be otherwise interpreted as
 a special character.
 
 | Query string  | JSON                                                | C#                                                                              |
-| ------------- | --------------------------------------------------- | ------------------------------------------------------------------------------- |
+|---------------|-----------------------------------------------------|---------------------------------------------------------------------------------|
 | `comment=*\!` | `{"field":"comment", "op":"endswith", "value":"!"}` | `new Filter(field: "comments", @operator: FilterOperator.EndsWith, value: "!")` |
 
-💡 Escaping special characters can be a tedious task when working with longer texts. Just use a text expression instead by wrapping 
+💡 Escaping special characters can be a tedious task when working with longer texts. Just use a text expression instead
+by wrapping
 the text between double quotes (`"`).
 
 | Query string   | JSON                                                | C#                                                                              |
-| -------------- | --------------------------------------------------- | ------------------------------------------------------------------------------- |
+|----------------|-----------------------------------------------------|---------------------------------------------------------------------------------|
 | `comment=*"!"` | `{"field":"comment", "op":"endswith", "value":"!"}` | `new Filter(field: "comments", @operator: FilterOperator.EndsWith, value: "!")` |
 
-Example : 
+Example :
 
 ```
 I'm a long text with some \"special characters\"  in it and each one must be escaped properly`
 ```
+
 can be rewritten
 
 ```
@@ -460,7 +466,8 @@ For example `sort=+nickname,-age` allows to sort by `nickname` ascending, then b
 ## How to install
 
 1. run `dotnet install DataFilters` : you can already start building [IFilter][class-ifilter] instances 😉 !
-2. install one or more `DataFilters.XXXX`  extension packages to convert [IFilter][class-ifilter] instances to various target.
+2. install one or more `DataFilters.XXXX`  extension packages to convert [IFilter][class-ifilter] instances to various
+   target.
 
 ## How to use
 
@@ -544,11 +551,12 @@ Some explanation on the controller's code above  :
 1. The endpoint is bound to incoming HTTP `GET` and `HEAD` requests on `/vigilante/search`
 2. The framework will parse incoming querystring and feeds the `query` parameter accordingly.
 3. From this point we test each criterion to see if it's acceptable to turn it into a [IFilter][class-ifilter] instance.
-   For that purpose, the handy `.ToFilter<T>()` string extension method is available. It turns a query-string key-value pair into a
+   For that purpose, the handy `.ToFilter<T>()` string extension method is available. It turns a query-string key-value
+   pair into a
    full [IFilter][class-ifilter].
 4. we can then either :
-   - use the filter directly is there was only one filter
-   - or combine them using [composite filter][class-multi-filter] when there is more than one criterion.
+    - use the filter directly is there was only one filter
+    - or combine them using [composite filter][class-multi-filter] when there is more than one criterion.
 
 💡 _Remarks_
 
@@ -559,7 +567,8 @@ This is to distinguish if the `Age` criterion was provided or not when calling t
 
 Most of the time, once you have an [IFilter][class-ifilter], you want to use it against a datasource.
 Using `Expression<Func<T, bool>>` is the most common type used for this kind of purpose.
-[DataFilters.Expressions][Datafilters.expressions] library adds `ToExpression<T>()` extension method on top of [IFilter][class-ifilter] instance to convert it
+[DataFilters.Expressions][Datafilters.expressions] library adds `ToExpression<T>()` extension method on top
+of [IFilter][class-ifilter] instance to convert it
 to an equivalent `System.Expression<Func<T, bool>>` instance.
 Using the example of the `VigilantesController`, we can turn our `filter` into a `Expression<Func<T, bool>>`
 
@@ -568,26 +577,35 @@ IFilter filter = ...
 Expression<Func<Vigilante, bool>> predicate = filter.ToExpression<Vigilante>();
 ```
 
-The `predicate` expression can now be used against any datasource that accepts `Expression<Func<Vigilante, bool>>` (👋🏾 EntityFramework and the likes )
+The `predicate` expression can now be used against any datasource that accepts `Expression<Func<Vigilante, bool>>` (👋🏾
+EntityFramework and the likes )
 
 #### Extending `IFIlter`s
 
-What to do when you cannot use expression trees when querying your datasource ? Well, you can write your own method to render it duh !!!
+What to do when you cannot use expression trees when querying your datasource ? Well, you can write your own method to
+render it duh !!!
 
-DataFilters.Queries[![Nuget](https://img.shields.io/nuget/v/DataFilters.Queries?color=blue)](https://www.nuget.org/packages/DataFilters.Queries) adds `ToWhere<T>()` extension 
+DataFilters.Queries[![Nuget](https://img.shields.io/nuget/v/DataFilters.Queries?color=blue)](https://www.nuget.org/packages/DataFilters.Queries)
+adds `ToWhere<T>()` extension
 method on top of [IFilter][class-ifilter] instance to convert
-it to an equivalent [`IWhereClause`](https://github.com/candoumbe/Queries/blob/develop/src/Queries.Core/Parts/Clauses/IWhereClause.cs) instance.
-[`IWhereClause`](https://github.com/candoumbe/Queries/blob/develop/src/Queries.Core/Parts/Clauses/IWhereClause.cs) is an interface from the [Queries](https://github.com/candoumbe/Queries) that 
+it to an equivalent [
+`IWhereClause`](https://github.com/candoumbe/Queries/blob/develop/src/Queries.Core/Parts/Clauses/IWhereClause.cs)
+instance.
+[`IWhereClause`](https://github.com/candoumbe/Queries/blob/develop/src/Queries.Core/Parts/Clauses/IWhereClause.cs) is an
+interface from the [Queries](https://github.com/candoumbe/Queries) that
 can later be translated a secure SQL string.
 You can find more info on that directly in the Github repository.
 
 | Package                                                                                                                                                             | Downloads                                                                                                            | Description                                                                                                                                                                                                                                  |
-| ------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|---------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | [![Nuget](https://img.shields.io/nuget/v/Datafilters?label=Datafilters&color=blue)](https://www.nuget.org/packages/DataFilters)                                     | ![DataFilters download count](https://img.shields.io/nuget/dt/Datafilters?label=&color=blue)                         | provides core functionalities of parsing strings and converting to [IFilter][class-ifilter] instances.                                                                                                                                       |
 | [![Nuget](https://img.shields.io/nuget/v/DataFilters.Expressions?label=Datafilters.Expressions&color=blue)](https://www.nuget.org/packages/DataFilters.Expressions) | ![DataFilters.Expressions download count](https://img.shields.io/nuget/dt/Datafilters.Expressions?label=&color=blue) | adds `ToExpression<T>()` extension method on top of [IFilter][class-ifilter] instance to convert it to an equivalent `System.Linq.Expressions.Expression<Func<T, bool>>` instance.                                                           |
 | [![Nuget](https://img.shields.io/nuget/v/Datafilters.Queries?label=DataFilters.Queries&color=blue)](https://www.nuget.org/packages/DataFilters.Queries)             | ![DataFilters.Queries download count](https://img.shields.io/nuget/dt/Datafilters.Queries?label=&color=blue)         | adds `ToWhere<T>()` extension method on top of [IFilter][class-ifilter] instance to convert it to an equivalent [`IWhereClause`](https://github.com/candoumbe/Queries/blob/develop/src/Queries.Core/Parts/Clauses/IWhereClause.cs) instance. |
 
 [class-multi-filter]: /src/DataFilters/MultiFilter.cs
+
 [class-ifilter]: /src/DataFilters/IFilter.cs
+
 [DataFilters.Expressions]: https://www.nuget.org/packages/DataFilters.Expressions
+
 [DataFilters.Queries]: https://www.nuget.org/packages/DataFilters.Queries

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -1,143 +1,143 @@
 using Nuke.Common.Tools.GitHub;
 
-namespace DataFilters.ContinuousIntegration
+namespace DataFilters.ContinuousIntegration;
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Candoumbe.Pipelines.Components;
+using Candoumbe.Pipelines.Components.Formatting;
+using Candoumbe.Pipelines.Components.GitHub;
+using Candoumbe.Pipelines.Components.NuGet;
+using Candoumbe.Pipelines.Components.Workflows;
+using Nuke.Common;
+using Nuke.Common.CI.GitHubActions;
+using Nuke.Common.IO;
+using Nuke.Common.ProjectModel;
+using Nuke.Common.Tooling;
+using Nuke.Common.Tools.DotNet;
+
+[GitHubActions(
+    "integration",
+    GitHubActionsImage.Ubuntu2204,
+    AutoGenerate = false,
+    FetchDepth = 0,
+    OnPushBranchesIgnore = [IHaveMainBranch.MainBranchName],
+    PublishArtifacts = true,
+    InvokedTargets = [nameof(IUnitTest.UnitTests), nameof(IPushNugetPackages.Publish), nameof(IPack.Pack)],
+    CacheKeyFiles = ["global.json", "src/**/*.csproj"],
+    ImportSecrets =
+    [
+        nameof(NugetApiKey),
+        nameof(IReportCoverage.CodecovToken),
+    ],
+    OnPullRequestExcludePaths =
+    [
+        "docs/*",
+        "README.md",
+        "CHANGELOG.md",
+        "LICENSE"
+    ]
+)]
+[GitHubActions(
+    "delivery",
+    GitHubActionsImage.Ubuntu2204,
+    AutoGenerate = false,
+    FetchDepth = 0,
+    OnPushBranches = [IHaveMainBranch.MainBranchName, IGitFlow.ReleaseBranch + "/*"],
+    InvokedTargets = [nameof(IUnitTest.UnitTests), nameof(IPushNugetPackages.Publish), nameof(ICreateGithubRelease.AddGithubRelease)],
+    EnableGitHubToken = true,
+    CacheKeyFiles = ["global.json", "src/**/*.csproj"],
+    PublishArtifacts = true,
+    ImportSecrets =
+    [
+        nameof(NugetApiKey),
+        nameof(IReportCoverage.CodecovToken)
+    ],
+    OnPullRequestExcludePaths =
+    [
+        "docs/*",
+        "README.md",
+        "CHANGELOG.md",
+        "LICENSE"
+    ]
+)]
+
+//[GitHubActions("nightly", GitHubActionsImage.Ubuntu2204,
+//    AutoGenerate = false,
+//    FetchDepth = 0,
+//    OnCronSchedule = "0 0 * * *",
+//    InvokedTargets = new[] { nameof(IUnitTest.Compile), nameof(IMutationTest.MutationTests), nameof(IPushNugetPackages.Pack) },
+//    OnPushBranches = new[] { IHaveDevelopBranch.DevelopBranchName },
+//    CacheKeyFiles = new[] {
+//        "src/**/*.csproj",
+//        "test/**/*.csproj",
+//        "stryker-config.json",
+//        "test/**/*/xunit.runner.json" },
+//    EnableGitHubToken = true,
+//    ImportSecrets = new[]
+//    {
+//        nameof(NugetApiKey),
+//        nameof(IReportCoverage.CodecovToken),
+//        nameof(IMutationTest.StrykerDashboardApiKey)
+//    },
+//    PublishArtifacts = true,
+//    OnPullRequestExcludePaths = new[]
+//    {
+//        "docs/*",
+//        "README.md",
+//        "CHANGELOG.md",
+//        "LICENSE"
+//    }
+//)]
+[GitHubActions("nightly-manual", GitHubActionsImage.Ubuntu2204,
+    AutoGenerate = false,
+    FetchDepth = 0,
+    On = [GitHubActionsTrigger.WorkflowDispatch],
+    InvokedTargets = [nameof(IUnitTest.Compile), nameof(IMutationTest.MutationTests), nameof(IPushNugetPackages.Pack)],
+    CacheKeyFiles = [
+        "src/**/*.csproj",
+        "test/**/*.csproj",
+        "stryker-config.json",
+        "test/**/*/xunit.runner.json"],
+    EnableGitHubToken = true,
+    ImportSecrets =
+    [
+        nameof(NugetApiKey),
+        nameof(IReportCoverage.CodecovToken),
+        nameof(IMutationTest.StrykerDashboardApiKey)
+    ],
+    PublishArtifacts = true
+)]
+[DotNetVerbosityMapping]
+public class Build : EnhancedNukeBuild,
+    IHaveSolution,
+    IHaveSourceDirectory,
+    IHaveTestDirectory,
+    IGitFlowWithPullRequest,
+    IClean,
+    IRestore,
+    ICompile,
+    IUnitTest,
+    IMutationTest,
+    IBenchmark,
+    IReportCoverage,
+    IPack,
+    IPushNugetPackages,
+    ICreateGithubRelease
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Linq;
-    using Candoumbe.Pipelines.Components;
-    using Candoumbe.Pipelines.Components.Formatting;
-    using Candoumbe.Pipelines.Components.GitHub;
-    using Candoumbe.Pipelines.Components.NuGet;
-    using Candoumbe.Pipelines.Components.Workflows;
-    using Nuke.Common;
-    using Nuke.Common.CI.GitHubActions;
-    using Nuke.Common.IO;
-    using Nuke.Common.ProjectModel;
-    using Nuke.Common.Tooling;
-    using Nuke.Common.Tools.DotNet;
+    [Parameter("API key used to publish artifacts to Nuget.org")]
+    [Secret]
+    public readonly string NugetApiKey;
 
-    [GitHubActions(
-        "integration",
-        GitHubActionsImage.Ubuntu2204,
-        AutoGenerate = false,
-        FetchDepth = 0,
-        OnPushBranchesIgnore = [IHaveMainBranch.MainBranchName],
-        PublishArtifacts = true,
-        InvokedTargets = [nameof(IUnitTest.UnitTests), nameof(IPushNugetPackages.Publish), nameof(IPack.Pack)],
-        CacheKeyFiles = ["global.json", "src/**/*.csproj"],
-        ImportSecrets =
-        [
-            nameof(NugetApiKey),
-            nameof(IReportCoverage.CodecovToken),
-        ],
-        OnPullRequestExcludePaths =
-        [
-            "docs/*",
-            "README.md",
-            "CHANGELOG.md",
-            "LICENSE"
-        ]
-    )]
-    [GitHubActions(
-        "delivery",
-        GitHubActionsImage.Ubuntu2204,
-        AutoGenerate = false,
-        FetchDepth = 0,
-        OnPushBranches = [IHaveMainBranch.MainBranchName, IGitFlow.ReleaseBranch + "/*"],
-        InvokedTargets = [nameof(IUnitTest.UnitTests), nameof(IPushNugetPackages.Publish), nameof(ICreateGithubRelease.AddGithubRelease)],
-        EnableGitHubToken = true,
-        CacheKeyFiles = ["global.json", "src/**/*.csproj"],
-        PublishArtifacts = true,
-        ImportSecrets =
-        [
-            nameof(NugetApiKey),
-            nameof(IReportCoverage.CodecovToken)
-        ],
-        OnPullRequestExcludePaths =
-        [
-            "docs/*",
-            "README.md",
-            "CHANGELOG.md",
-            "LICENSE"
-        ]
-    )]
+    [Solution]
+    [Required]
+    public readonly Solution Solution;
 
-    //[GitHubActions("nightly", GitHubActionsImage.Ubuntu2204,
-    //    AutoGenerate = false,
-    //    FetchDepth = 0,
-    //    OnCronSchedule = "0 0 * * *",
-    //    InvokedTargets = new[] { nameof(IUnitTest.Compile), nameof(IMutationTest.MutationTests), nameof(IPushNugetPackages.Pack) },
-    //    OnPushBranches = new[] { IHaveDevelopBranch.DevelopBranchName },
-    //    CacheKeyFiles = new[] {
-    //        "src/**/*.csproj",
-    //        "test/**/*.csproj",
-    //        "stryker-config.json",
-    //        "test/**/*/xunit.runner.json" },
-    //    EnableGitHubToken = true,
-    //    ImportSecrets = new[]
-    //    {
-    //        nameof(NugetApiKey),
-    //        nameof(IReportCoverage.CodecovToken),
-    //        nameof(IMutationTest.StrykerDashboardApiKey)
-    //    },
-    //    PublishArtifacts = true,
-    //    OnPullRequestExcludePaths = new[]
-    //    {
-    //        "docs/*",
-    //        "README.md",
-    //        "CHANGELOG.md",
-    //        "LICENSE"
-    //    }
-    //)]
-    [GitHubActions("nightly-manual", GitHubActionsImage.Ubuntu2204,
-        AutoGenerate = false,
-        FetchDepth = 0,
-        On = [GitHubActionsTrigger.WorkflowDispatch],
-        InvokedTargets = [nameof(IUnitTest.Compile), nameof(IMutationTest.MutationTests), nameof(IPushNugetPackages.Pack)],
-        CacheKeyFiles = [
-            "src/**/*.csproj",
-            "test/**/*.csproj",
-            "stryker-config.json",
-            "test/**/*/xunit.runner.json"],
-        EnableGitHubToken = true,
-        ImportSecrets =
-        [
-            nameof(NugetApiKey),
-            nameof(IReportCoverage.CodecovToken),
-            nameof(IMutationTest.StrykerDashboardApiKey)
-        ],
-        PublishArtifacts = true
-    )]
-    [DotNetVerbosityMapping]
-    public class Build : EnhancedNukeBuild,
-        IHaveSolution,
-        IHaveSourceDirectory,
-        IHaveTestDirectory,
-        IGitFlowWithPullRequest,
-        IClean,
-        IRestore,
-        ICompile,
-        IUnitTest,
-        IMutationTest,
-        IBenchmark,
-        IReportCoverage,
-        IPack,
-        IPushNugetPackages,
-        ICreateGithubRelease
-    {
-        [Parameter("API key used to publish artifacts to Nuget.org")]
-        [Secret]
-        public readonly string NugetApiKey;
+    ///<inheritdoc/>
+    Solution IHaveSolution.Solution => Solution;
 
-        [Solution]
-        [Required]
-        public readonly Solution Solution;
-
-        ///<inheritdoc/>
-        Solution IHaveSolution.Solution => Solution;
-
-        public static int Main() => Execute<Build>(x => ((ICompile)x).Compile);
+    public static int Main() => Execute<Build>(x => ((ICompile)x).Compile);
 
     ///<inheritdoc/>
     IEnumerable<AbsolutePath> IClean.DirectoriesToDelete
@@ -147,53 +147,52 @@ namespace DataFilters.ContinuousIntegration
             .. this.Get<IHaveTestDirectory>().TestDirectory.GlobDirectories("**/bin", "**/obj")
         ];
 
-        /// <inheritdoc />
-        Configure<DotNetToolRestoreSettings> IRestore.RestoreToolSettings => _ => _.SetDisableParallel(true);
+    /// <inheritdoc />
+    Configure<DotNetToolRestoreSettings> IRestore.RestoreToolSettings => _ => _.SetDisableParallel(true);
 
-        ///<inheritdoc/>
-        AbsolutePath IHaveSourceDirectory.SourceDirectory => RootDirectory / "src";
+    ///<inheritdoc/>
+    AbsolutePath IHaveSourceDirectory.SourceDirectory => RootDirectory / "src";
 
-        ///<inheritdoc/>
-        AbsolutePath IHaveTestDirectory.TestDirectory => RootDirectory / "test";
+    ///<inheritdoc/>
+    AbsolutePath IHaveTestDirectory.TestDirectory => RootDirectory / "test";
 
-        ///<inheritdoc/>
-        IEnumerable<Project> IUnitTest.UnitTestsProjects => this.Get<IHaveSolution>().Solution.GetAllProjects("*UnitTests");
+    ///<inheritdoc/>
+    IEnumerable<Project> IUnitTest.UnitTestsProjects => this.Get<IHaveSolution>().Solution.GetAllProjects("*UnitTests");
 
-        private static IReadOnlyList<string> Projects => ["DataFilters", "DataFilters.Expressions", "DataFilters.Queries"];
+    private static IReadOnlyList<string> Projects => ["DataFilters", "DataFilters.Expressions", "DataFilters.Queries"];
 
-        ///<inheritdoc/>
-        IEnumerable<MutationProjectConfiguration> IMutationTest.MutationTestsProjects
-            => Projects.Select(projectName => new MutationProjectConfiguration(sourceProject: Solution.AllProjects.Single(csproj => string.Equals(csproj.Name, projectName, StringComparison.InvariantCultureIgnoreCase)),
+    ///<inheritdoc/>
+    IEnumerable<MutationProjectConfiguration> IMutationTest.MutationTestsProjects
+        => Projects.Select(projectName => new MutationProjectConfiguration(sourceProject: Solution.AllProjects.Single(csproj => string.Equals(csproj.Name, projectName, StringComparison.InvariantCultureIgnoreCase)),
                 testProjects: Solution.AllProjects.Where(csproj => string.Equals(csproj.Name, $"{projectName}.UnitTests", StringComparison.InvariantCultureIgnoreCase)),
                 configurationFile: this.Get<IHaveTestDirectory>().TestDirectory / $"{projectName}.UnitTests" / "stryker-config.json"))
             .ToArray();
 
-        ///<inheritdoc/>
-        IEnumerable<Project> IBenchmark.BenchmarkProjects => this.Get<IHaveSolution>().Solution.GetAllProjects("*.PerformanceTests");
+    ///<inheritdoc/>
+    IEnumerable<Project> IBenchmark.BenchmarkProjects => this.Get<IHaveSolution>().Solution.GetAllProjects("*.PerformanceTests");
 
-        ///<inheritdoc/>
-        bool IReportCoverage.ReportToCodeCov => this.Get<IReportCoverage>().CodecovToken is not null;
+    ///<inheritdoc/>
+    bool IReportCoverage.ReportToCodeCov => this.Get<IReportCoverage>().CodecovToken is not null;
 
-        ///<inheritdoc/>
-        IEnumerable<AbsolutePath> IPack.PackableProjects => this.Get<IHaveSourceDirectory>().SourceDirectory.GlobFiles("**/*.csproj");
+    ///<inheritdoc/>
+    IEnumerable<AbsolutePath> IPack.PackableProjects => this.Get<IHaveSourceDirectory>().SourceDirectory.GlobFiles("**/*.csproj");
 
     ///<inheritdoc/>
     IEnumerable<PushNugetPackageConfiguration> IPushNugetPackages.PublishConfigurations =>
     [
         new NugetPushConfiguration(apiKey: NugetApiKey,
-                                  source: new Uri("https://api.nuget.org/v3/index.json"),
-                                  canBeUsed: () => NugetApiKey is not null),
+            source: new Uri("https://api.nuget.org/v3/index.json"),
+            canBeUsed: () => NugetApiKey is not null),
         new GitHubPushNugetConfiguration(githubToken: this.Get<IHaveGitHubRepository>().GitHubToken,
-                                         source: new Uri($"https://nuget.pkg.github.com/{this.Get<IHaveGitHubRepository>().GitRepository.GetGitHubOwner()}/index.json"),
-                                         canBeUsed: () => this.As<ICreateGithubRelease>()?.GitHubToken is not null)
+            source: new Uri($"https://nuget.pkg.github.com/{this.Get<IHaveGitHubRepository>().GitRepository.GetGitHubOwner()}/index.json"),
+            canBeUsed: () => this.As<ICreateGithubRelease>()?.GitHubToken is not null)
     ];
 
-        protected override void OnBuildCreated()
+    protected override void OnBuildCreated()
+    {
+        if (IsServerBuild)
         {
-            if (IsServerBuild)
-            {
-                EnvironmentInfo.SetVariable("DOTNET_ROLL_FORWARD", "LatestMajor");
-            }
+            EnvironmentInfo.SetVariable("DOTNET_ROLL_FORWARD", "LatestMajor");
         }
     }
 }

--- a/src/DataFilters.Queries/FilterToQueries.cs
+++ b/src/DataFilters.Queries/FilterToQueries.cs
@@ -1,131 +1,130 @@
-﻿namespace DataFilters
+﻿namespace DataFilters;
+
+using System;
+using System.Linq;
+using Queries.Core.Parts.Clauses;
+
+/// <summary>
+/// Extensions method <see cref="IFilter"/> type.
+/// </summary>
+public static class FilterToQueries
 {
-    using System;
-    using System.Linq;
-    using Queries.Core.Parts.Clauses;
-
     /// <summary>
-    /// Extensions method <see cref="IFilter"/> type.
+    /// Converts <paramref name="filter"/> to <see cref="IWhereClause"/>.
     /// </summary>
-    public static class FilterToQueries
+    /// <param name="filter">The filter to convert</param>
+    /// <returns>A <see cref="IWhereClause"/> equivalent of the given <paramref name="filter"/>.</returns>
+    public static IWhereClause ToWhere(this IFilter filter)
     {
-        /// <summary>
-        /// Converts <paramref name="filter"/> to <see cref="IWhereClause"/>.
-        /// </summary>
-        /// <param name="filter">The filter to convert</param>
-        /// <returns>A <see cref="IWhereClause"/> equivalent of the given <paramref name="filter"/>.</returns>
-        public static IWhereClause ToWhere(this IFilter filter)
+        IWhereClause clause = null;
+
+        switch (filter)
         {
-            IWhereClause clause = null;
-
-            switch (filter)
+            case Filter f:
             {
-                case Filter f:
-                    {
-                        ClauseOperator clauseOperator;
-                        object value = f.Value;
+                ClauseOperator clauseOperator;
+                object value = f.Value;
 
-                        switch (f.Operator)
+                switch (f.Operator)
+                {
+                    case FilterOperator.EqualTo:
+                        clauseOperator = ClauseOperator.EqualTo;
+                        break;
+                    case FilterOperator.NotEqualTo:
+                        clauseOperator = ClauseOperator.NotEqualTo;
+                        break;
+                    case FilterOperator.IsNull:
+                        clauseOperator = ClauseOperator.IsNull;
+                        break;
+                    case FilterOperator.IsNotNull:
+                        clauseOperator = ClauseOperator.IsNotNull;
+                        break;
+                    case FilterOperator.LessThan:
+                        clauseOperator = ClauseOperator.LessThan;
+                        break;
+                    case FilterOperator.LessThanOrEqualTo:
+                        clauseOperator = ClauseOperator.LessThanOrEqualTo;
+                        break;
+                    case FilterOperator.GreaterThan:
+                        clauseOperator = ClauseOperator.GreaterThan;
+                        break;
+                    case FilterOperator.GreaterThanOrEqual:
+                        clauseOperator = ClauseOperator.GreaterThanOrEqualTo;
+                        break;
+                    case FilterOperator.StartsWith:
+                    case FilterOperator.EndsWith:
+                    case FilterOperator.Contains:
+                        clauseOperator = ClauseOperator.Like;
+                        if (f.Operator == FilterOperator.StartsWith)
                         {
-                            case FilterOperator.EqualTo:
-                                clauseOperator = ClauseOperator.EqualTo;
-                                break;
-                            case FilterOperator.NotEqualTo:
-                                clauseOperator = ClauseOperator.NotEqualTo;
-                                break;
-                            case FilterOperator.IsNull:
-                                clauseOperator = ClauseOperator.IsNull;
-                                break;
-                            case FilterOperator.IsNotNull:
-                                clauseOperator = ClauseOperator.IsNotNull;
-                                break;
-                            case FilterOperator.LessThan:
-                                clauseOperator = ClauseOperator.LessThan;
-                                break;
-                            case FilterOperator.LessThanOrEqualTo:
-                                clauseOperator = ClauseOperator.LessThanOrEqualTo;
-                                break;
-                            case FilterOperator.GreaterThan:
-                                clauseOperator = ClauseOperator.GreaterThan;
-                                break;
-                            case FilterOperator.GreaterThanOrEqual:
-                                clauseOperator = ClauseOperator.GreaterThanOrEqualTo;
-                                break;
-                            case FilterOperator.StartsWith:
-                            case FilterOperator.EndsWith:
-                            case FilterOperator.Contains:
-                                clauseOperator = ClauseOperator.Like;
-                                if (f.Operator == FilterOperator.StartsWith)
-                                {
-                                    value = $"{value}%";
-                                }
-                                else if (f.Operator == FilterOperator.EndsWith)
-                                {
-                                    value = $"%{value}";
-                                }
-                                else
-                                {
-                                    value = $"%{value}%";
-                                }
-                                break;
-                            case FilterOperator.NotStartsWith:
-                            case FilterOperator.NotEndsWith:
-                            case FilterOperator.NotContains:
-                                clauseOperator = ClauseOperator.NotLike;
-                                if (f.Operator == FilterOperator.NotStartsWith)
-                                {
-                                    value = $"{value}%";
-                                }
-                                else if (f.Operator == FilterOperator.NotEndsWith)
-                                {
-                                    value = $"%{value}";
-                                }
-                                else
-                                {
-                                    value = $"%{value}%";
-                                }
-                                break;
-                            default:
-                                throw new NotSupportedException($"Unsupported {f.Operator} operator");
+                            value = $"{value}%";
                         }
-
-                        clause = new WhereClause(f.Field.Field(), clauseOperator, value switch
+                        else if (f.Operator == FilterOperator.EndsWith)
                         {
-                            bool b => b.Literal(),
-                            DateTime date => date.Literal(),
-                            string s => s.Literal(),
-                            null => null,
-                            long l => l.Literal(),
-                            float floatValue => floatValue.Literal(),
-                            decimal decimalValue => decimalValue.Literal(),
-                            double doubleValue => doubleValue.Literal(),
-                            int intValue => intValue.Literal(),
+                            value = $"%{value}";
+                        }
+                        else
+                        {
+                            value = $"%{value}%";
+                        }
+                        break;
+                    case FilterOperator.NotStartsWith:
+                    case FilterOperator.NotEndsWith:
+                    case FilterOperator.NotContains:
+                        clauseOperator = ClauseOperator.NotLike;
+                        if (f.Operator == FilterOperator.NotStartsWith)
+                        {
+                            value = $"{value}%";
+                        }
+                        else if (f.Operator == FilterOperator.NotEndsWith)
+                        {
+                            value = $"%{value}";
+                        }
+                        else
+                        {
+                            value = $"%{value}%";
+                        }
+                        break;
+                    default:
+                        throw new NotSupportedException($"Unsupported {f.Operator} operator");
+                }
+
+                clause = new WhereClause(f.Field.Field(), clauseOperator, value switch
+                    {
+                        bool b => b.Literal(),
+                        DateTime date => date.Literal(),
+                        string s => s.Literal(),
+                        null => null,
+                        long l => l.Literal(),
+                        float floatValue => floatValue.Literal(),
+                        decimal decimalValue => decimalValue.Literal(),
+                        double doubleValue => doubleValue.Literal(),
+                        int intValue => intValue.Literal(),
 #if NET6_0_OR_GREATER
-                            DateOnly date => date.Literal(),
-                            TimeOnly time => time.Literal(),
+                        DateOnly date => date.Literal(),
+                        TimeOnly time => time.Literal(),
 #endif
-                            _ => throw new NotSupportedException($"Unexpected '{value?.GetType().Name}' type when building WhereClause")
-                        }
-                        );
-                        break;
+                        _ => throw new NotSupportedException($"Unexpected '{value?.GetType().Name}' type when building WhereClause")
                     }
-
-                case MultiFilter cf:
-                    {
-                        clause = new CompositeWhereClause
-                        {
-                            Logic = cf.Logic == FilterLogic.And
-                                ? ClauseLogic.And
-                                : ClauseLogic.Or,
-                            Clauses = cf.Filters.Select(item => item.ToWhere())
-                        };
-                        break;
-                    }
-                default:
-                    throw new NotSupportedException("Unsupported filter type");
+                );
+                break;
             }
 
-            return clause;
+            case MultiFilter cf:
+            {
+                clause = new CompositeWhereClause
+                {
+                    Logic = cf.Logic == FilterLogic.And
+                        ? ClauseLogic.And
+                        : ClauseLogic.Or,
+                    Clauses = cf.Filters.Select(item => item.ToWhere())
+                };
+                break;
+            }
+            default:
+                throw new NotSupportedException("Unsupported filter type");
         }
+
+        return clause;
     }
 }

--- a/src/DataFilters.Queries/OrderExtensions.cs
+++ b/src/DataFilters.Queries/OrderExtensions.cs
@@ -1,47 +1,46 @@
-﻿namespace DataFilters
+﻿namespace DataFilters;
+
+using System;
+using System.Collections.Generic;
+using Queries.Core.Parts.Sorting;
+
+/// <summary>
+/// Extensions method for <see cref="IOrder{T}"/> types
+/// </summary>
+public static class OrderExtensions
 {
-    using System;
-    using System.Collections.Generic;
-    using Queries.Core.Parts.Sorting;
-
     /// <summary>
-    /// Extensions method for <see cref="IOrder{T}"/> types
+    /// Converts <paramref name="order"/> to <see cref="IOrder"/>.
     /// </summary>
-    public static class OrderExtensions
+    /// <typeparam name="T">Type of element the sort will be apply to.</typeparam>
+    /// <param name="order"></param>
+    /// <exception cref="NotSupportedException"><paramref name="order"/> is neither <see cref="Order{T}"/> nor <see cref="MultiOrder{T}"/>.</exception>
+    public static IEnumerable<IOrder> ToOrder<T>(this IOrder<T> order)
     {
-        /// <summary>
-        /// Converts <paramref name="order"/> to <see cref="IOrder"/>.
-        /// </summary>
-        /// <typeparam name="T">Type of element the sort will be apply to.</typeparam>
-        /// <param name="order"></param>
-        /// <exception cref="NotSupportedException"><paramref name="order"/> is neither <see cref="Order{T}"/> nor <see cref="MultiOrder{T}"/>.</exception>
-        public static IEnumerable<IOrder> ToOrder<T>(this IOrder<T> order)
+        static OrderExpression CreateOrderExpressionFromOrder(in Order<T> instance)
         {
-            static OrderExpression CreateOrderExpressionFromOrder(in Order<T> instance)
+            return new OrderExpression(instance.Expression.Field(), direction: instance.Direction == OrderDirection.Ascending
+                ? Queries.Core.Parts.Sorting.OrderDirection.Ascending
+                : Queries.Core.Parts.Sorting.OrderDirection.Descending);
+        }
+
+        switch (order)
+        {
+            case Order<T> expression:
+                yield return CreateOrderExpressionFromOrder(expression);
+                break;
+            case MultiOrder<T> multisort:
             {
-                return new OrderExpression(instance.Expression.Field(), direction: instance.Direction == OrderDirection.Ascending
-                    ? Queries.Core.Parts.Sorting.OrderDirection.Ascending
-                    : Queries.Core.Parts.Sorting.OrderDirection.Descending);
+                foreach (Order<T> item in multisort.Orders)
+                {
+                    yield return CreateOrderExpressionFromOrder(item);
+                }
+
+                break;
             }
 
-            switch (order)
-            {
-                case Order<T> expression:
-                    yield return CreateOrderExpressionFromOrder(expression);
-                    break;
-                case MultiOrder<T> multisort:
-                    {
-                        foreach (Order<T> item in multisort.Orders)
-                        {
-                            yield return CreateOrderExpressionFromOrder(item);
-                        }
-
-                        break;
-                    }
-
-                default:
-                    throw new NotSupportedException("Unsupported order type");
-            }
+            default:
+                throw new NotSupportedException("Unsupported order type");
         }
     }
 }

--- a/src/DataFilters/Casing/CamelCasePropertyNameResolutionStrategy.cs
+++ b/src/DataFilters/Casing/CamelCasePropertyNameResolutionStrategy.cs
@@ -1,13 +1,12 @@
-﻿namespace DataFilters.Casing
-{
-    using System;
+﻿namespace DataFilters.Casing;
 
-    /// <summary>
-    /// <see cref="PropertyNameResolutionStrategy"/> that transform input to it <strong>camelCase</strong> equivalent.
-    /// </summary>
-    public class CamelCasePropertyNameResolutionStrategy : PropertyNameResolutionStrategy
-    {
-        ///<inheritdoc/>
-        public override string Handle(string name) => name.ToCamelCase();
-    }
+using System;
+
+/// <summary>
+/// <see cref="PropertyNameResolutionStrategy"/> that transform input to it <strong>camelCase</strong> equivalent.
+/// </summary>
+public class CamelCasePropertyNameResolutionStrategy : PropertyNameResolutionStrategy
+{
+    ///<inheritdoc/>
+    public override string Handle(string name) => name.ToCamelCase();
 }

--- a/src/DataFilters/Casing/DefaultPropertyNameResolutionStrategy.cs
+++ b/src/DataFilters/Casing/DefaultPropertyNameResolutionStrategy.cs
@@ -1,11 +1,10 @@
-﻿namespace DataFilters.Casing
+﻿namespace DataFilters.Casing;
+
+/// <summary>
+/// <see cref="PropertyNameResolutionStrategy"/> implementation that leaves the name extracted from querystring unchanged.
+/// </summary>
+public class DefaultPropertyNameResolutionStrategy : PropertyNameResolutionStrategy
 {
-    /// <summary>
-    /// <see cref="PropertyNameResolutionStrategy"/> implementation that leaves the name extracted from querystring unchanged.
-    /// </summary>
-    public class DefaultPropertyNameResolutionStrategy : PropertyNameResolutionStrategy
-    {
-        /// <inheritdoc/>
-        public override string Handle(string name) => name;
-    }
+    /// <inheritdoc/>
+    public override string Handle(string name) => name;
 }

--- a/src/DataFilters/Casing/PascalCasePropertyNameResolutionStrategy.cs
+++ b/src/DataFilters/Casing/PascalCasePropertyNameResolutionStrategy.cs
@@ -1,13 +1,12 @@
-﻿namespace DataFilters.Casing
-{
-    using System;
+﻿namespace DataFilters.Casing;
 
-    /// <summary>
-    /// <see cref="PropertyNameResolutionStrategy"/> that transform input to it <strong>PascalCase</strong> equivalent.
-    /// </summary>
-    public class PascalCasePropertyNameResolutionStrategy : PropertyNameResolutionStrategy
-    {
-        ///<inheritdoc/>
-        public override string Handle(string name) => name.ToPascalCase();
-    }
+using System;
+
+/// <summary>
+/// <see cref="PropertyNameResolutionStrategy"/> that transform input to it <strong>PascalCase</strong> equivalent.
+/// </summary>
+public class PascalCasePropertyNameResolutionStrategy : PropertyNameResolutionStrategy
+{
+    ///<inheritdoc/>
+    public override string Handle(string name) => name.ToPascalCase();
 }

--- a/src/DataFilters/Casing/PropertyNameResolutionStrategy.cs
+++ b/src/DataFilters/Casing/PropertyNameResolutionStrategy.cs
@@ -1,39 +1,38 @@
-﻿namespace DataFilters.Casing
+﻿namespace DataFilters.Casing;
+
+/// <summary>
+/// <para>
+/// Base class to derive from to alter the way <see cref="System.StringExtensions.ToFilter{T}(string)"/>
+/// and <see cref="System.StringExtensions.ToSort{T}(string)"/> performs property names lookup.
+/// </para>
+/// </summary>
+public abstract class PropertyNameResolutionStrategy
 {
     /// <summary>
-    /// <para>
-    /// Base class to derive from to alter the way <see cref="System.StringExtensions.ToFilter{T}(string)"/>
-    /// and <see cref="System.StringExtensions.ToSort{T}(string)"/> performs property names lookup.
-    /// </para>
+    /// A casing strategy that leave the fieldname casing unchanged
     /// </summary>
-    public abstract class PropertyNameResolutionStrategy
-    {
-        /// <summary>
-        /// A casing strategy that leave the fieldname casing unchanged
-        /// </summary>
-        public readonly static PropertyNameResolutionStrategy Default = new DefaultPropertyNameResolutionStrategy();
+    public static readonly PropertyNameResolutionStrategy Default = new DefaultPropertyNameResolutionStrategy();
 
-        /// <summary>
-        /// A resolution strategy that change each name case to conform to camelCasing.
-        /// </summary>
-        public readonly static PropertyNameResolutionStrategy CamelCase = new CamelCasePropertyNameResolutionStrategy();
+    /// <summary>
+    /// A resolution strategy that change each name case to conform to camelCasing.
+    /// </summary>
+    public static readonly PropertyNameResolutionStrategy CamelCase = new CamelCasePropertyNameResolutionStrategy();
 
-        /// <summary>
-        /// A resolution strategy that change each name case to conform to camelCasing.
-        /// </summary>
-        public readonly static PropertyNameResolutionStrategy PascalCase = new PascalCasePropertyNameResolutionStrategy();
+    /// <summary>
+    /// A resolution strategy that change each name case to conform to pascal casing.
+    /// </summary>
+    public static readonly PropertyNameResolutionStrategy PascalCase = new PascalCasePropertyNameResolutionStrategy();
 
-        /// <summary>
-        /// A casing strategy that change each fieldName case to conform to snake casing
-        /// </summary>
-        public readonly static PropertyNameResolutionStrategy SnakeCase = new SnakeCasePropertyNameResolutionStrategy();
+    /// <summary>
+    /// A casing strategy that change each fieldName case to conform to snake casing.
+    /// </summary>
+    public static readonly PropertyNameResolutionStrategy SnakeCase = new SnakeCasePropertyNameResolutionStrategy();
 
-        /// <summary>
-        /// Performs the desired transformation.
-        /// The result of this method will <strong>BEFORE</strong>be used instead of name <paramref name="name"/>
-        /// </summary>
-        /// <param name="name">The name of the key in the query string</param>
-        /// <returns>The name to use when looking up for a corresponding property</returns>
-        public abstract string Handle(string name);
-    }
+    /// <summary>
+    /// Performs the desired transformation.
+    /// The result of this method will be used instead of name <paramref name="name"/>
+    /// </summary>
+    /// <param name="name">The name of the key in the query string</param>
+    /// <returns>The name to use when looking up for a corresponding property</returns>
+    public abstract string Handle(string name);
 }

--- a/src/DataFilters/Casing/SnakeCasePropertyNameResolutionStrategy.cs
+++ b/src/DataFilters/Casing/SnakeCasePropertyNameResolutionStrategy.cs
@@ -1,13 +1,12 @@
-﻿namespace DataFilters.Casing
-{
-    using System;
+﻿namespace DataFilters.Casing;
 
-    /// <summary>
-    /// <see cref="PropertyNameResolutionStrategy"/> that transform input to its snake_case equivalent.
-    /// </summary>
-    public class SnakeCasePropertyNameResolutionStrategy : PropertyNameResolutionStrategy
-    {
-        ///<inheritdoc/>
-        public override string Handle(string name) => name.ToSnakeCase();
-    }
+using System;
+
+/// <summary>
+/// <see cref="PropertyNameResolutionStrategy"/> that transform input to its snake_case equivalent.
+/// </summary>
+public class SnakeCasePropertyNameResolutionStrategy : PropertyNameResolutionStrategy
+{
+    ///<inheritdoc/>
+    public override string Handle(string name) => name.ToSnakeCase();
 }

--- a/src/DataFilters/DataFilters.csproj
+++ b/src/DataFilters/DataFilters.csproj
@@ -7,7 +7,6 @@
     <PackageTags>expressions, querystring</PackageTags>
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\DataFilters.xml</DocumentationFile>
     <PackageReadmeFile>README.md</PackageReadmeFile>
-    <DefineConstants>STRING_SEGMENT</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/DataFilters/Filter.cs
+++ b/src/DataFilters/Filter.cs
@@ -1,247 +1,246 @@
-﻿namespace DataFilters
-{
-    using System;
-    using System.Collections.Generic;
-    using System.Text.RegularExpressions;
-    using DataFilters.Converters;
-    using Newtonsoft.Json;
-    using Newtonsoft.Json.Schema;
-    using static Newtonsoft.Json.DefaultValueHandling;
-    using static Newtonsoft.Json.Required;
+﻿namespace DataFilters;
+
+using System;
+using System.Collections.Generic;
+using System.Text.RegularExpressions;
+using DataFilters.Converters;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Schema;
+using static Newtonsoft.Json.DefaultValueHandling;
+using static Newtonsoft.Json.Required;
 #if !NETSTANDARD1_3
-    using System.Text.Json.Serialization;
+using System.Text.Json.Serialization;
 #endif
 
-    /// <summary>
-    /// An instance of this class holds a filter
-    /// </summary>
+/// <summary>
+/// An instance of this class holds a filter
+/// </summary>
 #if NETSTANDARD1_3
     [JsonObject]
     [JsonConverter(typeof(FilterConverter))]
 #else
-    [System.Text.Json.Serialization.JsonConverter(typeof(FilterConverter))]
+[System.Text.Json.Serialization.JsonConverter(typeof(FilterConverter))]
 #endif
-    public sealed class Filter : IFilter, IEquatable<Filter>
+public sealed class Filter : IFilter, IEquatable<Filter>
+{
+    /// <summary>
+    /// Filter that always returns <c>true</c>
+    /// </summary>
+    public static Filter True => new(default, default);
+
+    /// <summary>
+    /// Pattern that field name should respect.
+    /// </summary>
+    /// #lang : regex
+    public const string ValidFieldNamePattern = @"[a-zA-Z_]+((\[""[a-zA-Z0-9_]+""]|(\.[a-zA-Z0-9_]+))*)";
+
+    /// <summary>
+    /// Regular expression used to validate
+    /// </summary>
+    /// <returns></returns>
+    public static readonly Regex ValidFieldNameRegex = new(ValidFieldNamePattern, RegexOptions.IgnoreCase, TimeSpan.FromSeconds(1));
+
+    /// <summary>
+    /// Name of the json property that holds the field name
+    /// </summary>
+    public const string FieldJsonPropertyName = "field";
+
+    /// <summary>
+    /// Name of the json property that holds the operator
+    /// </summary>
+    public const string OperatorJsonPropertyName = "op";
+
+    /// <summary>
+    /// Name of the json property that holds the value
+    /// </summary>
+    public const string ValueJsonPropertyName = "value";
+
+    /// <summary>
+    /// <see cref="FilterOperator"/>s that required <see cref="Value"/> to be null.
+    /// </summary>
+    public static ISet<FilterOperator> UnaryOperators { get; } = new HashSet<FilterOperator>{
+        FilterOperator.IsEmpty,
+        FilterOperator.IsNotEmpty,
+        FilterOperator.IsNotNull,
+        FilterOperator.IsNull
+    };
+
+    /// <summary>
+    /// Generates the <see cref="JSchema"/> for the specified <see cref="FilterOperator"/>.
+    /// </summary>
+    /// <param name="op"></param>
+    /// <returns></returns>
+    public static JSchema Schema(FilterOperator op)
     {
-        /// <summary>
-        /// Filter that always returns <c>true</c>
-        /// </summary>
-        public static Filter True => new(default, default);
-
-        /// <summary>
-        /// Pattern that field name should respect.
-        /// </summary>
-        /// #lang : regex
-        public const string ValidFieldNamePattern = @"[a-zA-Z_]+((\[""[a-zA-Z0-9_]+""]|(\.[a-zA-Z0-9_]+))*)";
-
-        /// <summary>
-        /// Regular expression used to validate
-        /// </summary>
-        /// <returns></returns>
-        public static readonly Regex ValidFieldNameRegex = new(ValidFieldNamePattern, RegexOptions.IgnoreCase, TimeSpan.FromSeconds(1));
-
-        /// <summary>
-        /// Name of the json property that holds the field name
-        /// </summary>
-        public const string FieldJsonPropertyName = "field";
-
-        /// <summary>
-        /// Name of the json property that holds the operator
-        /// </summary>
-        public const string OperatorJsonPropertyName = "op";
-
-        /// <summary>
-        /// Name of the json property that holds the value
-        /// </summary>
-        public const string ValueJsonPropertyName = "value";
-
-        /// <summary>
-        /// <see cref="FilterOperator"/>s that required <see cref="Value"/> to be null.
-        /// </summary>
-        public static ISet<FilterOperator> UnaryOperators { get; } = new HashSet<FilterOperator>{
-            FilterOperator.IsEmpty,
-            FilterOperator.IsNotEmpty,
-            FilterOperator.IsNotNull,
-            FilterOperator.IsNull
-        };
-
-        /// <summary>
-        /// Generates the <see cref="JSchema"/> for the specified <see cref="FilterOperator"/>.
-        /// </summary>
-        /// <param name="op"></param>
-        /// <returns></returns>
-        public static JSchema Schema(FilterOperator op)
+        JSchema schema = op switch
         {
-            JSchema schema = op switch
+            FilterOperator.Contains or FilterOperator.StartsWith or FilterOperator.EndsWith => new JSchema
             {
-                FilterOperator.Contains or FilterOperator.StartsWith or FilterOperator.EndsWith => new JSchema
+                Type = JSchemaType.Object,
+                Properties =
                 {
-                    Type = JSchemaType.Object,
-                    Properties =
-                        {
-                            [FieldJsonPropertyName] = new JSchema { Type = JSchemaType.String },
-                            [OperatorJsonPropertyName] = new JSchema { Type = JSchemaType.String },
-                            [ValueJsonPropertyName] = new JSchema { Type = JSchemaType.String }
-                        },
-                    Required = { FieldJsonPropertyName, OperatorJsonPropertyName }
+                    [FieldJsonPropertyName] = new JSchema { Type = JSchemaType.String },
+                    [OperatorJsonPropertyName] = new JSchema { Type = JSchemaType.String },
+                    [ValueJsonPropertyName] = new JSchema { Type = JSchemaType.String }
                 },
-                FilterOperator.IsEmpty or FilterOperator.IsNotEmpty or FilterOperator.IsNotNull or FilterOperator.IsNull => new JSchema
+                Required = { FieldJsonPropertyName, OperatorJsonPropertyName }
+            },
+            FilterOperator.IsEmpty or FilterOperator.IsNotEmpty or FilterOperator.IsNotNull or FilterOperator.IsNull => new JSchema
+            {
+                Type = JSchemaType.Object,
+                Properties =
                 {
-                    Type = JSchemaType.Object,
-                    Properties =
-                        {
-                            [FieldJsonPropertyName] = new JSchema { Type = JSchemaType.String },
-                            [OperatorJsonPropertyName] = new JSchema { Type = JSchemaType.String }
-                        },
-                    Required = { FieldJsonPropertyName, OperatorJsonPropertyName }
+                    [FieldJsonPropertyName] = new JSchema { Type = JSchemaType.String },
+                    [OperatorJsonPropertyName] = new JSchema { Type = JSchemaType.String }
                 },
-                _ => new JSchema
+                Required = { FieldJsonPropertyName, OperatorJsonPropertyName }
+            },
+            _ => new JSchema
+            {
+                Type = JSchemaType.Object,
+                Properties =
                 {
-                    Type = JSchemaType.Object,
-                    Properties =
-                        {
-                            [FieldJsonPropertyName] = new JSchema { Type = JSchemaType.String,  },
-                            [OperatorJsonPropertyName] = new JSchema { Type = JSchemaType.String },
-                            [ValueJsonPropertyName] = new JSchema {
-                                Not = new JSchema() { Type = JSchemaType.Null }
-                            }
-                        },
-                    Required = { FieldJsonPropertyName, OperatorJsonPropertyName, ValueJsonPropertyName }
+                    [FieldJsonPropertyName] = new JSchema { Type = JSchemaType.String,  },
+                    [OperatorJsonPropertyName] = new JSchema { Type = JSchemaType.String },
+                    [ValueJsonPropertyName] = new JSchema {
+                        Not = new JSchema() { Type = JSchemaType.Null }
+                    }
                 },
-            };
-            schema.AllowAdditionalProperties = false;
+                Required = { FieldJsonPropertyName, OperatorJsonPropertyName, ValueJsonPropertyName }
+            },
+        };
+        schema.AllowAdditionalProperties = false;
 
-            return schema;
-        }
+        return schema;
+    }
 
-        /// <summary>
-        /// Name of the field  the filter will be applied to
-        /// </summary>
+    /// <summary>
+    /// Name of the field  the filter will be applied to
+    /// </summary>
 #if NETSTANDARD1_3
         [JsonProperty(FieldJsonPropertyName, Required = Always)]
 #else
-        [JsonPropertyName(FieldJsonPropertyName)]
+    [JsonPropertyName(FieldJsonPropertyName)]
 #endif
-        public string Field { get; }
+    public string Field { get; }
 
-        /// <summary>
-        /// Operator to apply to the filter
-        /// </summary>
+    /// <summary>
+    /// Operator to apply to the filter
+    /// </summary>
 #if NETSTANDARD1_3
         [JsonProperty(OperatorJsonPropertyName, Required = Always)]
         [JsonConverter(typeof(CamelCaseEnumTypeConverter))]
 #else
-        [JsonPropertyName(OperatorJsonPropertyName)]
+    [JsonPropertyName(OperatorJsonPropertyName)]
 #endif
-        public FilterOperator Operator { get; }
+    public FilterOperator Operator { get; }
 
-        /// <summary>
-        /// Value of the filter
-        /// </summary>
+    /// <summary>
+    /// Value of the filter
+    /// </summary>
 #if NETSTANDARD1_3
         [JsonProperty(ValueJsonPropertyName,
             Required = AllowNull,
             DefaultValueHandling = IgnoreAndPopulate,
             NullValueHandling = NullValueHandling.Ignore)]
 #else
-        [JsonPropertyName(ValueJsonPropertyName)]
+    [JsonPropertyName(ValueJsonPropertyName)]
 #endif
-        public object Value { get; }
+    public object Value { get; }
 
-        /// <summary>
-        /// Builds a new <see cref="Filter"/> instance.
-        /// </summary>
-        /// <param name="field">name of the field</param>
-        /// <param name="operator"><see cref="Filter"/> to apply</param>
-        /// <param name="value">value of the filter</param>
-        /// <exception cref="ArgumentOutOfRangeException"><paramref name="field"/> does not conform with <see cref="ValidFieldNamePattern"/></exception>
-        public Filter(string field, FilterOperator @operator, object value = null)
+    /// <summary>
+    /// Builds a new <see cref="Filter"/> instance.
+    /// </summary>
+    /// <param name="field">name of the field</param>
+    /// <param name="operator"><see cref="Filter"/> to apply</param>
+    /// <param name="value">value of the filter</param>
+    /// <exception cref="ArgumentOutOfRangeException"><paramref name="field"/> does not conform with <see cref="ValidFieldNamePattern"/></exception>
+    public Filter(string field, FilterOperator @operator, object value = null)
+    {
+        if (!string.IsNullOrEmpty(field) && !ValidFieldNameRegex.IsMatch(field))
         {
-            if (!string.IsNullOrEmpty(field) && !ValidFieldNameRegex.IsMatch(field))
-            {
-                throw new ArgumentOutOfRangeException(nameof(field), field, $"field name is not valid ({ValidFieldNamePattern}).");
-            }
-
-            Field = field;
-            switch (@operator)
-            {
-                case FilterOperator.EqualTo when value is null:
-                    Operator = FilterOperator.IsNull;
-                    break;
-                case FilterOperator.NotEqualTo when value is null:
-                    Operator = FilterOperator.IsNotNull;
-                    break;
-                default:
-                    Operator = @operator;
-                    Value = value;
-                    break;
-            }
+            throw new ArgumentOutOfRangeException(nameof(field), field, $"field name is not valid ({ValidFieldNamePattern}).");
         }
 
-        ///<inheritdoc/>
+        Field = field;
+        switch (@operator)
+        {
+            case FilterOperator.EqualTo when value is null:
+                Operator = FilterOperator.IsNull;
+                break;
+            case FilterOperator.NotEqualTo when value is null:
+                Operator = FilterOperator.IsNotNull;
+                break;
+            default:
+                Operator = @operator;
+                Value = value;
+                break;
+        }
+    }
+
+    ///<inheritdoc/>
 #if NETSTANDARD1_3
         public string ToJson()
         {
             return this.Jsonify(new JsonSerializerSettings());
         }
 #else
-        public string ToJson() => this.Jsonify();
+    public string ToJson() => this.Jsonify();
 #endif
 
-        ///<inheritdoc/>
-        public override string ToString() => ToJson();
+    ///<inheritdoc/>
+    public override string ToString() => ToJson();
 
-        ///<inheritdoc/>
-        public bool Equals(Filter other)
-            => other != null
-            && (ReferenceEquals(other, this)
-            || (Equals(other.Field, Field) && Equals(other.Operator, Operator) && Equals(other.Value, Value)));
+    ///<inheritdoc/>
+    public bool Equals(Filter other)
+        => other != null
+           && (ReferenceEquals(other, this)
+               || (Equals(other.Field, Field) && Equals(other.Operator, Operator) && Equals(other.Value, Value)));
 
-        ///<inheritdoc/>
-        public override bool Equals(object obj) => Equals(obj as Filter);
+    ///<inheritdoc/>
+    public override bool Equals(object obj) => Equals(obj as Filter);
 
-        ///<inheritdoc/>
-        public bool Equals(IFilter other) => Equals(other as Filter);
+    ///<inheritdoc/>
+    public bool Equals(IFilter other) => Equals(other as Filter);
 
-        ///<inheritdoc/>
+    ///<inheritdoc/>
 #if NETSTANDARD1_3 || NETSTANDARD2_0
         public override int GetHashCode() => (Field, Operator, Value).GetHashCode();
 #else
-        public override int GetHashCode() => HashCode.Combine(Field, Operator, Value);
+    public override int GetHashCode() => HashCode.Combine(Field, Operator, Value);
 #endif
 
-        ///<inheritdoc/>
-        public IFilter Negate()
+    ///<inheritdoc/>
+    public IFilter Negate()
+    {
+        FilterOperator @operator = Operator switch
         {
-            FilterOperator @operator = Operator switch
-            {
-                FilterOperator.EqualTo => FilterOperator.NotEqualTo,
-                FilterOperator.NotEqualTo => FilterOperator.EqualTo,
-                FilterOperator.IsNull => FilterOperator.IsNotNull,
-                FilterOperator.IsNotNull => FilterOperator.IsNull,
-                FilterOperator.LessThan => FilterOperator.GreaterThan,
-                FilterOperator.GreaterThan => FilterOperator.LessThan,
-                FilterOperator.GreaterThanOrEqual => FilterOperator.LessThanOrEqualTo,
-                FilterOperator.StartsWith => FilterOperator.NotStartsWith,
-                FilterOperator.NotStartsWith => FilterOperator.StartsWith,
-                FilterOperator.EndsWith => FilterOperator.NotEndsWith,
-                FilterOperator.NotEndsWith => FilterOperator.EndsWith,
-                FilterOperator.Contains => FilterOperator.NotContains,
-                FilterOperator.NotContains => FilterOperator.Contains,
-                FilterOperator.IsEmpty => FilterOperator.IsNotEmpty,
-                FilterOperator.IsNotEmpty => FilterOperator.IsEmpty,
-                FilterOperator.LessThanOrEqualTo => FilterOperator.GreaterThanOrEqual,
-                _ => throw new NotSupportedException("Unknown operator"),
-            };
-            return new Filter(Field, @operator, Value);
-        }
+            FilterOperator.EqualTo => FilterOperator.NotEqualTo,
+            FilterOperator.NotEqualTo => FilterOperator.EqualTo,
+            FilterOperator.IsNull => FilterOperator.IsNotNull,
+            FilterOperator.IsNotNull => FilterOperator.IsNull,
+            FilterOperator.LessThan => FilterOperator.GreaterThan,
+            FilterOperator.GreaterThan => FilterOperator.LessThan,
+            FilterOperator.GreaterThanOrEqual => FilterOperator.LessThanOrEqualTo,
+            FilterOperator.StartsWith => FilterOperator.NotStartsWith,
+            FilterOperator.NotStartsWith => FilterOperator.StartsWith,
+            FilterOperator.EndsWith => FilterOperator.NotEndsWith,
+            FilterOperator.NotEndsWith => FilterOperator.EndsWith,
+            FilterOperator.Contains => FilterOperator.NotContains,
+            FilterOperator.NotContains => FilterOperator.Contains,
+            FilterOperator.IsEmpty => FilterOperator.IsNotEmpty,
+            FilterOperator.IsNotEmpty => FilterOperator.IsEmpty,
+            FilterOperator.LessThanOrEqualTo => FilterOperator.GreaterThanOrEqual,
+            _ => throw new NotSupportedException("Unknown operator"),
+        };
+        return new Filter(Field, @operator, Value);
+    }
 
-        ///<inheritdoc/>
-        public void Deconstruct(out string field, out FilterOperator @operator, out object value)
-        {
-            field = Field;
-            @operator = Operator;
-            value = Value;
-        }
+    ///<inheritdoc/>
+    public void Deconstruct(out string field, out FilterOperator @operator, out object value)
+    {
+        field = Field;
+        @operator = Operator;
+        value = Value;
     }
 }

--- a/src/DataFilters/FilterLogic.cs
+++ b/src/DataFilters/FilterLogic.cs
@@ -1,19 +1,18 @@
-﻿namespace DataFilters
+﻿namespace DataFilters;
+
+/// <summary>
+/// Logic that can be apply when combining several <see cref="Filter"/>s together.
+/// </summary>
+/// <see cref="MultiFilter.Logic"/>
+public enum FilterLogic
 {
     /// <summary>
-    /// Logic that can be apply when combining several <see cref="Filter"/>s together.
+    /// Logical AND operator will be applied to all
     /// </summary>
-    /// <see cref="MultiFilter.Logic"/>
-    public enum FilterLogic
-    {
-        /// <summary>
-        /// Logical AND operator will be applied to all
-        /// </summary>
-        And,
+    And,
 
-        /// <summary>
-        /// Logicial OR operatior will be applied
-        /// </summary>
-        Or
-    }
+    /// <summary>
+    /// Logicial OR operatior will be applied
+    /// </summary>
+    Or
 }

--- a/src/DataFilters/FilterOperator.cs
+++ b/src/DataFilters/FilterOperator.cs
@@ -1,96 +1,95 @@
-﻿namespace DataFilters
-{
-    using Converters;
+﻿namespace DataFilters;
+
+using Converters;
 
 #if NETSTANDARD1_3
     using Newtonsoft.Json;
 #else
-    using System.Text.Json.Serialization;
+using System.Text.Json.Serialization;
 #endif
+/// <summary>
+/// Operators that can be used when building <see cref="Filter"/> instances.
+/// </summary>
+[JsonConverter(typeof(FilterOperatorConverter))]
+public enum FilterOperator : short
+{
     /// <summary>
-    /// Operators that can be used when building <see cref="Filter"/> instances.
+    /// <c>=</c> operator
     /// </summary>
-    [JsonConverter(typeof(FilterOperatorConverter))]
-    public enum FilterOperator : short
-    {
-        /// <summary>
-        /// <c>=</c> operator
-        /// </summary>
-        EqualTo,
+    EqualTo,
 
-        /// <summary>
-        /// <c>!=</c> operator
-        /// </summary>
-        NotEqualTo,
+    /// <summary>
+    /// <c>!=</c> operator
+    /// </summary>
+    NotEqualTo,
 
-        /// <summary>
-        /// <c>is null</c> operator
-        /// </summary>
-        IsNull,
+    /// <summary>
+    /// <c>is null</c> operator
+    /// </summary>
+    IsNull,
 
-        /// <summary>
-        /// <c>is not null</c> operator
-        /// </summary>
-        IsNotNull,
+    /// <summary>
+    /// <c>is not null</c> operator
+    /// </summary>
+    IsNotNull,
 
-        /// <summary>
-        /// <c>&lt;</c> operator
-        /// </summary>
-        LessThan,
+    /// <summary>
+    /// <c>&lt;</c> operator
+    /// </summary>
+    LessThan,
 
-        /// <summary>
-        /// <c>&gt;</c> operator
-        /// </summary>
-        GreaterThan,
+    /// <summary>
+    /// <c>&gt;</c> operator
+    /// </summary>
+    GreaterThan,
 
-        /// <summary>
-        /// <c>&gt;=</c> operator
-        /// </summary>
-        GreaterThanOrEqual,
+    /// <summary>
+    /// <c>&gt;=</c> operator
+    /// </summary>
+    GreaterThanOrEqual,
 
-        /// <summary>
-        /// Applies only to string
-        /// </summary>
-        StartsWith,
+    /// <summary>
+    /// Applies only to string
+    /// </summary>
+    StartsWith,
 
-        /// <summary>
-        /// Applies only to string
-        /// </summary>
-        NotStartsWith,
+    /// <summary>
+    /// Applies only to string
+    /// </summary>
+    NotStartsWith,
 
-        /// <summary>
-        /// <remarks>Applies only to string</remarks>
-        /// </summary>
-        EndsWith,
+    /// <summary>
+    /// <remarks>Applies only to string</remarks>
+    /// </summary>
+    EndsWith,
 
-        /// <summary>
-        /// <remarks>Applies only to string</remarks>
-        /// </summary>
-        NotEndsWith,
+    /// <summary>
+    /// <remarks>Applies only to string</remarks>
+    /// </summary>
+    NotEndsWith,
 
-        /// <summary>
-        /// "Contains" operator
-        /// </summary>
-        Contains,
+    /// <summary>
+    /// "Contains" operator
+    /// </summary>
+    Contains,
 
-        /// <summary>
-        /// opposite of <see cref="Contains"/> operator
-        /// </summary>
-        NotContains,
+    /// <summary>
+    /// opposite of <see cref="Contains"/> operator
+    /// </summary>
+    NotContains,
 
-        /// <summary>
-        /// <c>isempty</c> operator
-        /// </summary>
-        IsEmpty,
+    /// <summary>
+    /// <c>isempty</c> operator
+    /// </summary>
+    IsEmpty,
 
-        /// <summary>
-        /// Opposite of <see cref="IsEmpty"/> operator
-        /// </summary>
-        IsNotEmpty,
+    /// <summary>
+    /// Opposite of <see cref="IsEmpty"/> operator
+    /// </summary>
+    IsNotEmpty,
 
-        /// <summary>
-        /// <c>&lt;=</c> operator
-        /// </summary>
-        LessThanOrEqualTo
-    }
+    /// <summary>
+    /// <c>&lt;=</c> operator
+    /// </summary>
+    LessThanOrEqualTo
 }

--- a/src/DataFilters/FilterOptions.cs
+++ b/src/DataFilters/FilterOptions.cs
@@ -1,98 +1,97 @@
 ﻿using DataFilters.Casing;
 
-namespace DataFilters
-{
-    /// <summary>
-    /// Allow to customize the computation of an <see cref="IFilter"/> instance.
-    /// </summary>
+namespace DataFilters;
+
+/// <summary>
+/// Allow to customize the computation of an <see cref="IFilter"/> instance.
+/// </summary>
 #if NET6_0_OR_GREATER
-    public record FilterOptions
+public record FilterOptions
 #else
     public class FilterOptions
 #endif
-    {
-        private PropertyNameResolutionStrategy _propertyNameResolutionStrategy;
+{
+    private PropertyNameResolutionStrategy _propertyNameResolutionStrategy;
 
-        /// <summary>
-        /// Gets or sets the default <see cref="PropertyNameResolutionStrategy"/> to use when matching property names whilst
-        /// computing <see cref="IFilter"/> instances.
-        /// </summary>
-        public PropertyNameResolutionStrategy DefaultPropertyNameResolutionStrategy
-        {
-            get => _propertyNameResolutionStrategy;
+    /// <summary>
+    /// Gets or sets the default <see cref="PropertyNameResolutionStrategy"/> to use when matching property names whilst
+    /// computing <see cref="IFilter"/> instances.
+    /// </summary>
+    public PropertyNameResolutionStrategy DefaultPropertyNameResolutionStrategy
+    {
+        get => _propertyNameResolutionStrategy;
 #if !NET6_0_OR_GREATER
             set
 #else
-            init
+        init
 #endif
             => _propertyNameResolutionStrategy = value ?? PropertyNameResolutionStrategy.Default;
-        }
+    }
 
-        /// <summary>
-        /// <see cref="FilterLogic"/> to apply when converting a query that could result in a <see cref="MultiFilter"/> instance.
-        /// <para>
-        /// This will only apply when the logic cannot be determined by the query from which the computation itself
-        /// <example>
-        /// <code>
-        /// FilterOptions options = new() { Logic = FilterLogic.And };
-        /// string query = "Nickname=bat&amp;Name=Grayson";
-        /// IFilter  filter = query.ToFilter&lt;T&gt;(options);
-        /// </code>
-        /// </example>
-        /// will result in a <see cref="IFilter"/> that is equivalent to
-        /// <code>
-        /// MultiFilter multifilter = new ()
-        /// {
-        ///     Logic = FilterLogic.And,
-        ///     Filters = new IFilter[]
-        ///     {
-        ///         new Filter("Nickname", EqualTo, "bat"),
-        ///         new Filter("Name", EqualTo, "Grayson"),
-        ///     }
-        /// }
-        /// </code>
-        /// whereas
-        /// <example>
-        /// <code>
-        /// FilterOptions options = new() { Logic = FilterLogic.Or };
-        /// string query = "Nickname=bat&amp;Name=Grayson";
-        /// IFilter  filter = query.ToFilter&lt;T&gt;(options);
-        /// </code>
-        /// </example>
-        /// will result in a <see cref="IFilter"/> that is equivalent to
-        /// <code>
-        /// MultiFilter multifilter = new ()
-        /// {
-        ///     Logic = FilterLogic.Or,
-        ///     Filters = new IFilter[]
-        ///     {
-        ///         new Filter("Nickname", EqualTo, "bat"),
-        ///         new Filter("Name", EqualTo, "Grayson"),
-        ///     }
-        /// }
-        /// </code>
-        /// </para>
-        /// </summary>
-        /// <remarks>
-        /// <see cref="Logic"/> is <see cref="FilterLogic.And"/> by default.
-        /// </remarks>
-        public FilterLogic Logic
-        {
-            get;
+    /// <summary>
+    /// <see cref="FilterLogic"/> to apply when converting a query that could result in a <see cref="MultiFilter"/> instance.
+    /// <para>
+    /// This will only apply when the logic cannot be determined by the query from which the computation itself
+    /// <example>
+    /// <code>
+    /// FilterOptions options = new() { Logic = FilterLogic.And };
+    /// string query = "Nickname=bat&amp;Name=Grayson";
+    /// IFilter  filter = query.ToFilter&lt;T&gt;(options);
+    /// </code>
+    /// </example>
+    /// will result in a <see cref="IFilter"/> that is equivalent to
+    /// <code>
+    /// MultiFilter multifilter = new ()
+    /// {
+    ///     Logic = FilterLogic.And,
+    ///     Filters = new IFilter[]
+    ///     {
+    ///         new Filter("Nickname", EqualTo, "bat"),
+    ///         new Filter("Name", EqualTo, "Grayson"),
+    ///     }
+    /// }
+    /// </code>
+    /// whereas
+    /// <example>
+    /// <code>
+    /// FilterOptions options = new() { Logic = FilterLogic.Or };
+    /// string query = "Nickname=bat&amp;Name=Grayson";
+    /// IFilter  filter = query.ToFilter&lt;T&gt;(options);
+    /// </code>
+    /// </example>
+    /// will result in a <see cref="IFilter"/> that is equivalent to
+    /// <code>
+    /// MultiFilter multifilter = new ()
+    /// {
+    ///     Logic = FilterLogic.Or,
+    ///     Filters = new IFilter[]
+    ///     {
+    ///         new Filter("Nickname", EqualTo, "bat"),
+    ///         new Filter("Name", EqualTo, "Grayson"),
+    ///     }
+    /// }
+    /// </code>
+    /// </para>
+    /// </summary>
+    /// <remarks>
+    /// <see cref="Logic"/> is <see cref="FilterLogic.And"/> by default.
+    /// </remarks>
+    public FilterLogic Logic
+    {
+        get;
 #if !NET6_0_OR_GREATER
             set;
 #else
-            init;
+        init;
 #endif
-        }
+    }
 
-        /// <summary>
-        /// Builds a new <see cref="FilterOptions"/> instance.
-        /// </summary>
-        public FilterOptions()
-        {
-            Logic = FilterLogic.And;
-            DefaultPropertyNameResolutionStrategy = PropertyNameResolutionStrategy.Default;
-        }
+    /// <summary>
+    /// Builds a new <see cref="FilterOptions"/> instance.
+    /// </summary>
+    public FilterOptions()
+    {
+        Logic = FilterLogic.And;
+        DefaultPropertyNameResolutionStrategy = PropertyNameResolutionStrategy.Default;
     }
 }

--- a/src/DataFilters/Grammar/Exceptions/BoundariesTypeMismatchException.cs
+++ b/src/DataFilters/Grammar/Exceptions/BoundariesTypeMismatchException.cs
@@ -1,19 +1,18 @@
-﻿namespace DataFilters.Grammar.Exceptions
-{
-    using System;
+﻿namespace DataFilters.Grammar.Exceptions;
 
-    /// <summary>
-    /// Exception thrown when a <see cref="Syntax.IntervalExpression"/> has incorrect <see cref="Syntax.IntervalExpression.Min"/>
-    /// </summary>
-    /// <remarks>
-    /// Creates a new <see cref="BoundariesTypeMismatchException"/> instance
-    /// </remarks>
-    /// <param name="message">message of the exception</param>
-    /// <param name="paramName">name of the argument which causes the exception to be thrown</param>
+using System;
+
+/// <summary>
+/// Exception thrown when a <see cref="Syntax.IntervalExpression"/> has incorrect <see cref="Syntax.IntervalExpression.Min"/>
+/// </summary>
+/// <remarks>
+/// Creates a new <see cref="BoundariesTypeMismatchException"/> instance
+/// </remarks>
+/// <param name="message">message of the exception</param>
+/// <param name="paramName">name of the argument which causes the exception to be thrown</param>
 #pragma warning disable RCS1194 // Implement exception constructors.
-    [Serializable]
-    public sealed class BoundariesTypeMismatchException(string message, string paramName) : ArgumentException(message, paramName)
+[Serializable]
+public sealed class BoundariesTypeMismatchException(string message, string paramName) : ArgumentException(message, paramName)
 #pragma warning restore RCS1194 // Implement exception constructors.
-    {
-    }
+{
 }

--- a/src/DataFilters/Grammar/Exceptions/IncorrectBoundaryException.cs
+++ b/src/DataFilters/Grammar/Exceptions/IncorrectBoundaryException.cs
@@ -1,35 +1,34 @@
-﻿namespace DataFilters.Grammar.Exceptions
+﻿namespace DataFilters.Grammar.Exceptions;
+
+using System;
+
+/// <summary>
+/// Exception thrown when <see cref="Syntax.IntervalExpression"/> constructor is passed incorrect <see cref="Syntax.BoundaryExpression"/>s.
+/// </summary>
+public class IncorrectBoundaryException : ArgumentException
 {
-    using System;
-
-    /// <summary>
-    /// Exception thrown when <see cref="Syntax.IntervalExpression"/> constructor is passed incorrect <see cref="Syntax.BoundaryExpression"/>s.
-    /// </summary>
-    public class IncorrectBoundaryException : ArgumentException
+    ///<inheritdoc/>
+    public IncorrectBoundaryException() : base()
     {
-        ///<inheritdoc/>
-        public IncorrectBoundaryException() : base()
-        {
-        }
+    }
 
-        ///<inheritdoc/>
-        public IncorrectBoundaryException(string message) : base(message)
-        {
-        }
+    ///<inheritdoc/>
+    public IncorrectBoundaryException(string message) : base(message)
+    {
+    }
 
-        ///<inheritdoc/>
-        public IncorrectBoundaryException(string message, Exception innerException) : base(message, innerException)
-        {
-        }
+    ///<inheritdoc/>
+    public IncorrectBoundaryException(string message, Exception innerException) : base(message, innerException)
+    {
+    }
 
-        ///<inheritdoc/>
-        public IncorrectBoundaryException(string message, string paramName) : base(message, paramName)
-        {
-        }
+    ///<inheritdoc/>
+    public IncorrectBoundaryException(string message, string paramName) : base(message, paramName)
+    {
+    }
 
-        ///<inheritdoc/>
-        public IncorrectBoundaryException(string message, string paramName, Exception innerException) : base(message, paramName, innerException)
-        {
-        }
+    ///<inheritdoc/>
+    public IncorrectBoundaryException(string message, string paramName, Exception innerException) : base(message, paramName, innerException)
+    {
     }
 }

--- a/src/DataFilters/Grammar/Parsing/FilterToken.cs
+++ b/src/DataFilters/Grammar/Parsing/FilterToken.cs
@@ -1,151 +1,150 @@
-﻿namespace DataFilters.Grammar.Parsing
+﻿namespace DataFilters.Grammar.Parsing;
+
+using Superpower.Display;
+
+/// <summary>
+/// Enumeration of token used throughout the parsing process.
+/// </summary>
+/// <remarks>
+/// <see cref="FilterToken"/>s acts as "markers" with special meaning. They can be combined to create a syntax tree with a higher meaning.
+/// </remarks>
+public enum FilterToken
 {
-    using Superpower.Display;
+    /// <summary>
+    /// A token that has no specific meaning
+    /// </summary>
+    None,
 
     /// <summary>
-    /// Enumeration of token used throughout the parsing process.
+    /// Token that indicates the start of a group of token
     /// </summary>
-    /// <remarks>
-    /// <see cref="FilterToken"/>s acts as "markers" with special meaning. They can be combined to create a syntax tree with a higher meaning.
-    /// </remarks>
-    public enum FilterToken
-    {
-        /// <summary>
-        /// A token that has no specific meaning
-        /// </summary>
-        None,
+    [Token(Example = "(", Description = "left parenthesis")]
+    LeftParenthesis,
 
-        /// <summary>
-        /// Token that indicates the start of a group of token
-        /// </summary>
-        [Token(Example = "(", Description = "left parenthesis")]
-        LeftParenthesis,
+    /// <summary>
+    /// Token that indicates the end of a group of tokens.
+    /// </summary>
+    /// <see cref="LeftParenthesis"/>
+    [Token(Example = ")", Description = "right parenthesis")]
+    RightParenthesis,
 
-        /// <summary>
-        /// Token that indicates the end of a group of tokens.
-        /// </summary>
-        /// <see cref="LeftParenthesis"/>
-        [Token(Example = ")", Description = "right parenthesis")]
-        RightParenthesis,
+    /// <summary>
+    /// Letter
+    /// </summary>
+    [Token(Example = "c", Description = "a letter")]
+    Letter,
 
-        /// <summary>
-        /// Letter
-        /// </summary>
-        [Token(Example = "c", Description = "a letter")]
-        Letter,
+    /// <summary>
+    /// Numeric value of some sort
+    /// </summary>
+    [Token(Example = "2", Description = "a digit")]
+    Digit,
 
-        /// <summary>
-        /// Numeric value of some sort
-        /// </summary>
-        [Token(Example = "2", Description = "a digit")]
-        Digit,
+    /// <summary>
+    /// <c>[</c> character
+    /// </summary>
+    [Token(Example = "[", Description = "left squared bracket")]
+    LeftSquaredBracket,
 
-        /// <summary>
-        /// <c>[</c> character
-        /// </summary>
-        [Token(Example = "[", Description = "left squared bracket")]
-        LeftSquaredBracket,
+    /// <summary>
+    /// <c>]</c> character
+    /// </summary>
+    [Token(Example = "]", Description = "right squared bracket")]
+    RightSquaredBracket,
 
-        /// <summary>
-        /// <c>]</c> character
-        /// </summary>
-        [Token(Example = "]", Description = "right squared bracket")]
-        RightSquaredBracket,
+    /// <summary>
+    /// Asterisk operator used in like expression
+    /// </summary>
+    [Token(Example = "*", Description = "asterisk")]
+    Asterisk,
 
-        /// <summary>
-        /// Asterisk operator used in like expression
-        /// </summary>
-        [Token(Example = "*", Description = "asterisk")]
-        Asterisk,
+    /// <summary>
+    /// Logical AND operator
+    /// </summary>
+    [Token(Example = ",", Description = "comma")]
+    And,
 
-        /// <summary>
-        /// Logical AND operator
-        /// </summary>
-        [Token(Example = ",", Description = "comma")]
-        And,
+    /// <summary>
+    /// Logical OR operator
+    /// </summary>
+    [Token(Example = "|", Description = "pipe")]
+    Or,
 
-        /// <summary>
-        /// Logical OR operator
-        /// </summary>
-        [Token(Example = "|", Description = "pipe")]
-        Or,
+    /// <summary>
+    /// Hyphen
+    /// </summary>
+    [Token(Example = "-", Description = "hyphen")]
+    Dash,
 
-        /// <summary>
-        /// Hyphen
-        /// </summary>
-        [Token(Example = "-", Description = "hyphen")]
-        Dash,
+    /// <summary>
+    /// Equal sign
+    /// </summary>
+    [Token(Example = "=", Description = "equal symbol")]
+    Equal,
 
-        /// <summary>
-        /// Equal sign
-        /// </summary>
-        [Token(Example = "=", Description = "equal symbol")]
-        Equal,
+    /// <summary>
+    /// Underscore sign
+    /// </summary>
+    [Token(Example = "_", Description = "underscore")]
+    Underscore,
 
-        /// <summary>
-        /// Underscore sign
-        /// </summary>
-        [Token(Example = "_", Description = "underscore")]
-        Underscore,
+    /// <summary>
+    /// Bang sign
+    /// </summary>
+    [Token(Example = "!", Description = "exclamation point")]
+    Bang,
 
-        /// <summary>
-        /// Bang sign
-        /// </summary>
-        [Token(Example = "!", Description = "exclamation point")]
-        Bang,
+    /// <summary>
+    /// The whitespace
+    /// </summary>
+    [Token(Example = " ")]
+    Whitespace,
 
-        /// <summary>
-        /// The whitespace
-        /// </summary>
-        [Token(Example = " ")]
-        Whitespace,
+    /// <summary>
+    /// The <c>:</c> character
+    /// </summary>
+    [Token(Example = ":")]
+    Colon,
 
-        /// <summary>
-        /// The <c>:</c> character
-        /// </summary>
-        [Token(Example = ":")]
-        Colon,
+    /// <summary>
+    /// The <c>.</c> character.
+    /// </summary>
+    [Token(Example = ".")]
+    Dot,
 
-        /// <summary>
-        /// The <c>.</c> character.
-        /// </summary>
-        [Token(Example = ".")]
-        Dot,
+    /// <summary>
+    /// The <c>\</c> (backslash) character
+    /// </summary>
+    [Token(Example = @"\")]
+    Backslash,
 
-        /// <summary>
-        /// The <c>\</c> (backslash) character
-        /// </summary>
-        [Token(Example = @"\")]
-        Backslash,
+    /// <summary>
+    /// Token that allow to escape the token that comes right after itself.
+    /// </summary>
+    [Token(Description = "Token that allow to escape character with a special meaning", Example = @"\\")]
+    Escaped,
 
-        /// <summary>
-        /// Token that allow to escape the token that comes right after itself.
-        /// </summary>
-        [Token(Description = "Token that allow to escape character with a special meaning", Example = @"\\")]
-        Escaped,
+    /// <summary>
+    /// The <c>"</c> charater
+    /// </summary>
+    [Token(Example = @"""", Description = "double quote")]
+    DoubleQuote,
 
-        /// <summary>
-        /// The <c>"</c> charater
-        /// </summary>
-        [Token(Example = @"""", Description = "double quote")]
-        DoubleQuote,
+    /// <summary>
+    /// The <c>&#38;</c> character.
+    /// </summary>
+    [Token(Example = "&", Description = "ampersand")]
+    Ampersand,
 
-        /// <summary>
-        /// The <c>&#38;</c> character.
-        /// </summary>
-        [Token(Example = "&", Description = "ampersand")]
-        Ampersand,
+    /// <summary>
+    /// The <c>{</c> character.
+    /// </summary>
+    [Token(Example = "{", Description = "left curly brace")]
+    LeftCurlyBrace,
 
-        /// <summary>
-        /// The <c>{</c> character.
-        /// </summary>
-        [Token(Example = "{", Description = "left curly brace")]
-        LeftCurlyBrace,
-
-        /// <summary>
-        /// The <c>}</c> character.
-        /// </summary>
-        [Token(Example = "}", Description = "right curly brace")]
-        RightCurlyBrace
-    }
+    /// <summary>
+    /// The <c>}</c> character.
+    /// </summary>
+    [Token(Example = "}", Description = "right curly brace")]
+    RightCurlyBrace
 }

--- a/src/DataFilters/Grammar/Parsing/FilterTokenParser.cs
+++ b/src/DataFilters/Grammar/Parsing/FilterTokenParser.cs
@@ -219,7 +219,7 @@
                             from max in Constant
                             from ___ in Token.EqualTo(FilterToken.RightSquaredBracket)
 
-                            where min != default || max != default
+                            where min is not null || max is not null
                             select new IntervalExpression(
                                 min: new BoundaryExpression(min switch
                                 {
@@ -252,7 +252,7 @@
                             from max in Constant
                             from ___ in Token.EqualTo(FilterToken.RightSquaredBracket)
 
-                            where min != default || max != default
+                            where min is not null || max is not null
                             select new IntervalExpression(
                                 min: new BoundaryExpression(min switch
                                 {
@@ -287,7 +287,7 @@
 
                             from ___ in Token.EqualTo(FilterToken.LeftSquaredBracket)
 
-                            where min != default || max != default
+                            where min is not null || max is not null
                             select new IntervalExpression(
                                 min: new BoundaryExpression(min switch
                                 {
@@ -323,7 +323,7 @@
                                                 .Or(Constant)
                             from ___ in Token.EqualTo(FilterToken.LeftSquaredBracket)
 
-                            where min != default || max != default
+                            where min is not null || max is not null
                             select new IntervalExpression(
                                 min: new BoundaryExpression(min switch
                                 {
@@ -391,7 +391,7 @@
                                                                                  from _ in Token.EqualTo(FilterToken.LeftSquaredBracket)
                                                                                  from subProp in AlphaNumeric.Between(Token.EqualTo(FilterToken.DoubleQuote), Token.EqualTo(FilterToken.DoubleQuote))
                                                                                  from __ in Token.EqualTo(FilterToken.RightSquaredBracket)
-                                                                                 select @$"[""{subProp.Value}""]"
+                                                                                 select $"""["{subProp.Value}"]"""
                                                                              ).Many()
                                                                              select new PropertyName(string.Concat(prop.Value, string.Concat(subProps)));
 
@@ -485,7 +485,7 @@
                     (null, BracketExpression bracket, AsteriskExpression) => new OneOfExpression([.. ConvertRegexToCharArray(bracket.Values).Select(chr => new StartsWithExpression(chr.ToString()))]),
 
                     // <ends with><bracket>
-                    (EndsWithExpression head, BracketExpression body, null) => new OneOfExpression(ConvertRegexToCharArray(body.Values).Select(chr => (FilterExpression) new EndsWithExpression($"{head.Value}{chr}")).ToArray()),
+                    (EndsWithExpression head, BracketExpression body, null) => new OneOfExpression(ConvertRegexToCharArray(body.Values).Select(FilterExpression (chr) => new EndsWithExpression($"{head.Value}{chr}")).ToArray()),
 
                     // <ends with><bracket><constant>
                     (EndsWithExpression head, BracketExpression body, ConstantValueExpression constant) => new OneOfExpression([.. ConvertRegexToCharArray(body.Values).Select(chr => new EndsWithExpression($"{head.Value}{chr}{constant.Value}"))]),
@@ -601,9 +601,9 @@
         private static TokenListParser<FilterToken, Token<FilterToken>> PlusSign => Token.EqualToValue(FilterToken.None, "+");
 
         private static TokenListParser<FilterToken, NumericSign> MinusOrPlusSign => MinusSign.Or(PlusSign).Optional()
-                                                                                              .Select(token => token?.ToStringValue() switch
+                                                                                              .Select(token => token switch
                                                                                               {
-                                                                                                  "-" => NumericSign.Minus,
+                                                                                                  { Kind: FilterToken.Dash } => NumericSign.Minus,
                                                                                                   _ => NumericSign.Plus
                                                                                               });
 

--- a/src/DataFilters/Grammar/Parsing/FilterTokenParser.cs
+++ b/src/DataFilters/Grammar/Parsing/FilterTokenParser.cs
@@ -1,201 +1,201 @@
-﻿namespace DataFilters.Grammar.Parsing
-{
-    using Syntax;
+﻿namespace DataFilters.Grammar.Parsing;
 
-    using Superpower;
-    using Superpower.Model;
-    using Superpower.Parsers;
+using Syntax;
 
-    using System;
-    using System.Collections.Generic;
+using Superpower;
+using Superpower.Model;
+using Superpower.Parsers;
+
+using System;
+using System.Collections.Generic;
 #if NET7_0_OR_GREATER
-    using System.Diagnostics;
+using System.Diagnostics;
 #endif
-    using System.Globalization;
-    using System.Linq;
+using System.Globalization;
+using System.Linq;
+
+/// <summary>
+/// Parses a tree of <see cref="FilterToken"/> into <see cref="FilterExpression"/>
+/// </summary>
+public static class FilterTokenParser
+{
+    /// <summary>
+    /// Parser for many <see cref="FilterToken.Letter"/>s or <see cref="FilterToken.Digit"/>s.
+    /// </summary>
+    public static TokenListParser<FilterToken, ConstantValueExpression> AlphaNumeric => from data in (
+            from symbolBefore in Token.EqualTo(FilterToken.Escaped).Try()
+                .Or(Token.EqualTo(FilterToken.None).Try())
+                .Or(Token.EqualTo(FilterToken.Dot).Try()).Many()
+            from digitsBefore in Digit.Many()
+            from alpha in Alpha.Many()
+            from digitsAfter in Digit.Many()
+            from symbolAfter in Token.EqualTo(FilterToken.Escaped).Try()
+                .Or(Token.EqualTo(FilterToken.None).Try())
+                .Or(Token.EqualTo(FilterToken.Dot).Try())
+                .Many()
+            where symbolBefore.Length > 0
+                  || digitsBefore.Length > 0
+                  || alpha.Length > 0
+                  || digitsAfter.Length > 0
+                  || symbolAfter.Length > 0
+
+            let value = string.Concat(string.Concat(symbolBefore.Select(x => x.ToStringValue())),
+                string.Concat(digitsBefore.Select(x => x.ToStringValue())),
+                string.Concat(alpha.Select(item => item.ToStringValue())),
+                string.Concat(digitsAfter.Select(x => x.ToStringValue())),
+                string.Concat(symbolAfter.Select(x => x.ToStringValue())))
+            select value).AtLeastOnce()
+
+        let alphaNumericValue = string.Concat(data)
+        let textSpan = new TextSpan(alphaNumericValue)
+        select Numerics.Decimal.IsMatch(textSpan) || Numerics.Integer.IsMatch(textSpan)
+            ? new NumericValueExpression(alphaNumericValue)
+            : (ConstantValueExpression)new StringValueExpression(alphaNumericValue);
+
+    private static TokenListParser<FilterToken, Token<FilterToken>> Alpha => Token.EqualTo(FilterToken.Letter).Try()
+        .Or(Token.EqualTo(FilterToken.Escaped)).Try()
+        .Or(Token.EqualTo(FilterToken.Underscore)).Try()
+        .Or(Token.EqualTo(FilterToken.None));
+
+    private static TokenListParser<FilterToken, Token<FilterToken>> Digit => Token.EqualTo(FilterToken.Digit);
+
+    private static TokenListParser<FilterToken, StringValueExpression> Bool => Token.EqualToValueIgnoreCase(FilterToken.Letter, "t")
+        .IgnoreThen(Token.EqualToValueIgnoreCase(FilterToken.Letter, "r"))
+        .IgnoreThen(Token.EqualToValueIgnoreCase(FilterToken.Letter, "u"))
+        .IgnoreThen(Token.EqualToValueIgnoreCase(FilterToken.Letter, "e"))
+        .Select(_ => new StringValueExpression(bool.TrueString)).Try()
+        .Or(
+            Token.EqualToValueIgnoreCase(FilterToken.Letter, "f")
+                .IgnoreThen(Token.EqualToValueIgnoreCase(FilterToken.Letter, "a"))
+                .IgnoreThen(Token.EqualToValueIgnoreCase(FilterToken.Letter, "l"))
+                .IgnoreThen(Token.EqualToValueIgnoreCase(FilterToken.Letter, "s"))
+                .IgnoreThen(Token.EqualToValueIgnoreCase(FilterToken.Letter, "e"))
+                .Select(_ => new StringValueExpression(bool.FalseString)));
 
     /// <summary>
-    /// Parses a tree of <see cref="FilterToken"/> into <see cref="FilterExpression"/>
+    /// Parser for '*' character
     /// </summary>
-    public static class FilterTokenParser
-    {
-        /// <summary>
-        /// Parser for many <see cref="FilterToken.Letter"/>s or <see cref="FilterToken.Digit"/>s.
-        /// </summary>
-        public static TokenListParser<FilterToken, ConstantValueExpression> AlphaNumeric => from data in (
-                                                                                               from symbolBefore in Token.EqualTo(FilterToken.Escaped).Try()
-                                                                                                                         .Or(Token.EqualTo(FilterToken.None).Try())
-                                                                                                                         .Or(Token.EqualTo(FilterToken.Dot).Try()).Many()
-                                                                                               from digitsBefore in Digit.Many()
-                                                                                               from alpha in Alpha.Many()
-                                                                                               from digitsAfter in Digit.Many()
-                                                                                               from symbolAfter in Token.EqualTo(FilterToken.Escaped).Try()
-                                                                                                                        .Or(Token.EqualTo(FilterToken.None).Try())
-                                                                                                                        .Or(Token.EqualTo(FilterToken.Dot).Try())
-                                                                                                                        .Many()
-                                                                                               where symbolBefore.Length > 0
-                                                                                                     || digitsBefore.Length > 0
-                                                                                                     || alpha.Length > 0
-                                                                                                     || digitsAfter.Length > 0
-                                                                                                     || symbolAfter.Length > 0
+    private static TokenListParser<FilterToken, AsteriskExpression> Asterisk => from __ in Token.EqualTo(FilterToken.Asterisk)
+        select AsteriskExpression.Instance;
 
-                                                                                               let value = string.Concat(string.Concat(symbolBefore.Select(x => x.ToStringValue())),
-                                                                                                                         string.Concat(digitsBefore.Select(x => x.ToStringValue())),
-                                                                                                                         string.Concat(alpha.Select(item => item.ToStringValue())),
-                                                                                                                         string.Concat(digitsAfter.Select(x => x.ToStringValue())),
-                                                                                                                         string.Concat(symbolAfter.Select(x => x.ToStringValue())))
-                                                                                               select value).AtLeastOnce()
+    /// <summary>
+    /// Parser for "starts with" expressions
+    /// </summary>
+    public static TokenListParser<FilterToken, StartsWithExpression> StartsWith => (from text in Text
+            from _ in Asterisk
+            select new StartsWithExpression(text)).Try()
+        .Or(
+            from data in AlphaNumeric.AtLeastOnce()
+            from _ in Asterisk
+            select new StartsWithExpression(string.Concat(data.Select(x => x.Value)))
+        );
 
-                                                                                            let alphaNumericValue = string.Concat(data)
-                                                                                            let textSpan = new TextSpan(alphaNumericValue)
-                                                                                            select Numerics.Decimal.IsMatch(textSpan) || Numerics.Integer.IsMatch(textSpan)
-                                                                                                  ? new NumericValueExpression(alphaNumericValue)
-                                                                                                  : (ConstantValueExpression)new StringValueExpression(alphaNumericValue);
+    /// <summary>
+    /// Parser for "ends with" expressions
+    /// </summary>
+    public static TokenListParser<FilterToken, EndsWithExpression> EndsWith => Asterisk.IgnoreThen(Text)
+        .Select(text => new EndsWithExpression(text)).Try()
+        .Or(Asterisk.IgnoreThen(AlphaNumeric.AtLeastOnce())
+            .Select(data => new EndsWithExpression(string.Concat(data.Select(item => item.Value)))));
 
-        private static TokenListParser<FilterToken, Token<FilterToken>> Alpha => Token.EqualTo(FilterToken.Letter).Try()
-                                                                                      .Or(Token.EqualTo(FilterToken.Escaped)).Try()
-                                                                                      .Or(Token.EqualTo(FilterToken.Underscore)).Try()
-                                                                                      .Or(Token.EqualTo(FilterToken.None));
-
-        private static TokenListParser<FilterToken, Token<FilterToken>> Digit => Token.EqualTo(FilterToken.Digit);
-
-        private static TokenListParser<FilterToken, StringValueExpression> Bool => Token.EqualToValueIgnoreCase(FilterToken.Letter, "t")
-                                                                                         .IgnoreThen(Token.EqualToValueIgnoreCase(FilterToken.Letter, "r"))
-                                                                                         .IgnoreThen(Token.EqualToValueIgnoreCase(FilterToken.Letter, "u"))
-                                                                                         .IgnoreThen(Token.EqualToValueIgnoreCase(FilterToken.Letter, "e"))
-                                                                                         .Select(_ => new StringValueExpression(bool.TrueString)).Try()
-                                                                   .Or(
-                                                                        Token.EqualToValueIgnoreCase(FilterToken.Letter, "f")
-                                                                             .IgnoreThen(Token.EqualToValueIgnoreCase(FilterToken.Letter, "a"))
-                                                                             .IgnoreThen(Token.EqualToValueIgnoreCase(FilterToken.Letter, "l"))
-                                                                             .IgnoreThen(Token.EqualToValueIgnoreCase(FilterToken.Letter, "s"))
-                                                                             .IgnoreThen(Token.EqualToValueIgnoreCase(FilterToken.Letter, "e"))
-                                                                             .Select(_ => new StringValueExpression(bool.FalseString)));
-
-        /// <summary>
-        /// Parser for '*' character
-        /// </summary>
-        private static TokenListParser<FilterToken, AsteriskExpression> Asterisk => from __ in Token.EqualTo(FilterToken.Asterisk)
-                                                                                    select AsteriskExpression.Instance;
-
-        /// <summary>
-        /// Parser for "starts with" expressions
-        /// </summary>
-        public static TokenListParser<FilterToken, StartsWithExpression> StartsWith => (from text in Text
-                                                                                        from _ in Asterisk
-                                                                                        select new StartsWithExpression(text)).Try()
-                                                                                        .Or(
-                                                                                            from data in AlphaNumeric.AtLeastOnce()
-                                                                                            from _ in Asterisk
-                                                                                            select new StartsWithExpression(string.Concat(data.Select(x => x.Value)))
-                                                                                        );
-
-        /// <summary>
-        /// Parser for "ends with" expressions
-        /// </summary>
-        public static TokenListParser<FilterToken, EndsWithExpression> EndsWith => Asterisk.IgnoreThen(Text)
-                                                                                           .Select(text => new EndsWithExpression(text)).Try()
-                                                                                   .Or(Asterisk.IgnoreThen(AlphaNumeric.AtLeastOnce())
-                                                                                       .Select(data => new EndsWithExpression(string.Concat(data.Select(item => item.Value)))));
-
-        /// <summary>
-        /// Parser for "contains" expression
-        /// </summary>
-        public static TokenListParser<FilterToken, ContainsExpression> Contains => Text.Between(Asterisk, Asterisk)
-                                                                                       .Select(text => new ContainsExpression(text)).Try()
-                                                                                       .Or(
-                                                                                           from _ in Asterisk
-                                                                                           from data in (
-                                                                                               from beforeSymbol in Token.EqualTo(FilterToken.Escaped).Try().Or(Whitespace).Many()
-                                                                                               from beforePunctuation in Punctuation.Many()
-                                                                                               from alpha in AlphaNumeric.Many()
-                                                                                               from afterPunctuation in Punctuation.Many()
-                                                                                               from afterSymbol in Token.EqualTo(FilterToken.Escaped).Try().Or(Whitespace).Many()
-                                                                                               where beforeSymbol.AtLeastOnce()
-                                                                                                     || beforePunctuation.AtLeastOnce()
-                                                                                                     || alpha.AtLeastOnce()
-                                                                                                     || afterPunctuation.AtLeastOnce()
-                                                                                                     || afterSymbol.AtLeastOnce()
-                                                                                               select new
-                                                                                               {
-                                                                                                   value = string.Concat(string.Concat(beforeSymbol.Select(x => x.ToStringValue())),
-                                                                                                                         string.Concat(beforePunctuation.Select(x => x.Value)),
-                                                                                                                         string.Concat(alpha.Select(item => item.Value)),
-                                                                                                                         string.Concat(afterPunctuation.Select(x => x.Value)),
-                                                                                                                         string.Concat(afterSymbol.Select(x => x.ToStringValue())))
-                                                                                               }).AtLeastOnce()
-                                                                                    from escaped in Token.EqualTo(FilterToken.Backslash).Many()
-                                                                                    from __ in Asterisk
-                                                                                    select new ContainsExpression(string.Concat(data.Select(x => x.value))));
-
-        /// <summary>
-        /// Parser for logical OR expression.
-        /// </summary>
-        public static TokenListParser<FilterToken, OrExpression> Or
-            => from left in Parse.Ref(() => UnaryExpression)
-               from _ in Token.EqualTo(FilterToken.Or)
-               from right in Parse.Ref(() => UnaryExpression)
-               select left | right;
-
-        /// <summary>
-        /// Parser for logical AND expression
-        /// </summary>
-        public static TokenListParser<FilterToken, AndExpression> And => (from left in Parse.Ref(() => UnaryExpression)
-                                                                          from _ in Token.EqualTo(FilterToken.And)
-                                                                          from right in Parse.Ref(() => UnaryExpression)
-                                                                          select new AndExpression(left, right)).Try()
-                                                                        .Or(from left in AlphaNumeric
-                                                                            from _ in Asterisk
-                                                                            from right in AlphaNumeric
-                                                                            from __ in Asterisk
-                                                                            select new AndExpression(new StartsWithExpression(left.Value),
-                                                                                                    new ContainsExpression(right.Value))).Try()
-                                                                        .Or(from left in AlphaNumeric
-                                                                            from _ in Asterisk
-                                                                            from right in AlphaNumeric
-                                                                            select new AndExpression(new StartsWithExpression(left.Value),
-                                                                                                    new EndsWithExpression(right.Value)))
-                                                                        ;
-
-        /// <summary>
-        /// Parser for NOT expression
-        /// </summary>
-        public static TokenListParser<FilterToken, NotExpression> Not => (from bangs in Token.EqualTo(FilterToken.Bang).AtLeastOnce()
-                                                                         from expression in Parse.Ref(() => UnaryExpression)
-                                                                         select (bangs, expression))
-            .Select(tuple =>
-            {
-                NotExpression notExpression = !tuple.expression;
-
-                for (int i = 1; i < tuple.bangs.Length; i++)
+    /// <summary>
+    /// Parser for "contains" expression
+    /// </summary>
+    public static TokenListParser<FilterToken, ContainsExpression> Contains => Text.Between(Asterisk, Asterisk)
+        .Select(text => new ContainsExpression(text)).Try()
+        .Or(
+            from _ in Asterisk
+            from data in (
+                from beforeSymbol in Token.EqualTo(FilterToken.Escaped).Try().Or(Whitespace).Many()
+                from beforePunctuation in Punctuation.Many()
+                from alpha in AlphaNumeric.Many()
+                from afterPunctuation in Punctuation.Many()
+                from afterSymbol in Token.EqualTo(FilterToken.Escaped).Try().Or(Whitespace).Many()
+                where beforeSymbol.AtLeastOnce()
+                      || beforePunctuation.AtLeastOnce()
+                      || alpha.AtLeastOnce()
+                      || afterPunctuation.AtLeastOnce()
+                      || afterSymbol.AtLeastOnce()
+                select new
                 {
-                    notExpression = !notExpression;
-                }
-                return notExpression;
-            });
+                    value = string.Concat(string.Concat(beforeSymbol.Select(x => x.ToStringValue())),
+                        string.Concat(beforePunctuation.Select(x => x.Value)),
+                        string.Concat(alpha.Select(item => item.Value)),
+                        string.Concat(afterPunctuation.Select(x => x.Value)),
+                        string.Concat(afterSymbol.Select(x => x.ToStringValue())))
+                }).AtLeastOnce()
+            from escaped in Token.EqualTo(FilterToken.Backslash).Many()
+            from __ in Asterisk
+            select new ContainsExpression(string.Concat(data.Select(x => x.value))));
 
-        private static TokenListParser<FilterToken, BracketExpression> Bracket => (
-                                                                                    from _ in Token.EqualTo(FilterToken.LeftSquaredBracket)
-                                                                                    from rangeValues in BuildRangeBracketValuesParser(Alpha).Or(BuildRangeBracketValuesParser(Digit)).AtLeastOnce()
-                                                                                    from __ in Token.EqualTo(FilterToken.RightSquaredBracket)
-                                                                                    select new BracketExpression(rangeValues)
-                                                                                ).Try()
-                                                                                .Or
-                                                                                (
-                                                                                    from _ in Token.EqualTo(FilterToken.LeftSquaredBracket)
-                                                                                    from alpha in Alpha.Try().Or(Digit).AtLeastOnce()
-                                                                                    from __ in Token.EqualTo(FilterToken.RightSquaredBracket)
-                                                                                    select new BracketExpression(new ConstantBracketValue(alpha.Select(chr => chr.ToStringValue())
-                                                                                                                                                     .Aggregate((total, current) => $"{total}{current}"))
-                                                                                                                )
-                                                                                );
-        /// <summary>
-        /// Builds a parser that can extract bracket expression values
-        /// </summary>
-        /// <param name="token">The parser that can parse values inside a <c>[</c> and <c>]</c></param>
-        /// <returns></returns>
-        private static TokenListParser<FilterToken, BracketValue> BuildRangeBracketValuesParser(TokenListParser<FilterToken, Token<FilterToken>> token)
-            => (from rangeStart in token
+    /// <summary>
+    /// Parser for logical OR expression.
+    /// </summary>
+    public static TokenListParser<FilterToken, OrExpression> Or
+        => from left in Parse.Ref(() => UnaryExpression)
+            from _ in Token.EqualTo(FilterToken.Or)
+            from right in Parse.Ref(() => UnaryExpression)
+            select left | right;
+
+    /// <summary>
+    /// Parser for logical AND expression
+    /// </summary>
+    public static TokenListParser<FilterToken, AndExpression> And => (from left in Parse.Ref(() => UnaryExpression)
+            from _ in Token.EqualTo(FilterToken.And)
+            from right in Parse.Ref(() => UnaryExpression)
+            select new AndExpression(left, right)).Try()
+        .Or(from left in AlphaNumeric
+            from _ in Asterisk
+            from right in AlphaNumeric
+            from __ in Asterisk
+            select new AndExpression(new StartsWithExpression(left.Value),
+                new ContainsExpression(right.Value))).Try()
+        .Or(from left in AlphaNumeric
+            from _ in Asterisk
+            from right in AlphaNumeric
+            select new AndExpression(new StartsWithExpression(left.Value),
+                new EndsWithExpression(right.Value)))
+    ;
+
+    /// <summary>
+    /// Parser for NOT expression
+    /// </summary>
+    public static TokenListParser<FilterToken, NotExpression> Not => (from bangs in Token.EqualTo(FilterToken.Bang).AtLeastOnce()
+            from expression in Parse.Ref(() => UnaryExpression)
+            select (bangs, expression))
+        .Select(tuple =>
+        {
+            NotExpression notExpression = !tuple.expression;
+
+            for (int i = 1; i < tuple.bangs.Length; i++)
+            {
+                notExpression = !notExpression;
+            }
+            return notExpression;
+        });
+
+    private static TokenListParser<FilterToken, BracketExpression> Bracket => (
+            from _ in Token.EqualTo(FilterToken.LeftSquaredBracket)
+            from rangeValues in BuildRangeBracketValuesParser(Alpha).Or(BuildRangeBracketValuesParser(Digit)).AtLeastOnce()
+            from __ in Token.EqualTo(FilterToken.RightSquaredBracket)
+            select new BracketExpression(rangeValues)
+        ).Try()
+        .Or
+        (
+            from _ in Token.EqualTo(FilterToken.LeftSquaredBracket)
+            from alpha in Alpha.Try().Or(Digit).AtLeastOnce()
+            from __ in Token.EqualTo(FilterToken.RightSquaredBracket)
+            select new BracketExpression(new ConstantBracketValue(alpha.Select(chr => chr.ToStringValue())
+                .Aggregate((total, current) => $"{total}{current}"))
+            )
+        );
+    /// <summary>
+    /// Builds a parser that can extract bracket expression values
+    /// </summary>
+    /// <param name="token">The parser that can parse values inside a <c>[</c> and <c>]</c></param>
+    /// <returns></returns>
+    private static TokenListParser<FilterToken, BracketValue> BuildRangeBracketValuesParser(TokenListParser<FilterToken, Token<FilterToken>> token)
+        => (from rangeStart in token
                 from _ in Token.EqualTo(FilterToken.Dash)
                 from rangeEnd in token
                 select (BracketValue)new RangeBracketValue(rangeStart.ToStringValue()[0], rangeEnd.ToStringValue()[0]))
@@ -203,274 +203,274 @@
             .Or(from values in token.AtLeastOnce()
                 select (BracketValue)new ConstantBracketValue(string.Concat(values.Select(value => value.ToStringValue()))))
 
-            ;
-        /// <summary>
-        /// Parses Range expressions
-        /// </summary>
-        public static TokenListParser<FilterToken, IntervalExpression> Interval
+    ;
+    /// <summary>
+    /// Parses Range expressions
+    /// </summary>
+    public static TokenListParser<FilterToken, IntervalExpression> Interval
+    {
+        get
         {
-            get
-            {
-                return  // Case [ min TO max ] 
-                        (
-                            from _ in Token.EqualTo(FilterToken.LeftSquaredBracket)
-                            from min in Constant
-                            from __ in RangeSeparator
-                            from max in Constant
-                            from ___ in Token.EqualTo(FilterToken.RightSquaredBracket)
+            return  // Case [ min TO max ] 
+                (
+                    from _ in Token.EqualTo(FilterToken.LeftSquaredBracket)
+                    from min in Constant
+                    from __ in RangeSeparator
+                    from max in Constant
+                    from ___ in Token.EqualTo(FilterToken.RightSquaredBracket)
 
-                            where min is not null || max is not null
-                            select new IntervalExpression(
-                                min: new BoundaryExpression(min switch
-                                {
-                                    NumericValueExpression constant => constant,
-                                    DateTimeExpression dateTime => dateTime,
+                    where min is not null || max is not null
+                    select new IntervalExpression(
+                        min: new BoundaryExpression(min switch
+                        {
+                            NumericValueExpression constant => constant,
+                            DateTimeExpression dateTime => dateTime,
 #if NET7_0_OR_GREATER
-                                    _ => throw new UnreachableException($"Unsupported '{min?.GetType()}' for min value")
+                            _ => throw new UnreachableException($"Unsupported '{min?.GetType()}' for min value")
 #else
                                     _ => throw new NotSupportedException($"Unsupported '{min?.GetType()}' for min value")
 #endif
-                                }, included: true),
-                                max: new BoundaryExpression(max switch
-                                {
-                                    NumericValueExpression constant => constant,
-                                    DateTimeExpression dateTime => dateTime,
+                        }, included: true),
+                        max: new BoundaryExpression(max switch
+                        {
+                            NumericValueExpression constant => constant,
+                            DateTimeExpression dateTime => dateTime,
 #if NET7_0_OR_GREATER
-                                    _ => throw new UnreachableException($"Unsupported '{max?.GetType()}' for max value")
+                            _ => throw new UnreachableException($"Unsupported '{max?.GetType()}' for max value")
 #else
                                     _ => throw new NotSupportedException($"Unsupported '{max?.GetType()}' for max value")
 #endif
-                                }, included: true)
-                            )
-                        ).Try()
-                      // Case ] min TO max ] : lower bound excluded from the interval
-                      .Or(
-                            from _ in Token.EqualTo(FilterToken.RightSquaredBracket)
-                            from min in Asterisk.Try().Cast<FilterToken, AsteriskExpression, FilterExpression>()
-                                                .Or(Constant)
-                            from __ in RangeSeparator
-                            from max in Constant
-                            from ___ in Token.EqualTo(FilterToken.RightSquaredBracket)
+                        }, included: true)
+                    )
+                ).Try()
+                // Case ] min TO max ] : lower bound excluded from the interval
+                .Or(
+                    from _ in Token.EqualTo(FilterToken.RightSquaredBracket)
+                    from min in Asterisk.Try().Cast<FilterToken, AsteriskExpression, FilterExpression>()
+                        .Or(Constant)
+                    from __ in RangeSeparator
+                    from max in Constant
+                    from ___ in Token.EqualTo(FilterToken.RightSquaredBracket)
 
-                            where min is not null || max is not null
-                            select new IntervalExpression(
-                                min: new BoundaryExpression(min switch
-                                {
-                                    AsteriskExpression asterisk => asterisk,
-                                    NumericValueExpression constant => constant,
-                                    DateTimeExpression dateTime => dateTime,
+                    where min is not null || max is not null
+                    select new IntervalExpression(
+                        min: new BoundaryExpression(min switch
+                        {
+                            AsteriskExpression asterisk => asterisk,
+                            NumericValueExpression constant => constant,
+                            DateTimeExpression dateTime => dateTime,
 #if NET7_0_OR_GREATER
-                                    _ => throw new UnreachableException($"Unsupported '{min?.GetType()}' for min value")
+                            _ => throw new UnreachableException($"Unsupported '{min?.GetType()}' for min value")
 #else
                                     _ => throw new NotSupportedException($"Unsupported '{min?.GetType()}' for min value")
 #endif
-                                }, included: false),
-                                max: new BoundaryExpression(max switch
-                                {
-                                    NumericValueExpression constant => constant,
-                                    DateTimeExpression dateTime => dateTime,
+                        }, included: false),
+                        max: new BoundaryExpression(max switch
+                        {
+                            NumericValueExpression constant => constant,
+                            DateTimeExpression dateTime => dateTime,
 #if NET7_0_OR_GREATER
-                                    _ => throw new UnreachableException($"Unsupported '{max?.GetType()}' for max value")
+                            _ => throw new UnreachableException($"Unsupported '{max?.GetType()}' for max value")
 #else
                                     _ => throw new NotSupportedException($"Unsupported '{max?.GetType()}' for max value")
 #endif
-                                }, included: true)
-                           )
-                        ).Try()
-                      // Case syntax [ min TO max [ : upper bound excluded from the interval
-                      .Or(
-                            from _ in Token.EqualTo(FilterToken.LeftSquaredBracket)
-                            from min in Constant
-                            from __ in RangeSeparator
-                            from max in Asterisk.Try().Cast<FilterToken, AsteriskExpression, FilterExpression>()
-                                                .Or(Constant)
+                        }, included: true)
+                    )
+                ).Try()
+                // Case syntax [ min TO max [ : upper bound excluded from the interval
+                .Or(
+                    from _ in Token.EqualTo(FilterToken.LeftSquaredBracket)
+                    from min in Constant
+                    from __ in RangeSeparator
+                    from max in Asterisk.Try().Cast<FilterToken, AsteriskExpression, FilterExpression>()
+                        .Or(Constant)
 
-                            from ___ in Token.EqualTo(FilterToken.LeftSquaredBracket)
+                    from ___ in Token.EqualTo(FilterToken.LeftSquaredBracket)
 
-                            where min is not null || max is not null
-                            select new IntervalExpression(
-                                min: new BoundaryExpression(min switch
-                                {
-                                    NumericValueExpression constant => constant,
-                                    DateTimeExpression dateTime => dateTime,
+                    where min is not null || max is not null
+                    select new IntervalExpression(
+                        min: new BoundaryExpression(min switch
+                        {
+                            NumericValueExpression constant => constant,
+                            DateTimeExpression dateTime => dateTime,
 #if NET7_0_OR_GREATER
-                                    _ => throw new UnreachableException($"Unsupported '{min?.GetType()}' for min value")
+                            _ => throw new UnreachableException($"Unsupported '{min?.GetType()}' for min value")
 #else
                                     _ => throw new NotSupportedException($"Unsupported '{min?.GetType()}' for min value")
 #endif
-                                }, included: true),
-                                max: new BoundaryExpression(max switch
-                                {
-                                    AsteriskExpression asterisk => asterisk,
-                                    NumericValueExpression constant => constant,
-                                    DateTimeExpression dateTime => dateTime,
+                        }, included: true),
+                        max: new BoundaryExpression(max switch
+                        {
+                            AsteriskExpression asterisk => asterisk,
+                            NumericValueExpression constant => constant,
+                            DateTimeExpression dateTime => dateTime,
 #if NET7_0_OR_GREATER
-                                    _ => throw new UnreachableException($"Unsupported '{max?.GetType()}' for max value")
+                            _ => throw new UnreachableException($"Unsupported '{max?.GetType()}' for max value")
 #else
                                     _ => throw new NotSupportedException($"Unsupported '{max?.GetType()}' for max value")
 #endif
-                                }, included: false)
-                           )
-                        ).Try()
-                      // Case  ] min TO max [ : lower and upper bounds excluded from the interval
-                      .Or(
-                            from _ in Token.EqualTo(FilterToken.RightSquaredBracket)
-                            from min in Asterisk.Try().Cast<FilterToken, AsteriskExpression, FilterExpression>()
-                                                .Or(Constant)
+                        }, included: false)
+                    )
+                ).Try()
+                // Case  ] min TO max [ : lower and upper bounds excluded from the interval
+                .Or(
+                    from _ in Token.EqualTo(FilterToken.RightSquaredBracket)
+                    from min in Asterisk.Try().Cast<FilterToken, AsteriskExpression, FilterExpression>()
+                        .Or(Constant)
 
-                            from __ in RangeSeparator
-                            from max in Asterisk.Try().Cast<FilterToken, AsteriskExpression, FilterExpression>()
-                                                .Or(Constant)
-                            from ___ in Token.EqualTo(FilterToken.LeftSquaredBracket)
+                    from __ in RangeSeparator
+                    from max in Asterisk.Try().Cast<FilterToken, AsteriskExpression, FilterExpression>()
+                        .Or(Constant)
+                    from ___ in Token.EqualTo(FilterToken.LeftSquaredBracket)
 
-                            where min is not null || max is not null
-                            select new IntervalExpression(
-                                min: new BoundaryExpression(min switch
-                                {
-                                    AsteriskExpression asterisk => asterisk,
-                                    NumericValueExpression constant => constant,
-                                    DateTimeExpression dateTime => dateTime,
+                    where min is not null || max is not null
+                    select new IntervalExpression(
+                        min: new BoundaryExpression(min switch
+                        {
+                            AsteriskExpression asterisk => asterisk,
+                            NumericValueExpression constant => constant,
+                            DateTimeExpression dateTime => dateTime,
 #if NET7_0_OR_GREATER
-                                    _ => throw new UnreachableException($"Unsupported '{min?.GetType()}' for min value")
+                            _ => throw new UnreachableException($"Unsupported '{min?.GetType()}' for min value")
 #else
                                     _ => throw new NotSupportedException($"Unsupported '{min?.GetType()}' for min value")
 #endif
-                                }, included: false),
-                                max: new BoundaryExpression(max switch
-                                {
-                                    AsteriskExpression asterisk => asterisk,
-                                    NumericValueExpression constant => constant,
-                                    DateTimeExpression dateTime => dateTime,
+                        }, included: false),
+                        max: new BoundaryExpression(max switch
+                        {
+                            AsteriskExpression asterisk => asterisk,
+                            NumericValueExpression constant => constant,
+                            DateTimeExpression dateTime => dateTime,
 #if NET7_0_OR_GREATER
-                                    _ => throw new UnreachableException($"Unsupported '{max?.GetType()}' for max value")
+                            _ => throw new UnreachableException($"Unsupported '{max?.GetType()}' for max value")
 #else
                                     _ => throw new NotSupportedException($"Unsupported '{max?.GetType()}' for max value")
 #endif
-                                }, included: false)
-                           )
-                        );
-            }
+                        }, included: false)
+                    )
+                );
         }
+    }
 
-        private static TokenListParser<FilterToken, FilterExpression> Constant => Parse.OneOf(GlobalUniqueIdentifier.Try().Cast<FilterToken, GuidValueExpression, FilterExpression>(),
-                                                                                              DateAndTime.Try().Cast<FilterToken, DateTimeExpression, FilterExpression>(),
-                                                                                              Time.Try().Cast<FilterToken, TimeExpression, FilterExpression>(),
-                                                                                              Date.Try().Cast<FilterToken, DateExpression, FilterExpression>(),
-                                                                                              Duration.Try().Cast<FilterToken, DurationExpression, FilterExpression>(),
-                                                                                              Number.Try().Cast<FilterToken, NumericValueExpression, FilterExpression>(),
-                                                                                              Bool.Try().Cast<FilterToken, StringValueExpression, FilterExpression>(),
-                                                                                              Text.Cast<FilterToken, TextExpression, FilterExpression>(),
-                                                                                              AlphaNumeric.Cast<FilterToken, ConstantValueExpression, FilterExpression>());
+    private static TokenListParser<FilterToken, FilterExpression> Constant => Parse.OneOf(GlobalUniqueIdentifier.Try().Cast<FilterToken, GuidValueExpression, FilterExpression>(),
+        DateAndTime.Try().Cast<FilterToken, DateTimeExpression, FilterExpression>(),
+        Time.Try().Cast<FilterToken, TimeExpression, FilterExpression>(),
+        Date.Try().Cast<FilterToken, DateExpression, FilterExpression>(),
+        Duration.Try().Cast<FilterToken, DurationExpression, FilterExpression>(),
+        Number.Try().Cast<FilterToken, NumericValueExpression, FilterExpression>(),
+        Bool.Try().Cast<FilterToken, StringValueExpression, FilterExpression>(),
+        Text.Cast<FilterToken, TextExpression, FilterExpression>(),
+        AlphaNumeric.Cast<FilterToken, ConstantValueExpression, FilterExpression>());
 
-        private static TokenListParser<FilterToken, Token<FilterToken>> RangeSeparator => from _ in Whitespace.AtLeastOnce()
-                                                                                          from rangeSeparator in Token.EqualToValue(FilterToken.Letter, "T")
-                                                                                                .Then(_ => Token.EqualToValue(FilterToken.Letter, "O"))
-                                                                                          from __ in Whitespace.AtLeastOnce()
-                                                                                          select rangeSeparator;
+    private static TokenListParser<FilterToken, Token<FilterToken>> RangeSeparator => from _ in Whitespace.AtLeastOnce()
+        from rangeSeparator in Token.EqualToValue(FilterToken.Letter, "T")
+            .Then(_ => Token.EqualToValue(FilterToken.Letter, "O"))
+        from __ in Whitespace.AtLeastOnce()
+        select rangeSeparator;
 
-        private static TokenListParser<FilterToken, Token<FilterToken>> Whitespace => Token.EqualTo(FilterToken.Whitespace);
+    private static TokenListParser<FilterToken, Token<FilterToken>> Whitespace => Token.EqualTo(FilterToken.Whitespace);
 
-        /// <summary>
-        /// Group expression
-        /// </summary>
-        public static TokenListParser<FilterToken, GroupExpression> Group => from _ in Token.EqualTo(FilterToken.LeftParenthesis)
-                                                                             from expression in Parse.Ref(() => BinaryOrUnaryExpression)
-                                                                             from __ in Token.EqualTo(FilterToken.RightParenthesis)
-                                                                             select new GroupExpression(expression);
+    /// <summary>
+    /// Group expression
+    /// </summary>
+    public static TokenListParser<FilterToken, GroupExpression> Group => from _ in Token.EqualTo(FilterToken.LeftParenthesis)
+        from expression in Parse.Ref(() => BinaryOrUnaryExpression)
+        from __ in Token.EqualTo(FilterToken.RightParenthesis)
+        select new GroupExpression(expression);
 
-        private static TokenListParser<FilterToken, FilterExpression> BinaryOrUnaryExpression => Parse.OneOf(Parse.Ref(() => And.Try().Cast<FilterToken, AndExpression, FilterExpression>()),
-                                                                                                             Parse.Ref(() => Or.Try().Cast<FilterToken, OrExpression, FilterExpression>()),
-                                                                                                             Parse.Ref(() => UnaryExpression ))
-        ;
+    private static TokenListParser<FilterToken, FilterExpression> BinaryOrUnaryExpression => Parse.OneOf(Parse.Ref(() => And.Try().Cast<FilterToken, AndExpression, FilterExpression>()),
+        Parse.Ref(() => Or.Try().Cast<FilterToken, OrExpression, FilterExpression>()),
+        Parse.Ref(() => UnaryExpression ))
+    ;
 
-        /// <summary>
-        /// Property name parser
-        /// </summary>
-        public static TokenListParser<FilterToken, PropertyName> Property => from prop in AlphaNumeric
-                                                                             from subProps in (
-                                                                                 from _ in Token.EqualTo(FilterToken.LeftSquaredBracket)
-                                                                                 from subProp in AlphaNumeric.Between(Token.EqualTo(FilterToken.DoubleQuote), Token.EqualTo(FilterToken.DoubleQuote))
-                                                                                 from __ in Token.EqualTo(FilterToken.RightSquaredBracket)
-                                                                                 select $"""["{subProp.Value}"]"""
-                                                                             ).Many()
-                                                                             select new PropertyName(string.Concat(prop.Value, string.Concat(subProps)));
+    /// <summary>
+    /// Property name parser
+    /// </summary>
+    public static TokenListParser<FilterToken, PropertyName> Property => from prop in AlphaNumeric
+        from subProps in (
+            from _ in Token.EqualTo(FilterToken.LeftSquaredBracket)
+            from subProp in AlphaNumeric.Between(Token.EqualTo(FilterToken.DoubleQuote), Token.EqualTo(FilterToken.DoubleQuote))
+            from __ in Token.EqualTo(FilterToken.RightSquaredBracket)
+            select $"""["{subProp.Value}"]"""
+        ).Many()
+        select new PropertyName(string.Concat(prop.Value, string.Concat(subProps)));
 
-        /// <summary>
-        /// Parser for any text between double quotes <c>"</c>
-        /// </summary>
-        public static TokenListParser<FilterToken, TextExpression> Text => from _ in Token.EqualTo(FilterToken.DoubleQuote)
+    /// <summary>
+    /// Parser for any text between double quotes <c>"</c>
+    /// </summary>
+    public static TokenListParser<FilterToken, TextExpression> Text => from _ in Token.EqualTo(FilterToken.DoubleQuote)
 #if NETSTANDARD1_3
                                                                            from text in (Token.EqualTo(FilterToken.Letter)
                                                                                              .Or(Token.EqualTo(FilterToken.Digit))
                                                                                              .Or(Token.EqualTo(FilterToken.Escaped))
                                                                                              .Or(Token.EqualTo(FilterToken.None))).AtLeastOnce()
 #else
-                                                                           from text in Token.Matching<FilterToken>(token => token != FilterToken.DoubleQuote, "Any character or symbol except double quote character")
-                                                                                                                                                                .AtLeastOnce()
+        from text in Token.Matching<FilterToken>(token => token != FilterToken.DoubleQuote, "Any character or symbol except double quote character")
+            .AtLeastOnce()
 #endif
-                                                                           from __ in Token.EqualTo(FilterToken.DoubleQuote)
-                                                                           select new TextExpression(TokensToString(text));
+        from __ in Token.EqualTo(FilterToken.DoubleQuote)
+        select new TextExpression(TokensToString(text));
 
-        private static IEnumerable<char> ConvertRegexToCharArray(IEnumerable<BracketValue> values)
-            => values.Select(value =>
-                    value switch
-                    {
-                        RangeBracketValue rangeValue => Enumerable.Range(rangeValue.Start, rangeValue.End - rangeValue.Start + 1)
-                                                                  .Select(ascii => (char)ascii),
-                        ConstantBracketValue constantValue => [.. constantValue.Value],
+    private static IEnumerable<char> ConvertRegexToCharArray(IEnumerable<BracketValue> values)
+        => values.Select(value =>
+                value switch
+                {
+                    RangeBracketValue rangeValue => Enumerable.Range(rangeValue.Start, rangeValue.End - rangeValue.Start + 1)
+                        .Select(ascii => (char)ascii),
+                    ConstantBracketValue constantValue => [.. constantValue.Value],
 #if NET7_0_OR_GREATER
-                        _ => throw new UnreachableException("Unexpected regex value")
+                    _ => throw new UnreachableException("Unexpected regex value")
 #else
                         _ => throw new NotSupportedException("Unexpected regex value")
 #endif
-                    })
-                // Flatten collections
-                .SelectMany(chr => chr);
+                })
+            // Flatten collections
+            .SelectMany(chr => chr);
 
-        /// <summary>
-        /// Parser for expressions that contains one or more regex parts.
-        /// </summary>
-        public static TokenListParser<FilterToken, OneOfExpression> OneOf
-            => (
+    /// <summary>
+    /// Parser for expressions that contains one or more regex parts.
+    /// </summary>
+    public static TokenListParser<FilterToken, OneOfExpression> OneOf
+        => (
                 from head in Bracket
                 from body in Asterisk.Try().Cast<FilterToken, AsteriskExpression, FilterExpression>()
-                                        .Or(AlphaNumeric.Cast<FilterToken, ConstantValueExpression, FilterExpression>())
-                                        .OptionalOrDefault()
+                    .Or(AlphaNumeric.Cast<FilterToken, ConstantValueExpression, FilterExpression>())
+                    .OptionalOrDefault()
                 from tail in Bracket
                 select (head: (FilterExpression)head, (object)body, tail: (FilterExpression)tail)
-                ).Try()
-                .Or(
-                    from head in EndsWith.Try().Cast<FilterToken, EndsWithExpression, FilterExpression>()
-                                            .Or(StartsWith.Try().Cast<FilterToken, StartsWithExpression, FilterExpression>())
-                                            .Or(AlphaNumeric.Cast<FilterToken, ConstantValueExpression, FilterExpression>())
-                                            .Or(Asterisk.Cast<FilterToken, AsteriskExpression, FilterExpression>())
-                                            .OptionalOrDefault()
-                    from body in Bracket
-                    from tail in EndsWith.Try().Cast<FilterToken, EndsWithExpression, FilterExpression>()
-                                        .Or(StartsWith.Try().Cast<FilterToken, StartsWithExpression, FilterExpression>())
-                                        .Or(AlphaNumeric.Try().Cast<FilterToken, ConstantValueExpression, FilterExpression>())
-                                        .Or(Asterisk.Try().Cast<FilterToken, AsteriskExpression, FilterExpression>())
-                                        .OptionalOrDefault()
+            ).Try()
+            .Or(
+                from head in EndsWith.Try().Cast<FilterToken, EndsWithExpression, FilterExpression>()
+                    .Or(StartsWith.Try().Cast<FilterToken, StartsWithExpression, FilterExpression>())
+                    .Or(AlphaNumeric.Cast<FilterToken, ConstantValueExpression, FilterExpression>())
+                    .Or(Asterisk.Cast<FilterToken, AsteriskExpression, FilterExpression>())
+                    .OptionalOrDefault()
+                from body in Bracket
+                from tail in EndsWith.Try().Cast<FilterToken, EndsWithExpression, FilterExpression>()
+                    .Or(StartsWith.Try().Cast<FilterToken, StartsWithExpression, FilterExpression>())
+                    .Or(AlphaNumeric.Try().Cast<FilterToken, ConstantValueExpression, FilterExpression>())
+                    .Or(Asterisk.Try().Cast<FilterToken, AsteriskExpression, FilterExpression>())
+                    .OptionalOrDefault()
 
-                    select (head, body: (object)body, tail)
-                ).Try()
-                .Or(
-                    from head in EndsWith.Try().Cast<FilterToken, EndsWithExpression, FilterExpression>()
-                                            .Or(StartsWith.Try().Cast<FilterToken, StartsWithExpression, FilterExpression>())
-                                            .Or(Constant.Try())
-                                            .Or(Asterisk.Try().Cast<FilterToken, AsteriskExpression, FilterExpression>())
-                                            .OptionalOrDefault()
-                    from _ in Token.EqualTo(FilterToken.LeftCurlyBrace)
-                    from body in Constant.AtLeastOnceDelimitedBy(Token.EqualTo(FilterToken.Or))
-                    from __ in Token.EqualTo(FilterToken.RightCurlyBrace)
-                    from tail in EndsWith.Try().Cast<FilterToken, EndsWithExpression, FilterExpression>()
-                                            .Or(StartsWith.Try().Cast<FilterToken, StartsWithExpression, FilterExpression>())
-                                            .Or(Constant.Try())
-                                            .Or(Asterisk.Try().Cast<FilterToken, AsteriskExpression, FilterExpression>())
-                                            .OptionalOrDefault()
+                select (head, body: (object)body, tail)
+            ).Try()
+            .Or(
+                from head in EndsWith.Try().Cast<FilterToken, EndsWithExpression, FilterExpression>()
+                    .Or(StartsWith.Try().Cast<FilterToken, StartsWithExpression, FilterExpression>())
+                    .Or(Constant.Try())
+                    .Or(Asterisk.Try().Cast<FilterToken, AsteriskExpression, FilterExpression>())
+                    .OptionalOrDefault()
+                from _ in Token.EqualTo(FilterToken.LeftCurlyBrace)
+                from body in Constant.AtLeastOnceDelimitedBy(Token.EqualTo(FilterToken.Or))
+                from __ in Token.EqualTo(FilterToken.RightCurlyBrace)
+                from tail in EndsWith.Try().Cast<FilterToken, EndsWithExpression, FilterExpression>()
+                    .Or(StartsWith.Try().Cast<FilterToken, StartsWithExpression, FilterExpression>())
+                    .Or(Constant.Try())
+                    .Or(Asterisk.Try().Cast<FilterToken, AsteriskExpression, FilterExpression>())
+                    .OptionalOrDefault()
 
-                    select (head, body: (object)body.Select(item => item).OfType<ConstantValueExpression>().ToArray(), tail)
-                )
+                select (head, body: (object)body.Select(item => item).OfType<ConstantValueExpression>().ToArray(), tail)
+            )
             .Select(item =>
             {
                 return item switch
@@ -510,14 +510,14 @@
 
                     // <bracket><constant><bracket>
                     (BracketExpression head, ConstantValueExpression body, BracketExpression tail) => new OneOfExpression([ ..ConvertRegexToCharArray(head.Values).CrossJoin(ConvertRegexToCharArray(tail.Values))
-                                                                            .Select(tuple => (start: tuple.Item1, end: tuple.Item2))
-                                                                            .Select(tuple => new StringValueExpression($"{tuple.start}{body.Value}{tuple.end}"))
-                                                                            ]),
+                        .Select(tuple => (start: tuple.Item1, end: tuple.Item2))
+                        .Select(tuple => new StringValueExpression($"{tuple.start}{body.Value}{tuple.end}"))
+                    ]),
                     // <bracket><bracket>
                     (BracketExpression head, null, BracketExpression tail) => new OneOfExpression([..ConvertRegexToCharArray(head.Values).CrossJoin(ConvertRegexToCharArray(tail.Values))
-                                                                            .Select(tuple => (start: tuple.Item1, end: tuple.Item2))
-                                                                            .Select(tuple => new StringValueExpression($"{tuple.start}{tuple.end}"))
-                                                                            ]),
+                        .Select(tuple => (start: tuple.Item1, end: tuple.Item2))
+                        .Select(tuple => new StringValueExpression($"{tuple.start}{tuple.end}"))
+                    ]),
                     // <bracket><ends with>
                     (null, BracketExpression body, EndsWithExpression tail) => new OneOfExpression([.. ConvertRegexToCharArray(body.Values).Select(chr => new AndExpression(new StartsWithExpression(chr.ToString()), tail))]),
 
@@ -543,143 +543,143 @@
                 };
             });
 
-        /// <summary>
-        /// Parser for Date and Time
-        /// </summary>
-        /// <returns>a <see cref="DateTimeExpression"/></returns>
-        public static TokenListParser<FilterToken, DateTimeExpression> DateAndTime => (from date in Date
-                                                                                       from separator in Token.EqualToValue(FilterToken.Letter, "T")
-                                                                                                              .Or(Token.EqualTo(FilterToken.Whitespace))
-                                                                                       from time in Time
-                                                                                       from offset in Offset.OptionalOrDefault()
-                                                                                       select new DateTimeExpression(date,
-                                                                                                                     new TimeExpression(hours: time.Hours,
-                                                                                                                                        minutes: time.Minutes,
-                                                                                                                                        seconds: time.Seconds,
-                                                                                                                                        milliseconds: time.Milliseconds),
-                                                                                                                     offset)).Try()
-                                                                                      // DATE
-                                                                                      .Or(from date in Date
-                                                                                          select new DateTimeExpression(date)
-                                                                                        ).Try()
-                                                                                    // TIME
-                                                                                    .Or(from time in Time
-                                                                                        select new DateTimeExpression(time)
-            );
+    /// <summary>
+    /// Parser for Date and Time
+    /// </summary>
+    /// <returns>a <see cref="DateTimeExpression"/></returns>
+    public static TokenListParser<FilterToken, DateTimeExpression> DateAndTime => (from date in Date
+            from separator in Token.EqualToValue(FilterToken.Letter, "T")
+                .Or(Token.EqualTo(FilterToken.Whitespace))
+            from time in Time
+            from offset in Offset.OptionalOrDefault()
+            select new DateTimeExpression(date,
+                new TimeExpression(hours: time.Hours,
+                    minutes: time.Minutes,
+                    seconds: time.Seconds,
+                    milliseconds: time.Milliseconds),
+                offset)).Try()
+        // DATE
+        .Or(from date in Date
+            select new DateTimeExpression(date)
+        ).Try()
+        // TIME
+        .Or(from time in Time
+            select new DateTimeExpression(time)
+        );
 
-        private static TokenListParser<FilterToken, OffsetExpression> Offset => (from _ in Token.EqualToValue(FilterToken.Letter, "Z")
-                                                                                 select OffsetExpression.Zero).Try()
-                                                                          .Or(
-                                                                                from sign in MinusOrPlusSign.OptionalOrDefault()
-                                                                                from hourDigits in IntDigits(2)
-                                                                                from _ in Colon
-                                                                                from minuteDigits in IntDigits(2)
-                                                                                select new OffsetExpression(sign,
-                                                                                                            uint.Parse(TokensToString(hourDigits), CultureInfo.InvariantCulture),
-                                                                                                            uint.Parse(TokensToString(minuteDigits), CultureInfo.InvariantCulture)));
+    private static TokenListParser<FilterToken, OffsetExpression> Offset => (from _ in Token.EqualToValue(FilterToken.Letter, "Z")
+            select OffsetExpression.Zero).Try()
+        .Or(
+            from sign in MinusOrPlusSign.OptionalOrDefault()
+            from hourDigits in IntDigits(2)
+            from _ in Colon
+            from minuteDigits in IntDigits(2)
+            select new OffsetExpression(sign,
+                uint.Parse(TokensToString(hourDigits), CultureInfo.InvariantCulture),
+                uint.Parse(TokensToString(minuteDigits), CultureInfo.InvariantCulture)));
 
-        private static TokenListParser<FilterToken, Token<FilterToken>[]> IntDigits(int count) => Token.EqualTo(FilterToken.Digit).Repeat(count);
+    private static TokenListParser<FilterToken, Token<FilterToken>[]> IntDigits(int count) => Token.EqualTo(FilterToken.Digit).Repeat(count);
 
-        /// <summary>
-        /// Parser for "date" expressions.
-        /// </summary>
-        public static TokenListParser<FilterToken, DateExpression> Date => from year in IntDigits(4)
-                                                                           from _ in Dash
-                                                                           from month in IntDigits(2)
-                                                                           from __ in Dash
-                                                                           from day in IntDigits(2)
-                                                                           select new DateExpression(int.Parse(TokensToString(year), CultureInfo.InvariantCulture),
-                                                                                                     int.Parse(TokensToString(month), CultureInfo.InvariantCulture),
-                                                                                                     int.Parse(TokensToString(day), CultureInfo.InvariantCulture));
+    /// <summary>
+    /// Parser for "date" expressions.
+    /// </summary>
+    public static TokenListParser<FilterToken, DateExpression> Date => from year in IntDigits(4)
+        from _ in Dash
+        from month in IntDigits(2)
+        from __ in Dash
+        from day in IntDigits(2)
+        select new DateExpression(int.Parse(TokensToString(year), CultureInfo.InvariantCulture),
+            int.Parse(TokensToString(month), CultureInfo.InvariantCulture),
+            int.Parse(TokensToString(day), CultureInfo.InvariantCulture));
 
-        private static TokenListParser<FilterToken, Token<FilterToken>> Colon => Token.EqualTo(FilterToken.Colon);
+    private static TokenListParser<FilterToken, Token<FilterToken>> Colon => Token.EqualTo(FilterToken.Colon);
 
-        private static TokenListParser<FilterToken, Token<FilterToken>> Dash => Token.EqualTo(FilterToken.Dash);
+    private static TokenListParser<FilterToken, Token<FilterToken>> Dash => Token.EqualTo(FilterToken.Dash);
 
-        private static TokenListParser<FilterToken, Token<FilterToken>> MinusSign => Dash;
+    private static TokenListParser<FilterToken, Token<FilterToken>> MinusSign => Dash;
 
-        private static TokenListParser<FilterToken, Token<FilterToken>> PlusSign => Token.EqualToValue(FilterToken.None, "+");
+    private static TokenListParser<FilterToken, Token<FilterToken>> PlusSign => Token.EqualToValue(FilterToken.None, "+");
 
-        private static TokenListParser<FilterToken, NumericSign> MinusOrPlusSign => MinusSign.Or(PlusSign).Optional()
-                                                                                              .Select(token => token switch
-                                                                                              {
-                                                                                                  { Kind: FilterToken.Dash } => NumericSign.Minus,
-                                                                                                  _ => NumericSign.Plus
-                                                                                              });
+    private static TokenListParser<FilterToken, NumericSign> MinusOrPlusSign => MinusSign.Or(PlusSign).Optional()
+        .Select(token => token switch
+        {
+            { Kind: FilterToken.Dash } => NumericSign.Minus,
+            _ => NumericSign.Plus
+        });
 
-        /// <summary>
-        /// Parser for time expression.
-        /// </summary>
-        public static TokenListParser<FilterToken, TimeExpression> Time => (from hourDigits in IntDigits(2)
-                                                                            from _ in Colon
-                                                                            from minuteDigits in IntDigits(2)
-                                                                            from __ in Colon
-                                                                            from secondDigits in IntDigits(2)
-                                                                            from ___ in Token.EqualTo(FilterToken.Dot)
-                                                                            from milliseconds in Token.EqualTo(FilterToken.Digit).AtLeastOnce()
-                                                                            select new TimeExpression(int.Parse(TokensToString(hourDigits), CultureInfo.InvariantCulture),
-                                                                                                      int.Parse(TokensToString(minuteDigits), CultureInfo.InvariantCulture),
-                                                                                                      int.Parse(TokensToString(secondDigits), CultureInfo.InvariantCulture),
-                                                                                                      int.Parse(TokensToString(milliseconds), CultureInfo.InvariantCulture)))
-                                                                           .Try()
-                                                                           .Or(from hourDigits in IntDigits(2)
-                                                                               from _ in Colon
-                                                                               from minuteDigits in IntDigits(2)
-                                                                               from __ in Colon
-                                                                               from secondDigits in IntDigits(2)
-                                                                               select new TimeExpression(int.Parse(TokensToString(hourDigits), CultureInfo.InvariantCulture),
-                                                                                                         int.Parse(TokensToString(minuteDigits), CultureInfo.InvariantCulture),
-                                                                                                         int.Parse(TokensToString(secondDigits), CultureInfo.InvariantCulture)));
+    /// <summary>
+    /// Parser for time expression.
+    /// </summary>
+    public static TokenListParser<FilterToken, TimeExpression> Time => (from hourDigits in IntDigits(2)
+            from _ in Colon
+            from minuteDigits in IntDigits(2)
+            from __ in Colon
+            from secondDigits in IntDigits(2)
+            from ___ in Token.EqualTo(FilterToken.Dot)
+            from milliseconds in Token.EqualTo(FilterToken.Digit).AtLeastOnce()
+            select new TimeExpression(int.Parse(TokensToString(hourDigits), CultureInfo.InvariantCulture),
+                int.Parse(TokensToString(minuteDigits), CultureInfo.InvariantCulture),
+                int.Parse(TokensToString(secondDigits), CultureInfo.InvariantCulture),
+                int.Parse(TokensToString(milliseconds), CultureInfo.InvariantCulture)))
+        .Try()
+        .Or(from hourDigits in IntDigits(2)
+            from _ in Colon
+            from minuteDigits in IntDigits(2)
+            from __ in Colon
+            from secondDigits in IntDigits(2)
+            select new TimeExpression(int.Parse(TokensToString(hourDigits), CultureInfo.InvariantCulture),
+                int.Parse(TokensToString(minuteDigits), CultureInfo.InvariantCulture),
+                int.Parse(TokensToString(secondDigits), CultureInfo.InvariantCulture)));
 
-        /// <summary>
-        /// Parses all supported unary expressions
-        /// </summary>
-        private static TokenListParser<FilterToken, FilterExpression> UnaryExpression => Parse.OneOf(Parse.Ref(() => OneOf.Try().Cast<FilterToken, OneOfExpression, FilterExpression>()),
-                                                                                                     Parse.Ref(() => Not.Try().Cast<FilterToken, NotExpression, FilterExpression>()),
-                                                                                                     Parse.Ref(() => Group.Try().Cast<FilterToken, GroupExpression, FilterExpression>()),
-                                                                                                     Parse.Ref(() => Interval.Try().Cast<FilterToken, IntervalExpression, FilterExpression>()),
-                                                                                                     Parse.Ref(() => GlobalUniqueIdentifier.Try().Cast<FilterToken, GuidValueExpression, FilterExpression>()),
-                                                                                                     Parse.Ref(() => Duration.Try().Cast<FilterToken, DurationExpression, FilterExpression>()),
-                                                                                                     Parse.Ref(() => DateAndTime.Try().Cast<FilterToken, DateTimeExpression, FilterExpression>()),
-                                                                                                     Parse.Ref(() => Time.Try().Cast<FilterToken, TimeExpression, FilterExpression>()),
-                                                                                                     Parse.Ref(() => Date.Try().Cast<FilterToken, DateExpression, FilterExpression>()),
-                                                                                              // Special case of <constant>*<constant> which should be turned into an AndExpression
-                                                                                              // even though from a user perspective it's just a text filter with no specific logic in it
-                                                                                                    Parse.Ref(() => StartsAndEndsWith.Try().Cast<FilterToken, AndExpression, FilterExpression>()),
-                                                                                                    Parse.Ref(() => Contains.Try().Cast<FilterToken, ContainsExpression, FilterExpression>()),
-                                                                                                    Parse.Ref(() => EndsWith.Try().Cast<FilterToken, EndsWithExpression, FilterExpression>()),
-                                                                                                    Parse.Ref(() => StartsWith.Try().Cast<FilterToken, StartsWithExpression, FilterExpression>()),
-                                                                                                    Parse.Ref(() => Bool.Try().Cast<FilterToken, StringValueExpression, FilterExpression>()),
-                                                                                                    Parse.Ref(() => Text.Try().Cast<FilterToken, TextExpression, FilterExpression>()),
-                                                                                                    Parse.Ref(() => AlphaNumeric.Try().Cast<FilterToken, ConstantValueExpression, FilterExpression>()),
-                                                                                                    Parse.Ref(() => Number.Cast<FilterToken, NumericValueExpression, FilterExpression>()))
-            ;
+    /// <summary>
+    /// Parses all supported unary expressions
+    /// </summary>
+    private static TokenListParser<FilterToken, FilterExpression> UnaryExpression => Parse.OneOf(Parse.Ref(() => OneOf.Try().Cast<FilterToken, OneOfExpression, FilterExpression>()),
+        Parse.Ref(() => Not.Try().Cast<FilterToken, NotExpression, FilterExpression>()),
+        Parse.Ref(() => Group.Try().Cast<FilterToken, GroupExpression, FilterExpression>()),
+        Parse.Ref(() => Interval.Try().Cast<FilterToken, IntervalExpression, FilterExpression>()),
+        Parse.Ref(() => GlobalUniqueIdentifier.Try().Cast<FilterToken, GuidValueExpression, FilterExpression>()),
+        Parse.Ref(() => Duration.Try().Cast<FilterToken, DurationExpression, FilterExpression>()),
+        Parse.Ref(() => DateAndTime.Try().Cast<FilterToken, DateTimeExpression, FilterExpression>()),
+        Parse.Ref(() => Time.Try().Cast<FilterToken, TimeExpression, FilterExpression>()),
+        Parse.Ref(() => Date.Try().Cast<FilterToken, DateExpression, FilterExpression>()),
+        // Special case of <constant>*<constant> which should be turned into an AndExpression
+        // even though from a user perspective it's just a text filter with no specific logic in it
+        Parse.Ref(() => StartsAndEndsWith.Try().Cast<FilterToken, AndExpression, FilterExpression>()),
+        Parse.Ref(() => Contains.Try().Cast<FilterToken, ContainsExpression, FilterExpression>()),
+        Parse.Ref(() => EndsWith.Try().Cast<FilterToken, EndsWithExpression, FilterExpression>()),
+        Parse.Ref(() => StartsWith.Try().Cast<FilterToken, StartsWithExpression, FilterExpression>()),
+        Parse.Ref(() => Bool.Try().Cast<FilterToken, StringValueExpression, FilterExpression>()),
+        Parse.Ref(() => Text.Try().Cast<FilterToken, TextExpression, FilterExpression>()),
+        Parse.Ref(() => AlphaNumeric.Try().Cast<FilterToken, ConstantValueExpression, FilterExpression>()),
+        Parse.Ref(() => Number.Cast<FilterToken, NumericValueExpression, FilterExpression>()))
+    ;
 
-        /// <summary>
-        /// Handles special case of &lt;constant&gt;*&lt;constant&gt; which should be turned into a <see cref="AndExpression"/>
-        /// even though from user's perspective, it's just a text filter with no specific logic in it.
-        /// </summary>
-        private static TokenListParser<FilterToken, AndExpression> StartsAndEndsWith
-            => from alphaBeforeAsterisk in AlphaNumeric
-                from __ in Asterisk
-                from alphaAfterAsterisk in AlphaNumeric
-                select new StartsWithExpression(alphaBeforeAsterisk.Value) & new EndsWithExpression(alphaAfterAsterisk.Value);
+    /// <summary>
+    /// Handles special case of &lt;constant&gt;*&lt;constant&gt; which should be turned into a <see cref="AndExpression"/>
+    /// even though from user's perspective, it's just a text filter with no specific logic in it.
+    /// </summary>
+    private static TokenListParser<FilterToken, AndExpression> StartsAndEndsWith
+        => from alphaBeforeAsterisk in AlphaNumeric
+            from __ in Asterisk
+            from alphaAfterAsterisk in AlphaNumeric
+            select new StartsWithExpression(alphaBeforeAsterisk.Value) & new EndsWithExpression(alphaAfterAsterisk.Value);
 
-        /// <summary>
-        /// Parser for a <c>property=&lt;expression&gt;</c> pair.
-        /// </summary>
-        public static TokenListParser<FilterToken, (PropertyName, FilterExpression)> Criterion => from property in Property
-                                                                                                  from _ in Token.EqualTo(FilterToken.Equal)
-                                                                                                  from expression in BinaryOrUnaryExpression
-                                                                                                  select (new PropertyName(property.Name), expression);
+    /// <summary>
+    /// Parser for a <c>property=&lt;expression&gt;</c> pair.
+    /// </summary>
+    public static TokenListParser<FilterToken, (PropertyName, FilterExpression)> Criterion => from property in Property
+        from _ in Token.EqualTo(FilterToken.Equal)
+        from expression in BinaryOrUnaryExpression
+        select (new PropertyName(property.Name), expression);
 
-        /// <summary>
-        /// Parser for numeric expressions
-        /// </summary>
-        public static TokenListParser<FilterToken, NumericValueExpression> Number => FloatOrDouble.Try().Or(IntegerOrLong);
+    /// <summary>
+    /// Parser for numeric expressions
+    /// </summary>
+    public static TokenListParser<FilterToken, NumericValueExpression> Number => FloatOrDouble.Try().Or(IntegerOrLong);
 
-        private static TokenListParser<FilterToken, NumericValueExpression> FloatOrDouble
-            => (from sign in MinusOrPlusSign.Optional()
+    private static TokenListParser<FilterToken, NumericValueExpression> FloatOrDouble
+        => (from sign in MinusOrPlusSign.Optional()
                 from beforeDotDigits in Token.EqualTo(FilterToken.Digit).AtLeastOnce()
                 from _ in Token.EqualTo(FilterToken.Dot)
                 from afterDotDigits in Token.EqualTo(FilterToken.Digit).AtLeastOnce()
@@ -687,172 +687,171 @@
                 from exponentSign in MinusOrPlusSign.Optional()
                 from afterExponentSignDigits in IntegerOrLong
                 select new NumericValueExpression($"{ConvertSignToChar(sign)}{TokensToString(beforeDotDigits)}.{TokensToString(afterDotDigits)}E{ConvertSignToChar(exponentSign, true)}{afterExponentSignDigits.EscapedParseableString}"))
-                .Try()
-                .Or(
-                    from sign in MinusOrPlusSign.Optional()
-                    from beforeDotDigits in Token.EqualTo(FilterToken.Digit).AtLeastOnce()
-                    from __ in Token.EqualToValueIgnoreCase(FilterToken.Letter, "e")
-                    from exponentSign in MinusOrPlusSign.Optional()
-                    from afterExponentSignDigits in IntegerOrLong
-                    select new NumericValueExpression($"{ConvertSignToChar(sign)}{TokensToString(beforeDotDigits)}E{ConvertSignToChar(exponentSign, true)}{afterExponentSignDigits.EscapedParseableString}"))
-                .Try()
-                .Or(from sign in MinusOrPlusSign.Optional()
-                    from digitBeforeDot in Token.EqualTo(FilterToken.Digit).AtLeastOnce()
-                    from _ in Token.EqualTo(FilterToken.Dot)
-                    from digitAfterDot in Token.EqualTo(FilterToken.Digit).AtLeastOnce()
-                    from __ in Token.EqualToValueIgnoreCase(FilterToken.Letter, "d")
-                    select new NumericValueExpression($"{ConvertSignToChar(sign)}{TokensToString(digitBeforeDot)}.{TokensToString(digitAfterDot)}"))
-                .Try()
-                .Or(
-                     from sign in MinusOrPlusSign.Optional()
-                     from digitBeforeDot in Token.EqualTo(FilterToken.Digit).AtLeastOnce()
-                     from _ in Token.EqualTo(FilterToken.Dot)
-                     from digitAfterDot in Token.EqualTo(FilterToken.Digit).AtLeastOnce()
-                     from __ in Token.EqualToValueIgnoreCase(FilterToken.Letter, "f")
-                     select new NumericValueExpression($"{ConvertSignToChar(sign)}{TokensToString(digitBeforeDot)}.{TokensToString(digitAfterDot)}"))
-                .Try()
-                .Or(
-                    from sign in MinusOrPlusSign.Optional()
-                    from digitBeforeDot in Token.EqualTo(FilterToken.Digit).AtLeastOnce()
-                    from _ in Token.EqualTo(FilterToken.Dot)
-                    from digitAfterDot in Token.EqualTo(FilterToken.Digit).AtLeastOnce()
-                    select new NumericValueExpression($"{ConvertSignToChar(sign)}{TokensToString(digitBeforeDot)}.{TokensToString(digitAfterDot)}")
-                )
-                .Try()
-                .Or(
-                    from sign in MinusOrPlusSign.Optional()
-                    from value in Token.EqualTo(FilterToken.Digit).AtLeastOnce()
-                    from __ in Token.EqualToValueIgnoreCase(FilterToken.Letter, "d")
-                    select new NumericValueExpression($"{ConvertSignToChar(sign)}{value}")
-                );
+            .Try()
+            .Or(
+                from sign in MinusOrPlusSign.Optional()
+                from beforeDotDigits in Token.EqualTo(FilterToken.Digit).AtLeastOnce()
+                from __ in Token.EqualToValueIgnoreCase(FilterToken.Letter, "e")
+                from exponentSign in MinusOrPlusSign.Optional()
+                from afterExponentSignDigits in IntegerOrLong
+                select new NumericValueExpression($"{ConvertSignToChar(sign)}{TokensToString(beforeDotDigits)}E{ConvertSignToChar(exponentSign, true)}{afterExponentSignDigits.EscapedParseableString}"))
+            .Try()
+            .Or(from sign in MinusOrPlusSign.Optional()
+                from digitBeforeDot in Token.EqualTo(FilterToken.Digit).AtLeastOnce()
+                from _ in Token.EqualTo(FilterToken.Dot)
+                from digitAfterDot in Token.EqualTo(FilterToken.Digit).AtLeastOnce()
+                from __ in Token.EqualToValueIgnoreCase(FilterToken.Letter, "d")
+                select new NumericValueExpression($"{ConvertSignToChar(sign)}{TokensToString(digitBeforeDot)}.{TokensToString(digitAfterDot)}"))
+            .Try()
+            .Or(
+                from sign in MinusOrPlusSign.Optional()
+                from digitBeforeDot in Token.EqualTo(FilterToken.Digit).AtLeastOnce()
+                from _ in Token.EqualTo(FilterToken.Dot)
+                from digitAfterDot in Token.EqualTo(FilterToken.Digit).AtLeastOnce()
+                from __ in Token.EqualToValueIgnoreCase(FilterToken.Letter, "f")
+                select new NumericValueExpression($"{ConvertSignToChar(sign)}{TokensToString(digitBeforeDot)}.{TokensToString(digitAfterDot)}"))
+            .Try()
+            .Or(
+                from sign in MinusOrPlusSign.Optional()
+                from digitBeforeDot in Token.EqualTo(FilterToken.Digit).AtLeastOnce()
+                from _ in Token.EqualTo(FilterToken.Dot)
+                from digitAfterDot in Token.EqualTo(FilterToken.Digit).AtLeastOnce()
+                select new NumericValueExpression($"{ConvertSignToChar(sign)}{TokensToString(digitBeforeDot)}.{TokensToString(digitAfterDot)}")
+            )
+            .Try()
+            .Or(
+                from sign in MinusOrPlusSign.Optional()
+                from value in Token.EqualTo(FilterToken.Digit).AtLeastOnce()
+                from __ in Token.EqualToValueIgnoreCase(FilterToken.Letter, "d")
+                select new NumericValueExpression($"{ConvertSignToChar(sign)}{value}")
+            );
 
-        private static TokenListParser<FilterToken, NumericValueExpression> IntegerOrLong
-            => (from sign in MinusOrPlusSign.Optional()
+    private static TokenListParser<FilterToken, NumericValueExpression> IntegerOrLong
+        => (from sign in MinusOrPlusSign.Optional()
                 from digits in Token.EqualTo(FilterToken.Digit).AtLeastOnce()
                 from hint in Token.EqualToValueIgnoreCase(FilterToken.Letter, "L")
                 select new NumericValueExpression($"{ConvertSignToChar(sign)}{TokensToString(digits)}"))
-        .Try()
+            .Try()
             .Or(from sign in MinusOrPlusSign.Optional()
                 from digits in Token.EqualTo(FilterToken.Digit).AtLeastOnce()
                 from hint in Token.EqualToValueIgnoreCase(FilterToken.Letter, "L")
                 select new NumericValueExpression($"{ConvertSignToChar(sign)}{TokensToString(digits)}"))
-                .Try()
-                .Or(
-                    from sign in MinusOrPlusSign.Optional()
-                    from digits in Token.EqualTo(FilterToken.Digit).AtLeastOnce()
-                    select new NumericValueExpression($"{ConvertSignToChar(sign)}{TokensToString(digits)}")
-                )
-            ;
+            .Try()
+            .Or(
+                from sign in MinusOrPlusSign.Optional()
+                from digits in Token.EqualTo(FilterToken.Digit).AtLeastOnce()
+                select new NumericValueExpression($"{ConvertSignToChar(sign)}{TokensToString(digits)}")
+            )
+    ;
 
-        private static string ConvertSignToChar(NumericSign? sign, bool mustOutputSign = false)
-            => sign switch
-            {
-                NumericSign.Minus => "-",
-                _ => mustOutputSign ? "+" : string.Empty
-            };
-
-        /// <summary>
-        /// Parser for many <see cref="Criterion"/> separated by <c>&amp;</c>.
-        /// </summary>
-        public static TokenListParser<FilterToken, (PropertyName, FilterExpression)[]> Criteria
-            => from criteria in Criterion.ManyDelimitedBy(Token.EqualTo(FilterToken.Ampersand))
-               select criteria;
-
-        private static TokenListParser<FilterToken, StringValueExpression> Punctuation =>
-        (
-            from c in Token.EqualTo(FilterToken.Dot)
-            select new StringValueExpression(c.ToStringValue())
-        ).Or(
-                from c in Token.EqualTo(FilterToken.Colon)
-                select new StringValueExpression(c.ToStringValue())
-        ).Or(
-            from c in Token.EqualTo(FilterToken.Dash)
-            select new StringValueExpression(c.ToStringValue())
-        ).Or(
-            from c in Token.EqualTo(FilterToken.Underscore)
-            select new StringValueExpression(c.ToStringValue())
-        );
-
-        private static TokenListParser<FilterToken, GuidValueExpression> GlobalUniqueIdentifier
-            => from chr1 in Token.EqualTo(FilterToken.Letter).Try().Or(Token.EqualTo(FilterToken.Digit))
-               from chr2 in Token.EqualTo(FilterToken.Letter).Try().Or(Token.EqualTo(FilterToken.Digit))
-               from chr3 in Token.EqualTo(FilterToken.Letter).Try().Or(Token.EqualTo(FilterToken.Digit))
-               from chr4 in Token.EqualTo(FilterToken.Letter).Try().Or(Token.EqualTo(FilterToken.Digit))
-               from chr5 in Token.EqualTo(FilterToken.Letter).Try().Or(Token.EqualTo(FilterToken.Digit))
-               from chr6 in Token.EqualTo(FilterToken.Letter).Try().Or(Token.EqualTo(FilterToken.Digit))
-               from chr7 in Token.EqualTo(FilterToken.Letter).Try().Or(Token.EqualTo(FilterToken.Digit))
-               from chr8 in Token.EqualTo(FilterToken.Letter).Try().Or(Token.EqualTo(FilterToken.Digit))
-               from _ in Token.EqualTo(FilterToken.Dash)
-               from chr9 in Token.EqualTo(FilterToken.Letter).Try().Or(Token.EqualTo(FilterToken.Digit))
-               from chr10 in Token.EqualTo(FilterToken.Letter).Try().Or(Token.EqualTo(FilterToken.Digit))
-               from chr11 in Token.EqualTo(FilterToken.Letter).Try().Or(Token.EqualTo(FilterToken.Digit))
-               from chr12 in Token.EqualTo(FilterToken.Letter).Try().Or(Token.EqualTo(FilterToken.Digit))
-               from __ in Token.EqualTo(FilterToken.Dash)
-               from chr13 in Token.EqualTo(FilterToken.Letter).Try().Or(Token.EqualTo(FilterToken.Digit))
-               from chr14 in Token.EqualTo(FilterToken.Letter).Try().Or(Token.EqualTo(FilterToken.Digit))
-               from chr15 in Token.EqualTo(FilterToken.Letter).Try().Or(Token.EqualTo(FilterToken.Digit))
-               from chr16 in Token.EqualTo(FilterToken.Letter).Try().Or(Token.EqualTo(FilterToken.Digit))
-               from ___ in Token.EqualTo(FilterToken.Dash)
-               from chr17 in Token.EqualTo(FilterToken.Letter).Try().Or(Token.EqualTo(FilterToken.Digit))
-               from chr18 in Token.EqualTo(FilterToken.Letter).Try().Or(Token.EqualTo(FilterToken.Digit))
-               from chr19 in Token.EqualTo(FilterToken.Letter).Try().Or(Token.EqualTo(FilterToken.Digit))
-               from chr20 in Token.EqualTo(FilterToken.Letter).Try().Or(Token.EqualTo(FilterToken.Digit))
-               from ____ in Token.EqualTo(FilterToken.Dash)
-               from chr21 in Token.EqualTo(FilterToken.Letter).Try().Or(Token.EqualTo(FilterToken.Digit))
-               from chr22 in Token.EqualTo(FilterToken.Letter).Try().Or(Token.EqualTo(FilterToken.Digit))
-               from chr23 in Token.EqualTo(FilterToken.Letter).Try().Or(Token.EqualTo(FilterToken.Digit))
-               from chr24 in Token.EqualTo(FilterToken.Letter).Try().Or(Token.EqualTo(FilterToken.Digit))
-               from chr25 in Token.EqualTo(FilterToken.Letter).Try().Or(Token.EqualTo(FilterToken.Digit))
-               from chr26 in Token.EqualTo(FilterToken.Letter).Try().Or(Token.EqualTo(FilterToken.Digit))
-               from chr27 in Token.EqualTo(FilterToken.Letter).Try().Or(Token.EqualTo(FilterToken.Digit))
-               from chr28 in Token.EqualTo(FilterToken.Letter).Try().Or(Token.EqualTo(FilterToken.Digit))
-               from chr29 in Token.EqualTo(FilterToken.Letter).Try().Or(Token.EqualTo(FilterToken.Digit))
-               from chr30 in Token.EqualTo(FilterToken.Letter).Try().Or(Token.EqualTo(FilterToken.Digit))
-               from chr31 in Token.EqualTo(FilterToken.Letter).Try().Or(Token.EqualTo(FilterToken.Digit))
-               from chr32 in Token.EqualTo(FilterToken.Letter).Try().Or(Token.EqualTo(FilterToken.Digit))
-               select new GuidValueExpression($"{TokensToString([chr1, chr2, chr3, chr4, chr5, chr6, chr7, chr8 ])}-{TokensToString([chr9, chr10, chr11, chr12 ])}-{TokensToString([chr13, chr14, chr15, chr16 ])}-{TokensToString([chr17, chr18, chr19, chr20 ])}-{TokensToString([chr21, chr22, chr23, chr24, chr25, chr26, chr27, chr28, chr29, chr30, chr31, chr32 ])}");
-
-        /// <summary>
-        /// Parser for duration
-        /// </summary>
-        public static TokenListParser<FilterToken, DurationExpression> Duration => from p in Token.EqualToValue(FilterToken.Letter, "P")
-
-                                                                                   from years in DurationPart("Y").OptionalOrDefault().Try()
-                                                                                   from months in DurationPart("M").OptionalOrDefault().Try()
-                                                                                   from weeks in DurationPart("W").OptionalOrDefault().Try()
-                                                                                   from days in DurationPart("D").OptionalOrDefault().Try()
-
-                                                                                   from timeSeparator in Token.EqualToValue(FilterToken.Letter, "T")
-
-                                                                                   from hours in DurationPart("H").OptionalOrDefault().Try()
-                                                                                   from minutes in DurationPart("M").OptionalOrDefault().Try()
-                                                                                   from seconds in DurationPart("S").OptionalOrDefault().Try()
-
-                                                                                   where years is not null
-                                                                                         || months is not null
-                                                                                         || weeks is not null
-                                                                                         || days is not null
-                                                                                         || hours is not null
-                                                                                         || minutes is not null
-                                                                                         || seconds is not null
-
-                                                                                   select new DurationExpression(years: years is not null ? int.Parse(years.Value, CultureInfo.InvariantCulture) : 0,
-                                                                                                                 months: months is not null ? int.Parse(months.Value, CultureInfo.InvariantCulture) : 0,
-                                                                                                                 weeks: weeks is not null ? int.Parse(weeks.Value, CultureInfo.InvariantCulture) : 0,
-                                                                                                                 days: days is not null ? int.Parse(days.Value, CultureInfo.InvariantCulture) : 0,
-                                                                                                                 hours: hours is not null ? int.Parse(hours.Value, CultureInfo.InvariantCulture) : 0,
-                                                                                                                 minutes: minutes is not null ? int.Parse(minutes.Value, CultureInfo.InvariantCulture) : 0,
-                                                                                                                 seconds: seconds is not null ? int.Parse(seconds.Value, CultureInfo.InvariantCulture) : 0);
-
-        private static TokenListParser<FilterToken, NumericValueExpression> DurationPart(string designator) => from n in IntegerOrLong
-                                                                                                               from _ in Token.EqualToValue(FilterToken.Letter, designator).Try()
-                                                                                                               select n;
-
-        private static string TokensToString(IEnumerable<Token<FilterToken>> tokens)
+    private static string ConvertSignToChar(NumericSign? sign, bool mustOutputSign = false)
+        => sign switch
         {
-            return string.Concat(tokens.Select(TokenToString));
+            NumericSign.Minus => "-",
+            _ => mustOutputSign ? "+" : string.Empty
+        };
 
-            static string TokenToString(Token<FilterToken> token) => token.ToStringValue();
-        }
+    /// <summary>
+    /// Parser for many <see cref="Criterion"/> separated by <c>&amp;</c>.
+    /// </summary>
+    public static TokenListParser<FilterToken, (PropertyName, FilterExpression)[]> Criteria
+        => from criteria in Criterion.ManyDelimitedBy(Token.EqualTo(FilterToken.Ampersand))
+            select criteria;
+
+    private static TokenListParser<FilterToken, StringValueExpression> Punctuation =>
+    (
+        from c in Token.EqualTo(FilterToken.Dot)
+        select new StringValueExpression(c.ToStringValue())
+    ).Or(
+        from c in Token.EqualTo(FilterToken.Colon)
+        select new StringValueExpression(c.ToStringValue())
+    ).Or(
+        from c in Token.EqualTo(FilterToken.Dash)
+        select new StringValueExpression(c.ToStringValue())
+    ).Or(
+        from c in Token.EqualTo(FilterToken.Underscore)
+        select new StringValueExpression(c.ToStringValue())
+    );
+
+    private static TokenListParser<FilterToken, GuidValueExpression> GlobalUniqueIdentifier
+        => from chr1 in Token.EqualTo(FilterToken.Letter).Try().Or(Token.EqualTo(FilterToken.Digit))
+            from chr2 in Token.EqualTo(FilterToken.Letter).Try().Or(Token.EqualTo(FilterToken.Digit))
+            from chr3 in Token.EqualTo(FilterToken.Letter).Try().Or(Token.EqualTo(FilterToken.Digit))
+            from chr4 in Token.EqualTo(FilterToken.Letter).Try().Or(Token.EqualTo(FilterToken.Digit))
+            from chr5 in Token.EqualTo(FilterToken.Letter).Try().Or(Token.EqualTo(FilterToken.Digit))
+            from chr6 in Token.EqualTo(FilterToken.Letter).Try().Or(Token.EqualTo(FilterToken.Digit))
+            from chr7 in Token.EqualTo(FilterToken.Letter).Try().Or(Token.EqualTo(FilterToken.Digit))
+            from chr8 in Token.EqualTo(FilterToken.Letter).Try().Or(Token.EqualTo(FilterToken.Digit))
+            from _ in Token.EqualTo(FilterToken.Dash)
+            from chr9 in Token.EqualTo(FilterToken.Letter).Try().Or(Token.EqualTo(FilterToken.Digit))
+            from chr10 in Token.EqualTo(FilterToken.Letter).Try().Or(Token.EqualTo(FilterToken.Digit))
+            from chr11 in Token.EqualTo(FilterToken.Letter).Try().Or(Token.EqualTo(FilterToken.Digit))
+            from chr12 in Token.EqualTo(FilterToken.Letter).Try().Or(Token.EqualTo(FilterToken.Digit))
+            from __ in Token.EqualTo(FilterToken.Dash)
+            from chr13 in Token.EqualTo(FilterToken.Letter).Try().Or(Token.EqualTo(FilterToken.Digit))
+            from chr14 in Token.EqualTo(FilterToken.Letter).Try().Or(Token.EqualTo(FilterToken.Digit))
+            from chr15 in Token.EqualTo(FilterToken.Letter).Try().Or(Token.EqualTo(FilterToken.Digit))
+            from chr16 in Token.EqualTo(FilterToken.Letter).Try().Or(Token.EqualTo(FilterToken.Digit))
+            from ___ in Token.EqualTo(FilterToken.Dash)
+            from chr17 in Token.EqualTo(FilterToken.Letter).Try().Or(Token.EqualTo(FilterToken.Digit))
+            from chr18 in Token.EqualTo(FilterToken.Letter).Try().Or(Token.EqualTo(FilterToken.Digit))
+            from chr19 in Token.EqualTo(FilterToken.Letter).Try().Or(Token.EqualTo(FilterToken.Digit))
+            from chr20 in Token.EqualTo(FilterToken.Letter).Try().Or(Token.EqualTo(FilterToken.Digit))
+            from ____ in Token.EqualTo(FilterToken.Dash)
+            from chr21 in Token.EqualTo(FilterToken.Letter).Try().Or(Token.EqualTo(FilterToken.Digit))
+            from chr22 in Token.EqualTo(FilterToken.Letter).Try().Or(Token.EqualTo(FilterToken.Digit))
+            from chr23 in Token.EqualTo(FilterToken.Letter).Try().Or(Token.EqualTo(FilterToken.Digit))
+            from chr24 in Token.EqualTo(FilterToken.Letter).Try().Or(Token.EqualTo(FilterToken.Digit))
+            from chr25 in Token.EqualTo(FilterToken.Letter).Try().Or(Token.EqualTo(FilterToken.Digit))
+            from chr26 in Token.EqualTo(FilterToken.Letter).Try().Or(Token.EqualTo(FilterToken.Digit))
+            from chr27 in Token.EqualTo(FilterToken.Letter).Try().Or(Token.EqualTo(FilterToken.Digit))
+            from chr28 in Token.EqualTo(FilterToken.Letter).Try().Or(Token.EqualTo(FilterToken.Digit))
+            from chr29 in Token.EqualTo(FilterToken.Letter).Try().Or(Token.EqualTo(FilterToken.Digit))
+            from chr30 in Token.EqualTo(FilterToken.Letter).Try().Or(Token.EqualTo(FilterToken.Digit))
+            from chr31 in Token.EqualTo(FilterToken.Letter).Try().Or(Token.EqualTo(FilterToken.Digit))
+            from chr32 in Token.EqualTo(FilterToken.Letter).Try().Or(Token.EqualTo(FilterToken.Digit))
+            select new GuidValueExpression($"{TokensToString([chr1, chr2, chr3, chr4, chr5, chr6, chr7, chr8 ])}-{TokensToString([chr9, chr10, chr11, chr12 ])}-{TokensToString([chr13, chr14, chr15, chr16 ])}-{TokensToString([chr17, chr18, chr19, chr20 ])}-{TokensToString([chr21, chr22, chr23, chr24, chr25, chr26, chr27, chr28, chr29, chr30, chr31, chr32 ])}");
+
+    /// <summary>
+    /// Parser for duration
+    /// </summary>
+    public static TokenListParser<FilterToken, DurationExpression> Duration => from p in Token.EqualToValue(FilterToken.Letter, "P")
+
+        from years in DurationPart("Y").OptionalOrDefault().Try()
+        from months in DurationPart("M").OptionalOrDefault().Try()
+        from weeks in DurationPart("W").OptionalOrDefault().Try()
+        from days in DurationPart("D").OptionalOrDefault().Try()
+
+        from timeSeparator in Token.EqualToValue(FilterToken.Letter, "T")
+
+        from hours in DurationPart("H").OptionalOrDefault().Try()
+        from minutes in DurationPart("M").OptionalOrDefault().Try()
+        from seconds in DurationPart("S").OptionalOrDefault().Try()
+
+        where years is not null
+              || months is not null
+              || weeks is not null
+              || days is not null
+              || hours is not null
+              || minutes is not null
+              || seconds is not null
+
+        select new DurationExpression(years: years is not null ? int.Parse(years.Value, CultureInfo.InvariantCulture) : 0,
+            months: months is not null ? int.Parse(months.Value, CultureInfo.InvariantCulture) : 0,
+            weeks: weeks is not null ? int.Parse(weeks.Value, CultureInfo.InvariantCulture) : 0,
+            days: days is not null ? int.Parse(days.Value, CultureInfo.InvariantCulture) : 0,
+            hours: hours is not null ? int.Parse(hours.Value, CultureInfo.InvariantCulture) : 0,
+            minutes: minutes is not null ? int.Parse(minutes.Value, CultureInfo.InvariantCulture) : 0,
+            seconds: seconds is not null ? int.Parse(seconds.Value, CultureInfo.InvariantCulture) : 0);
+
+    private static TokenListParser<FilterToken, NumericValueExpression> DurationPart(string designator) => from n in IntegerOrLong
+        from _ in Token.EqualToValue(FilterToken.Letter, designator).Try()
+        select n;
+
+    private static string TokensToString(IEnumerable<Token<FilterToken>> tokens)
+    {
+        return string.Concat(tokens.Select(TokenToString));
+
+        static string TokenToString(Token<FilterToken> token) => token.ToStringValue();
     }
 }

--- a/src/DataFilters/Grammar/Parsing/FilterTokenizer.cs
+++ b/src/DataFilters/Grammar/Parsing/FilterTokenizer.cs
@@ -1,372 +1,371 @@
-﻿namespace DataFilters.Grammar.Parsing
+﻿namespace DataFilters.Grammar.Parsing;
+
+using System.Collections.Generic;
+using System.Linq;
+using Superpower;
+using Superpower.Model;
+using static FilterToken;
+
+/// <summary>
+/// <see cref="FilterTokenizer"/> is the base class used to "tokenize" a string.
+/// </summary>
+/// <remarks>
+/// The tokenizer reads a string input and associated to one or more character a <see cref="FilterToken"/> which is the first step in the process of building <see cref="IFilter"/> instances.
+/// </remarks>
+public class FilterTokenizer : Tokenizer<FilterToken>
 {
-    using System.Collections.Generic;
-    using System.Linq;
-    using Superpower;
-    using Superpower.Model;
-    using static FilterToken;
+    private TokenizerMode _mode;
 
     /// <summary>
-    /// <see cref="FilterTokenizer"/> is the base class used to "tokenize" a string.
+    /// The <c>_</c> character
     /// </summary>
-    /// <remarks>
-    /// The tokenizer reads a string input and associated to one or more character a <see cref="FilterToken"/> which is the first step in the process of building <see cref="IFilter"/> instances.
-    /// </remarks>
-    public class FilterTokenizer : Tokenizer<FilterToken>
+    private const char Underscore = '_';
+
+    /// <summary>
+    /// The <c>*</c> character
+    /// </summary>
+    internal const char Asterisk = '*';
+
+    /// <summary>
+    /// The <c>=</c> character
+    /// </summary>
+    private const char EqualSign = '=';
+
+    /// <summary>
+    /// The <c>(</c> character
+    /// </summary>
+    private const char LeftParenthesis = '(';
+
+    /// <summary>
+    /// The <c>)</c> character
+    /// </summary>
+    private const char RightParenthesis = ')';
+
+    /// <summary>
+    /// The <c>[</c> character
+    /// </summary>
+    private const char LeftSquareBracket = '[';
+
+    /// <summary>
+    /// The <c>{</c> character
+    /// </summary>
+    private const char LeftCurlyBracket = '{';
+
+    /// <summary>
+    /// The <c>}</c> character
+    /// </summary>
+    private const char RightCurlyBracket = '}';
+
+    /// <summary>
+    /// The <c>]</c> character
+    /// </summary>
+    private const char RightSquareBracket = ']';
+
+    /// <summary>
+    /// The <c>-</c> character
+    /// </summary>
+    private const char Hyphen = '-';
+
+    /// <summary>
+    /// The <c>\</c> character
+    /// </summary>
+    public const char BackSlash = '\\';
+
+    /// <summary>
+    /// The <c>|</c> character
+    /// </summary>
+    private const char Pipe = '|';
+
+    /// <summary>
+    /// The <c>,</c> character
+    /// </summary>
+    private const char Comma = ',';
+
+    /// <summary>
+    /// The <c>!</c> character
+    /// </summary>
+    private const char Bang = '!';
+
+    /// <summary>
+    /// The <c>"</c> character
+    /// </summary>
+    public const char DoubleQuote = '"';
+
+    /// <summary>
+    /// The <c>&#38;</c> character
+    /// </summary>
+    private const char Ampersand = '&';
+
+    /// <summary>
+    /// The <c>.</c> character.
+    /// </summary>
+    private const char Dot = '.';
+
+    /// <summary>
+    /// The space character
+    /// </summary>
+    private const char Space = ' ';
+
+    /// <summary>
+    /// The character to use to escape a special character.
+    /// </summary>
+    public const char EscapedCharacter = BackSlash;
+
+    /// <summary>
+    /// List of characters that have a special meaning and should be escaped
+    /// </summary>
+    public static readonly char[] SpecialCharacters =
+    [
+        Asterisk,
+        EqualSign,
+        LeftParenthesis,
+        RightParenthesis,
+        LeftSquareBracket,
+        RightSquareBracket,
+        BackSlash,
+        Pipe,
+        Comma,
+        Bang,
+        DoubleQuote,
+        Ampersand,
+        RightCurlyBracket,
+        LeftCurlyBracket,
+        ':',
+        Hyphen,
+        Dot,
+        Space
+    ];
+
+    /// <summary>
+    /// Custom <see cref="Tokenizer{TKind}"/> implementation that serves as the foundation of parsing text.
+    /// </summary>
+    public FilterTokenizer() => _mode = TokenizerMode.Normal;
+
+    ///<inheritdoc/>
+    protected override IEnumerable<Result<FilterToken>> Tokenize(TextSpan span, TokenizationState<FilterToken> state)
     {
-        private TokenizerMode _mode;
+        Result<char> next = span.ConsumeChar();
 
-        /// <summary>
-        /// The <c>_</c> character
-        /// </summary>
-        private const char Underscore = '_';
-
-        /// <summary>
-        /// The <c>*</c> character
-        /// </summary>
-        internal const char Asterisk = '*';
-
-        /// <summary>
-        /// The <c>=</c> character
-        /// </summary>
-        private const char EqualSign = '=';
-
-        /// <summary>
-        /// The <c>(</c> character
-        /// </summary>
-        private const char LeftParenthesis = '(';
-
-        /// <summary>
-        /// The <c>)</c> character
-        /// </summary>
-        private const char RightParenthesis = ')';
-
-        /// <summary>
-        /// The <c>[</c> character
-        /// </summary>
-        private const char LeftSquareBracket = '[';
-
-        /// <summary>
-        /// The <c>{</c> character
-        /// </summary>
-        private const char LeftCurlyBracket = '{';
-
-        /// <summary>
-        /// The <c>}</c> character
-        /// </summary>
-        private const char RightCurlyBracket = '}';
-
-        /// <summary>
-        /// The <c>]</c> character
-        /// </summary>
-        private const char RightSquareBracket = ']';
-
-        /// <summary>
-        /// The <c>-</c> character
-        /// </summary>
-        private const char Hyphen = '-';
-
-        /// <summary>
-        /// The <c>\</c> character
-        /// </summary>
-        public const char BackSlash = '\\';
-
-        /// <summary>
-        /// The <c>|</c> character
-        /// </summary>
-        private const char Pipe = '|';
-
-        /// <summary>
-        /// The <c>,</c> character
-        /// </summary>
-        private const char Comma = ',';
-
-        /// <summary>
-        /// The <c>!</c> character
-        /// </summary>
-        private const char Bang = '!';
-
-        /// <summary>
-        /// The <c>"</c> character
-        /// </summary>
-        public const char DoubleQuote = '"';
-
-        /// <summary>
-        /// The <c>&#38;</c> character
-        /// </summary>
-        private const char Ampersand = '&';
-
-        /// <summary>
-        /// The <c>.</c> character.
-        /// </summary>
-        private const char Dot = '.';
-
-        /// <summary>
-        /// The space character
-        /// </summary>
-        private const char Space = ' ';
-
-        /// <summary>
-        /// The character to use to escape a special character.
-        /// </summary>
-        public const char EscapedCharacter = BackSlash;
-
-        /// <summary>
-        /// List of characters that have a special meaning and should be escaped
-        /// </summary>
-        public static readonly char[] SpecialCharacters =
-        [
-            Asterisk,
-            EqualSign,
-            LeftParenthesis,
-            RightParenthesis,
-            LeftSquareBracket,
-            RightSquareBracket,
-            BackSlash,
-            Pipe,
-            Comma,
-            Bang,
-            DoubleQuote,
-            Ampersand,
-            RightCurlyBracket,
-            LeftCurlyBracket,
-            ':',
-            Hyphen,
-            Dot,
-            Space
-        ];
-
-        /// <summary>
-        /// Custom <see cref="Tokenizer{TKind}"/> implementation that serves as the foundation of parsing text.
-        /// </summary>
-        public FilterTokenizer() => _mode = TokenizerMode.Normal;
-
-        ///<inheritdoc/>
-        protected override IEnumerable<Result<FilterToken>> Tokenize(TextSpan span, TokenizationState<FilterToken> state)
+        if (!next.HasValue)
         {
-            Result<char> next = span.ConsumeChar();
+            yield break;
+        }
 
-            if (!next.HasValue)
+        do
+        {
+            switch (next.Value)
             {
-                yield break;
-            }
-
-            do
-            {
-                switch (next.Value)
+                case var c when char.IsLetter(c):
                 {
-                    case var c when char.IsLetter(c):
-                    {
-                        yield return Result.Value(Letter, next.Location, next.Remainder);
-                        next = next.Remainder.ConsumeChar();
-                        break;
-                    }
+                    yield return Result.Value(Letter, next.Location, next.Remainder);
+                    next = next.Remainder.ConsumeChar();
+                    break;
+                }
 
-                    case var c when char.IsDigit(c):
+                case var c when char.IsDigit(c):
+                {
+                    yield return Result.Value(Digit, next.Location, next.Remainder);
+                    next = next.Remainder.ConsumeChar();
+                    break;
+                }
+                case Underscore:
+                {
+                    yield return Result.Value(_mode switch { TokenizerMode.Normal => FilterToken.Underscore, _ => Escaped },
+                        next.Location,
+                        next.Remainder);
+                    next = next.Remainder.ConsumeChar();
+                    break;
+                }
+                case Pipe:
+                {
+                    yield return Result.Value(_mode switch { TokenizerMode.Normal => Or, _ => Escaped },
+                        next.Location,
+                        next.Remainder);
+                    next = next.Remainder.ConsumeChar();
+                    break;
+                }
+                case Comma:
+                {
+                    yield return Result.Value(_mode switch { TokenizerMode.Normal => And, _ => Escaped },
+                        next.Location,
+                        next.Remainder);
+                    next = next.Remainder.ConsumeChar();
+                    break;
+                }
+                case EqualSign:
+                {
+                    yield return Result.Value(_mode switch { TokenizerMode.Normal => Equal, _ => Escaped },
+                        next.Location,
+                        next.Remainder);
+                    next = next.Remainder.ConsumeChar();
+                    break;
+                }
+                case Asterisk:
+                {
+                    yield return Result.Value(_mode switch { TokenizerMode.Normal => FilterToken.Asterisk, _ => Escaped },
+                        next.Location,
+                        next.Remainder);
+                    next = next.Remainder.ConsumeChar();
+                    break;
+                }
+                case LeftCurlyBracket:
+                {
+                    yield return Result.Value(_mode switch { TokenizerMode.Normal => LeftCurlyBrace, _ => Escaped },
+                        next.Location,
+                        next.Remainder);
+                    next = next.Remainder.ConsumeChar();
+                    break;
+                }
+                case RightCurlyBracket:
+                {
+                    yield return Result.Value(_mode switch { TokenizerMode.Normal => RightCurlyBrace, _ => Escaped },
+                        next.Location,
+                        next.Remainder);
+                    next = next.Remainder.ConsumeChar();
+                    break;
+                }
+                case Bang:
+                {
+                    yield return Result.Value(_mode switch { TokenizerMode.Normal => FilterToken.Bang, _ => Escaped },
+                        next.Location,
+                        next.Remainder);
+                    next = next.Remainder.ConsumeChar();
+                    break;
+                }
+                case LeftSquareBracket:
+                {
+                    yield return Result.Value(_mode switch { TokenizerMode.Normal => LeftSquaredBracket, _ => Escaped },
+                        next.Location,
+                        next.Remainder);
+                    next = next.Remainder.ConsumeChar();
+                    break;
+                }
+                case RightSquareBracket:
+                {
+                    yield return Result.Value(_mode switch { TokenizerMode.Normal => RightSquaredBracket, _ => Escaped },
+                        next.Location,
+                        next.Remainder);
+                    next = next.Remainder.ConsumeChar();
+                    break;
+                }
+                case Hyphen:
+                {
+                    yield return Result.Value(_mode switch { TokenizerMode.Normal => Dash, _ => Escaped },
+                        next.Location,
+                        next.Remainder);
+                    next = next.Remainder.ConsumeChar();
+                    break;
+                }
+                case LeftParenthesis:
+                {
+                    yield return Result.Value(_mode switch { TokenizerMode.Normal => FilterToken.LeftParenthesis, _ => Escaped },
+                        next.Location,
+                        next.Remainder);
+                    next = next.Remainder.ConsumeChar();
+                    break;
+                }
+                case RightParenthesis:
+                {
+                    yield return Result.Value(_mode switch { TokenizerMode.Normal => FilterToken.RightParenthesis, _ => Escaped },
+                        next.Location,
+                        next.Remainder);
+                    next = next.Remainder.ConsumeChar();
+                    break;
+                }
+                case Space:
+                {
+                    yield return Result.Value(_mode switch { TokenizerMode.Normal => Whitespace, _ => Escaped },
+                        next.Location,
+                        next.Remainder);
+                    next = next.Remainder.ConsumeChar();
+                    break;
+                }
+                case ':':
+                {
+                    yield return Result.Value(_mode switch { TokenizerMode.Normal => Colon, _ => Escaped },
+                        next.Location,
+                        next.Remainder);
+                    next = next.Remainder.ConsumeChar();
+                    break;
+                }
+                case Ampersand:
+                {
+                    yield return Result.Value(_mode switch { TokenizerMode.Normal => FilterToken.Ampersand, _ => Escaped },
+                        next.Location,
+                        next.Remainder);
+                    next = next.Remainder.ConsumeChar();
+                    break;
+                }
+                case DoubleQuote:
+                {
+                    yield return Result.Value(FilterToken.DoubleQuote,
+                        next.Location,
+                        next.Remainder);
+                    _mode = ToggleMode(_mode);
+                    next = next.Remainder.ConsumeChar();
+                    break;
+                }
+                case Dot:
+                {
+                    yield return Result.Value(_mode switch { TokenizerMode.Normal => FilterToken.Dot, _ => Escaped },
+                        next.Location,
+                        next.Remainder);
+                    next = next.Remainder.ConsumeChar();
+                    break;
+                }
+                case BackSlash:
+                {
+                    TextSpan backSlashStart = next.Location;
+                    if (_mode == TokenizerMode.Normal)
                     {
-                        yield return Result.Value(Digit, next.Location, next.Remainder);
                         next = next.Remainder.ConsumeChar();
-                        break;
-                    }
-                    case Underscore:
-                    {
-                        yield return Result.Value(_mode switch { TokenizerMode.Normal => FilterToken.Underscore, _ => Escaped },
-                            next.Location,
-                            next.Remainder);
-                        next = next.Remainder.ConsumeChar();
-                        break;
-                    }
-                    case Pipe:
-                    {
-                        yield return Result.Value(_mode switch { TokenizerMode.Normal => Or, _ => Escaped },
-                            next.Location,
-                            next.Remainder);
-                        next = next.Remainder.ConsumeChar();
-                        break;
-                    }
-                    case Comma:
-                    {
-                        yield return Result.Value(_mode switch { TokenizerMode.Normal => And, _ => Escaped },
-                            next.Location,
-                            next.Remainder);
-                        next = next.Remainder.ConsumeChar();
-                        break;
-                    }
-                    case EqualSign:
-                    {
-                        yield return Result.Value(_mode switch { TokenizerMode.Normal => Equal, _ => Escaped },
-                            next.Location,
-                            next.Remainder);
-                        next = next.Remainder.ConsumeChar();
-                        break;
-                    }
-                    case Asterisk:
-                    {
-                        yield return Result.Value(_mode switch { TokenizerMode.Normal => FilterToken.Asterisk, _ => Escaped },
-                            next.Location,
-                            next.Remainder);
-                        next = next.Remainder.ConsumeChar();
-                        break;
-                    }
-                    case LeftCurlyBracket:
-                    {
-                        yield return Result.Value(_mode switch { TokenizerMode.Normal => LeftCurlyBrace, _ => Escaped },
-                            next.Location,
-                            next.Remainder);
-                        next = next.Remainder.ConsumeChar();
-                        break;
-                    }
-                    case RightCurlyBracket:
-                    {
-                        yield return Result.Value(_mode switch { TokenizerMode.Normal => RightCurlyBrace, _ => Escaped },
-                            next.Location,
-                            next.Remainder);
-                        next = next.Remainder.ConsumeChar();
-                        break;
-                    }
-                    case Bang:
-                    {
-                        yield return Result.Value(_mode switch { TokenizerMode.Normal => FilterToken.Bang, _ => Escaped },
-                            next.Location,
-                            next.Remainder);
-                        next = next.Remainder.ConsumeChar();
-                        break;
-                    }
-                    case LeftSquareBracket:
-                    {
-                        yield return Result.Value(_mode switch { TokenizerMode.Normal => LeftSquaredBracket, _ => Escaped },
-                            next.Location,
-                            next.Remainder);
-                        next = next.Remainder.ConsumeChar();
-                        break;
-                    }
-                    case RightSquareBracket:
-                    {
-                        yield return Result.Value(_mode switch { TokenizerMode.Normal => RightSquaredBracket, _ => Escaped },
-                            next.Location,
-                            next.Remainder);
-                        next = next.Remainder.ConsumeChar();
-                        break;
-                    }
-                    case Hyphen:
-                    {
-                        yield return Result.Value(_mode switch { TokenizerMode.Normal => Dash, _ => Escaped },
-                            next.Location,
-                            next.Remainder);
-                        next = next.Remainder.ConsumeChar();
-                        break;
-                    }
-                    case LeftParenthesis:
-                    {
-                        yield return Result.Value(_mode switch { TokenizerMode.Normal => FilterToken.LeftParenthesis, _ => Escaped },
-                            next.Location,
-                            next.Remainder);
-                        next = next.Remainder.ConsumeChar();
-                        break;
-                    }
-                    case RightParenthesis:
-                    {
-                        yield return Result.Value(_mode switch { TokenizerMode.Normal => FilterToken.RightParenthesis, _ => Escaped },
-                                                  next.Location,
-                                                  next.Remainder);
-                        next = next.Remainder.ConsumeChar();
-                        break;
-                    }
-                    case Space:
-                    {
-                        yield return Result.Value(_mode switch { TokenizerMode.Normal => Whitespace, _ => Escaped },
-                                                  next.Location,
-                                                  next.Remainder);
-                        next = next.Remainder.ConsumeChar();
-                        break;
-                    }
-                    case ':':
-                    {
-                        yield return Result.Value(_mode switch { TokenizerMode.Normal => Colon, _ => Escaped },
-                            next.Location,
-                            next.Remainder);
-                        next = next.Remainder.ConsumeChar();
-                        break;
-                    }
-                    case Ampersand:
-                    {
-                        yield return Result.Value(_mode switch { TokenizerMode.Normal => FilterToken.Ampersand, _ => Escaped },
-                            next.Location,
-                            next.Remainder);
-                        next = next.Remainder.ConsumeChar();
-                        break;
-                    }
-                    case DoubleQuote:
-                    {
-                        yield return Result.Value(FilterToken.DoubleQuote,
-                            next.Location,
-                            next.Remainder);
-                        _mode = ToggleMode(_mode);
-                        next = next.Remainder.ConsumeChar();
-                        break;
-                    }
-                    case Dot:
-                    {
-                        yield return Result.Value(_mode switch { TokenizerMode.Normal => FilterToken.Dot, _ => Escaped },
-                            next.Location,
-                            next.Remainder);
-                        next = next.Remainder.ConsumeChar();
-                        break;
-                    }
-                    case BackSlash:
-                    {
-                        TextSpan backSlashStart = next.Location;
-                        if (_mode == TokenizerMode.Normal)
-                        {
-                            next = next.Remainder.ConsumeChar();
-                            yield return next.HasValue && SpecialCharacters.Contains(next.Value)
-                                ? Result.Value(Escaped, next.Location, next.Remainder)
-                                : Result.Value(Letter, backSlashStart, next.Remainder);
+                        yield return next.HasValue && SpecialCharacters.Contains(next.Value)
+                            ? Result.Value(Escaped, next.Location, next.Remainder)
+                            : Result.Value(Letter, backSlashStart, next.Remainder);
 
-                            next = next.Remainder.ConsumeChar();
-                        }
-                        else
+                        next = next.Remainder.ConsumeChar();
+                    }
+                    else
+                    {
+                        TextSpan remainderAfterBackslash = next.Remainder;
+                        next = next.Remainder.ConsumeChar();
+                        // Only backslash and double quote need to be escaped when in Escaped mode
+                        bool shouldEscape = next.Value is BackSlash or DoubleQuote;
+                        if (next.HasValue)
                         {
-                            TextSpan remainderAfterBackslash = next.Remainder;
-                            next = next.Remainder.ConsumeChar();
-                            // Only backslash and double quote need to be escaped when in Escaped mode
-                            bool shouldEscape = next.Value is BackSlash or DoubleQuote;
-                            if (next.HasValue)
+                            if (shouldEscape)
                             {
-                                if (shouldEscape)
-                                {
-                                    yield return Result.Value(Escaped, next.Location, next.Remainder);
-                                    next = next.Remainder.ConsumeChar();
-                                }
-                                else
-                                {
-                                    yield return Result.Value(Escaped, backSlashStart, remainderAfterBackslash);
-                                }
+                                yield return Result.Value(Escaped, next.Location, next.Remainder);
+                                next = next.Remainder.ConsumeChar();
                             }
                             else
                             {
                                 yield return Result.Value(Escaped, backSlashStart, remainderAfterBackslash);
                             }
                         }
+                        else
+                        {
+                            yield return Result.Value(Escaped, backSlashStart, remainderAfterBackslash);
+                        }
+                    }
 
-                        break;
-                    }
-                    default:
-                    {
-                        yield return Result.Value(None, next.Location, next.Remainder);
-                        next = next.Remainder.ConsumeChar();
-                        break;
-                    }
+                    break;
                 }
-            } while (next.HasValue);
+                default:
+                {
+                    yield return Result.Value(None, next.Location, next.Remainder);
+                    next = next.Remainder.ConsumeChar();
+                    break;
+                }
+            }
+        } while (next.HasValue);
 
-            yield break;
+        yield break;
 
-            static TokenizerMode ToggleMode(TokenizerMode currentMode) => currentMode switch
-            {
-                TokenizerMode.Normal => TokenizerMode.Escaped,
-                _ => TokenizerMode.Normal
-            };
-        }
+        static TokenizerMode ToggleMode(TokenizerMode currentMode) => currentMode switch
+        {
+            TokenizerMode.Normal => TokenizerMode.Escaped,
+            _ => TokenizerMode.Normal
+        };
     }
 }

--- a/src/DataFilters/Grammar/Parsing/FilterTokenizer.cs
+++ b/src/DataFilters/Grammar/Parsing/FilterTokenizer.cs
@@ -24,7 +24,7 @@
         /// <summary>
         /// The <c>*</c> character
         /// </summary>
-        private const char Asterisk = '*';
+        internal const char Asterisk = '*';
 
         /// <summary>
         /// The <c>=</c> character

--- a/src/DataFilters/Grammar/Parsing/TokenizerMode.cs
+++ b/src/DataFilters/Grammar/Parsing/TokenizerMode.cs
@@ -1,18 +1,17 @@
-﻿namespace DataFilters.Grammar.Parsing
+﻿namespace DataFilters.Grammar.Parsing;
+
+/// <summary>
+/// Defines the way <see cref="FilterTokenizer"/> "tokenizes" each <see cref="char"/> read.
+/// </summary>
+public enum TokenizerMode
 {
     /// <summary>
-    /// Defines the way <see cref="FilterTokenizer"/> "tokenizes" each <see cref="char"/> read.
+    /// Character are interpreted as-is
     /// </summary>
-    public enum TokenizerMode
-    {
-        /// <summary>
-        /// Character are interpreted as-is
-        /// </summary>
-        Normal,
+    Normal,
 
-        /// <summary>
-        /// Each character read is considered as already escaped
-        /// </summary>
-        Escaped
-    }
+    /// <summary>
+    /// Each character read is considered as already escaped
+    /// </summary>
+    Escaped
 }

--- a/src/DataFilters/Grammar/Syntax/AndExpression.cs
+++ b/src/DataFilters/Grammar/Syntax/AndExpression.cs
@@ -1,85 +1,84 @@
 ﻿using System.Linq.Expressions;
 
-namespace DataFilters.Grammar.Syntax
+namespace DataFilters.Grammar.Syntax;
+
+using System;
+
+/// <summary>
+/// A <see cref="FilterExpression"/> that combine two <see cref="FilterExpression"/> expressions using the logical <c>AND</c> operator
+/// </summary>
+public sealed class AndExpression : BinaryFilterExpression, IEquatable<AndExpression>
 {
-    using System;
+    private readonly Lazy<string> _lazyToString;
+    private readonly Lazy<string> _lazyEscapedParseableString;
+
+    /// <inheritdoc/>
+    public override double Complexity => Right.Complexity * Left.Complexity;
 
     /// <summary>
-    /// A <see cref="FilterExpression"/> that combine two <see cref="FilterExpression"/> expressions using the logical <c>AND</c> operator
+    /// Builds a new <see cref="AndExpression"/> that combines <paramref name="left"/> and <paramref name="right"/> using the logical
+    /// <c>AND</c> operator
     /// </summary>
-    public sealed class AndExpression : BinaryFilterExpression, IEquatable<AndExpression>
+    /// <remarks>
+    /// <paramref name="left"/> and/or <paramref name="right"/> will be wrapped inside a <see cref="GroupExpression"/> when either is a
+    /// <see cref="AndExpression"/> or a <see cref="OrExpression"/> instance.
+    /// </remarks>
+    /// <param name="left">Left member</param>
+    /// <param name="right">Right member</param>
+    /// <exception cref="ArgumentNullException">if either <paramref name="left"/> or <paramref name="right"/> is <see langword="null"/>.</exception>
+    public AndExpression(FilterExpression left, FilterExpression right) : base(left, right)
     {
-        private readonly Lazy<string> _lazyToString;
-        private readonly Lazy<string> _lazyEscapedParseableString;
+        _lazyToString = new Lazy<string>(() => $@"[""{nameof(Left)} ({Left.GetType().Name})"": '{Left}'; ""{nameof(Right)} ({Right.GetType().Name})"": '{Right}']");
+        _lazyEscapedParseableString = new Lazy<string>(() => $"{Left.EscapedParseableString},{Right.EscapedParseableString}");
+    }
 
-        /// <inheritdoc/>
-        public override double Complexity => Right.Complexity * Left.Complexity;
+    ///<inheritdoc/>
+    public bool Equals(AndExpression other) => (Left.Equals(other?.Left) && Right.Equals(other?.Right)) || (Left.Equals(other?.Right) && Right.Equals(other?.Left));
 
-        /// <summary>
-        /// Builds a new <see cref="AndExpression"/> that combines <paramref name="left"/> and <paramref name="right"/> using the logical
-        /// <c>AND</c> operator
-        /// </summary>
-        /// <remarks>
-        /// <paramref name="left"/> and/or <paramref name="right"/> will be wrapped inside a <see cref="GroupExpression"/> when either is a
-        /// <see cref="AndExpression"/> or a <see cref="OrExpression"/> instance.
-        /// </remarks>
-        /// <param name="left">Left member</param>
-        /// <param name="right">Right member</param>
-        /// <exception cref="ArgumentNullException">if either <paramref name="left"/> or <paramref name="right"/> is <c>null</c>.</exception>
-        public AndExpression(FilterExpression left, FilterExpression right) : base(left, right)
+    ///<inheritdoc/>
+    public override bool Equals(object obj) => Equals(obj as AndExpression);
+
+    ///<inheritdoc/>
+    public override int GetHashCode() => (Left, Right).GetHashCode();
+
+    ///<inheritdoc/>
+    public override bool IsEquivalentTo(FilterExpression other)
+        => ReferenceEquals(this, other)
+           || other switch
+           {
+               AndExpression and => Equals(and) || (Left.IsEquivalentTo(and.Left) && Right.IsEquivalentTo(and.Right)) || (Left.IsEquivalentTo(and.Right) && Right.IsEquivalentTo(and.Left)),
+               ConstantValueExpression constant => (Left.Equals(Right) || Left.IsEquivalentTo(Right)) && (Left.IsEquivalentTo(constant) || Right.IsEquivalentTo(constant)),
+               ISimplifiable simplifiable => simplifiable.Simplify().IsEquivalentTo(this),
+               _ => false
+           };
+
+    ///<inheritdoc/>
+    public override string EscapedParseableString => _lazyEscapedParseableString.Value;
+
+    ///<inheritdoc/>
+    public override string ToString() => _lazyEscapedParseableString.Value;
+
+    /// <inheritdoc />
+    public override FilterExpression Simplify()
+    {
+        FilterExpression simplified;
+        if (ReferenceEquals(Left, Right) || Left.Equals(Right) || Left.IsEquivalentTo(Right))
         {
-            _lazyToString = new Lazy<string>(() => $@"[""{nameof(Left)} ({Left.GetType().Name})"": '{Left}'; ""{nameof(Right)} ({Right.GetType().Name})"": '{Right}']");
-            _lazyEscapedParseableString = new Lazy<string>(() => $"{Left.EscapedParseableString},{Right.EscapedParseableString}");
+            simplified = Left.Complexity < Right.Complexity
+                ? Left.As<ISimplifiable>()?.Simplify() ?? Left
+                : Right.As<ISimplifiable>()?.Simplify() ?? Right;
+        }
+        else
+        {
+            simplified = ( Left, Right ) switch
+            {
+                (ISimplifiable left, ISimplifiable right) => new AndExpression(left.Simplify(), right.Simplify()),
+                (ISimplifiable left, not ISimplifiable) => new AndExpression(left.Simplify(), Right),
+                (not ISimplifiable, ISimplifiable right) => new AndExpression(Left, right.Simplify()),
+                (not ISimplifiable, not ISimplifiable) => this
+            };
         }
 
-        ///<inheritdoc/>
-        public bool Equals(AndExpression other) => (Left.Equals(other?.Left) && Right.Equals(other?.Right)) || (Left.Equals(other?.Right) && Right.Equals(other?.Left));
-
-        ///<inheritdoc/>
-        public override bool Equals(object obj) => Equals(obj as AndExpression);
-
-        ///<inheritdoc/>
-        public override int GetHashCode() => (Left, Right).GetHashCode();
-
-        ///<inheritdoc/>
-        public override bool IsEquivalentTo(FilterExpression other)
-            => ReferenceEquals(this, other)
-                || other switch
-                {
-                    AndExpression and => Equals(and) || (Left.IsEquivalentTo(and.Left) && Right.IsEquivalentTo(and.Right)) || (Left.IsEquivalentTo(and.Right) && Right.IsEquivalentTo(and.Left)),
-                    ConstantValueExpression constant => (Left.Equals(Right) || Left.IsEquivalentTo(Right)) && (Left.IsEquivalentTo(constant) || Right.IsEquivalentTo(constant)),
-                    ISimplifiable simplifiable => simplifiable.Simplify().IsEquivalentTo(this),
-                    _ => false
-                };
-
-        ///<inheritdoc/>
-        public override string EscapedParseableString => _lazyEscapedParseableString.Value;
-
-        ///<inheritdoc/>
-        public override string ToString() => _lazyEscapedParseableString.Value;
-
-        /// <inheritdoc />
-        public override FilterExpression Simplify()
-        {
-            FilterExpression simplified;
-            if (ReferenceEquals(Left, Right) || Left.Equals(Right) || Left.IsEquivalentTo(Right))
-            {
-                simplified = Left.Complexity < Right.Complexity
-                    ? Left.As<ISimplifiable>()?.Simplify() ?? Left
-                    : Right.As<ISimplifiable>()?.Simplify() ?? Right;
-            }
-            else
-            {
-                simplified = ( Left, Right ) switch
-                {
-                    (ISimplifiable left, ISimplifiable right) => new AndExpression(left.Simplify(), right.Simplify()),
-                    (ISimplifiable left, not ISimplifiable) => new AndExpression(left.Simplify(), Right),
-                    (not ISimplifiable, ISimplifiable right) => new AndExpression(Left, right.Simplify()),
-                    (not ISimplifiable, not ISimplifiable) => this
-                };
-            }
-
-            return simplified;
-        }
+        return simplified;
     }
 }

--- a/src/DataFilters/Grammar/Syntax/AsteriskExpression.cs
+++ b/src/DataFilters/Grammar/Syntax/AsteriskExpression.cs
@@ -1,65 +1,64 @@
-﻿namespace DataFilters.Grammar.Syntax
+﻿namespace DataFilters.Grammar.Syntax;
+
+using System;
+
+/// <summary>
+/// <see cref="AsteriskExpression"/> represent a <c>*</c> that can be used as a building block for more
+/// complex <see cref="FilterExpression"/>s.
+/// </summary>
+public sealed class AsteriskExpression : FilterExpression, IEquatable<AsteriskExpression>, IBoundaryExpression
 {
-    using System;
+    /// <summary>
+    /// The unique instance of the <see cref="AsteriskExpression"/>.
+    /// </summary>
+    /// <remarks>
+    /// This field is <see langword="readonly"/>
+    /// </remarks>
+    public static AsteriskExpression Instance { get; } = new();
+
+    private AsteriskExpression() { }
+
+    ///<inheritdoc/>
+    public bool Equals(AsteriskExpression other) => other is not null;
+
+    ///<inheritdoc/>
+    public override bool Equals(object obj) => Equals(obj as AsteriskExpression);
+
+    ///<inheritdoc/>
+    public override int GetHashCode() => 1;
+
+    ///<inheritdoc/>
+    public override string EscapedParseableString => "*";
 
     /// <summary>
-    /// <see cref="AsteriskExpression"/> represent a <c>*</c> that can be used as a building block for more
-    /// complex <see cref="FilterExpression"/>s.
+    /// Computes a <see cref="EndsWithExpression"/> by adding a <see cref="AsteriskExpression"/> to a <see cref="StringValueExpression"/>.
     /// </summary>
-    public sealed class AsteriskExpression : FilterExpression, IEquatable<AsteriskExpression>, IBoundaryExpression
-    {
-        /// <summary>
-        /// The unique instance of the <see cref="AsteriskExpression"/>.
-        /// </summary>
-        /// <remarks>
-        /// This field is <see langword="readonly"/>
-        /// </remarks>
-        public static AsteriskExpression Instance { get; } = new();
+    /// <param name="_"></param>
+    /// <param name="right"></param>
+    /// <returns><see cref="EndsWithExpression"/></returns>
+    public static EndsWithExpression operator +(AsteriskExpression _, TextExpression right) => new (right);
 
-        private AsteriskExpression() { }
+    /// <summary>
+    /// Computes a <see cref="EndsWithExpression"/> by adding a <see cref="AsteriskExpression"/> to a <see cref="StringValueExpression"/>.
+    /// </summary>
+    /// <param name="_"></param>
+    /// <param name="right"></param>
+    /// <returns><see cref="EndsWithExpression"/></returns>
+    public static EndsWithExpression operator +(AsteriskExpression _, ConstantValueExpression right) => new(right.Value);
 
-        ///<inheritdoc/>
-        public bool Equals(AsteriskExpression other) => other is not null;
+    /// <summary>
+    /// Computes a <see cref="StartsWithExpression"/> by adding a <see cref="ConstantValueExpression"/> to a <see cref="AsteriskExpression"/>.
+    /// </summary>
+    /// <param name="left">Left operand</param>
+    /// <param name="right">Right operand</param>
+    /// <returns><see cref="StartsWithExpression"/></returns>
+    public static StartsWithExpression operator +(ConstantValueExpression left, AsteriskExpression right) => new(left.Value);
 
-        ///<inheritdoc/>
-        public override bool Equals(object obj) => Equals(obj as AsteriskExpression);
-
-        ///<inheritdoc/>
-        public override int GetHashCode() => 1;
-
-        ///<inheritdoc/>
-        public override string EscapedParseableString => "*";
-
-        /// <summary>
-        /// Computes a <see cref="EndsWithExpression"/> by adding a <see cref="AsteriskExpression"/> to a <see cref="StringValueExpression"/>.
-        /// </summary>
-        /// <param name="_"></param>
-        /// <param name="right"></param>
-        /// <returns><see cref="EndsWithExpression"/></returns>
-        public static EndsWithExpression operator +(AsteriskExpression _, TextExpression right) => new (right);
-
-        /// <summary>
-        /// Computes a <see cref="EndsWithExpression"/> by adding a <see cref="AsteriskExpression"/> to a <see cref="StringValueExpression"/>.
-        /// </summary>
-        /// <param name="_"></param>
-        /// <param name="right"></param>
-        /// <returns><see cref="EndsWithExpression"/></returns>
-        public static EndsWithExpression operator +(AsteriskExpression _, ConstantValueExpression right) => new(right.Value);
-
-        /// <summary>
-        /// Computes a <see cref="StartsWithExpression"/> by adding a <see cref="ConstantValueExpression"/> to a <see cref="AsteriskExpression"/>.
-        /// </summary>
-        /// <param name="left">Left operand</param>
-        /// <param name="right">Right operand</param>
-        /// <returns><see cref="StartsWithExpression"/></returns>
-        public static StartsWithExpression operator +(ConstantValueExpression left, AsteriskExpression right) => new(left.Value);
-
-        /// <summary>
-        /// Computes a <see cref="StartsWithExpression"/> by adding a <see cref="TextExpression"/> to a <see cref="AsteriskExpression"/>.
-        /// </summary>
-        /// <param name="left">Left operand</param>
-        /// <param name="right">Right operand</param>
-        /// <returns><see cref="StartsWithExpression"/></returns>
-        public static StartsWithExpression operator +(TextExpression left, AsteriskExpression right) => new(left);
-    }
+    /// <summary>
+    /// Computes a <see cref="StartsWithExpression"/> by adding a <see cref="TextExpression"/> to a <see cref="AsteriskExpression"/>.
+    /// </summary>
+    /// <param name="left">Left operand</param>
+    /// <param name="right">Right operand</param>
+    /// <returns><see cref="StartsWithExpression"/></returns>
+    public static StartsWithExpression operator +(TextExpression left, AsteriskExpression right) => new(left);
 }

--- a/src/DataFilters/Grammar/Syntax/BoundaryExpression.cs
+++ b/src/DataFilters/Grammar/Syntax/BoundaryExpression.cs
@@ -1,42 +1,42 @@
 ﻿using System.Diagnostics;
 
-namespace DataFilters.Grammar.Syntax
+namespace DataFilters.Grammar.Syntax;
+
+using System;
+using System.Collections.Generic;
+
+/// <summary>
+/// A <see cref="FilterExpression"/> that can be used to construct <see cref="IntervalExpression"/> instances.
+/// </summary>
+/// <remarks>
+/// Builds a new <see cref="BoundaryExpression"/> instance.
+/// </remarks>
+/// <param name="expression">an <see cref="IBoundaryExpression"/></param>
+/// <param name="included"><c>true</c> if <paramref name="expression"/> should be included in the interval and <c>false</c> otherwise.</param>
+[DebuggerDisplay("{Expression.OriginalString}")]
+public sealed class BoundaryExpression(IBoundaryExpression expression, bool included) : IEquatable<BoundaryExpression>
 {
-    using System;
-    using System.Collections.Generic;
+    /// <summary>
+    /// Expression used as a boundary
+    /// </summary>
+    public IBoundaryExpression Expression { get; } = expression ?? throw new ArgumentNullException(nameof(expression));
 
     /// <summary>
-    /// A <see cref="FilterExpression"/> that can be used to construct <see cref="IntervalExpression"/> instances.
+    /// Should the <see cref="Expression"/> be included or excluded in the <see cref="IntervalExpression"/>
     /// </summary>
-    /// <remarks>
-    /// Builds a new <see cref="BoundaryExpression"/> instance.
-    /// </remarks>
-    /// <param name="expression">an <see cref="IBoundaryExpression"/></param>
-    /// <param name="included"><c>true</c> if <paramref name="expression"/> should be included in the interval and <c>false</c> otherwise.</param>
-    [DebuggerDisplay("{Expression.OriginalString}")]
-    public sealed class BoundaryExpression(IBoundaryExpression expression, bool included) : IEquatable<BoundaryExpression>
-    {
-        /// <summary>
-        /// Expression used as a boundary
-        /// </summary>
-        public IBoundaryExpression Expression { get; } = expression ?? throw new ArgumentNullException(nameof(expression));
+    public bool Included { get; } = included;
 
-        /// <summary>
-        /// Should the <see cref="Expression"/> be included or excluded in the <see cref="IntervalExpression"/>
-        /// </summary>
-        public bool Included { get; } = included;
+    ///<inheritdoc/>
+    public bool Equals(BoundaryExpression other) => other is not null
+                                                    && Included == other.Included
+                                                    && Expression.Equals(other.Expression);
 
-        ///<inheritdoc/>
-        public bool Equals(BoundaryExpression other) => other is not null
-                                                        && Included == other.Included
-                                                        && Expression.Equals(other.Expression);
+    ///<inheritdoc/>
+    public override bool Equals(object obj) => Equals(obj as BoundaryExpression);
 
-        ///<inheritdoc/>
-        public override bool Equals(object obj) => Equals(obj as BoundaryExpression);
-
-        ///<inheritdoc/>
+    ///<inheritdoc/>
 #if !(NETSTANDARD1_3 || NETSTANDARD2_0)
-        public override int GetHashCode() => HashCode.Combine(Expression, Included);
+    public override int GetHashCode() => HashCode.Combine(Expression, Included);
 #else
         public override int GetHashCode()
         {
@@ -47,24 +47,23 @@ namespace DataFilters.Grammar.Syntax
         }
 #endif
 
-        ///<inheritdoc/>
-        public static bool operator ==(BoundaryExpression left, BoundaryExpression right) => left switch
-        {
-            null => right is null,
-            _ => left.Equals(right),
-        };
+    ///<inheritdoc/>
+    public static bool operator ==(BoundaryExpression left, BoundaryExpression right) => left switch
+    {
+        null => right is null,
+        _ => left.Equals(right),
+    };
 
-        ///<inheritdoc/>
-        public static bool operator !=(BoundaryExpression left, BoundaryExpression right) => !(left == right);
+    ///<inheritdoc/>
+    public static bool operator !=(BoundaryExpression left, BoundaryExpression right) => !(left == right);
 
-        ///<inheritdoc/>
-        public override string ToString() => $"{{{Expression.GetType()}:{Expression.EscapedParseableString}, {nameof(Included)} : {Included}}}";
+    ///<inheritdoc/>
+    public override string ToString() => $"{{{Expression.GetType()}:{Expression.EscapedParseableString}, {nameof(Included)} : {Included}}}";
 
-        ///<inheritdoc/>
-        public void Deconstruct(out IBoundaryExpression expression, out bool included)
-        {
-            expression = Expression;
-            included = Included;
-        }
+    ///<inheritdoc/>
+    public void Deconstruct(out IBoundaryExpression expression, out bool included)
+    {
+        expression = Expression;
+        included = Included;
     }
 }

--- a/src/DataFilters/Grammar/Syntax/BracketExpression.cs
+++ b/src/DataFilters/Grammar/Syntax/BracketExpression.cs
@@ -1,101 +1,100 @@
-﻿namespace DataFilters.Grammar.Syntax
-{
-    using System;
-    using System.Collections.Generic;
-    using System.Linq;
+﻿namespace DataFilters.Grammar.Syntax;
 
-    using Utilities;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+using Utilities;
+
+/// <summary>
+/// A <see cref="FilterExpression"/> that holds a regex pattern as its <see cref="Values"/>.
+/// </summary>
+/// <remarks>
+/// As a regular expression can have many form, the constructor gives a way to define if it has :
+/// <list type="bullet">
+///  <item>a range : <c>[a-f]</c> would be built like <c>new RegularExpression(new RegularRangeValue('a', 'f'))</c></item>
+///  <item>a set of values : <c>[aMn]</c> would be built by using <see cref="ConstantBracketValue"/> as constructor parameters</item>
+///  <item>a combination of both : <c>[a-fMn]</c> by using<c>{ ('a', 'f', true), ('M', 'M', false), ('n', 'n', false),  }</c> to <see cref="Values"/></item>
+/// </list>
+/// </remarks>
+public sealed class BracketExpression : FilterExpression, IEquatable<BracketExpression>
+{
+    private static readonly ArrayEqualityComparer<BracketValue> EqualityComparer = new();
 
     /// <summary>
-    /// A <see cref="FilterExpression"/> that holds a regex pattern as its <see cref="Values"/>.
+    /// Builds a new <see cref="BracketExpression"/> instance.
     /// </summary>
-    /// <remarks>
-    /// As a regular expression can have many form, the constructor gives a way to define if it has :
-    /// <list type="bullet">
-    ///  <item>a range : <c>[a-f]</c> would be built like <c>new RegularExpression(new RegularRangeValue('a', 'f'))</c></item>
-    ///  <item>a set of values : <c>[aMn]</c> would be built by using <see cref="ConstantBracketValue"/> as constructor parameters</item>
-    ///  <item>a combination of both : <c>[a-fMn]</c> by using<c>{ ('a', 'f', true), ('M', 'M', false), ('n', 'n', false),  }</c> to <see cref="Values"/></item>
-    /// </list>
-    /// </remarks>
-    public sealed class BracketExpression : FilterExpression, IEquatable<BracketExpression>
+    /// <param name="values"></param>
+    public BracketExpression(params BracketValue[] values)
     {
-        private static readonly ArrayEqualityComparer<BracketValue> EqualityComparer = new();
-
-        /// <summary>
-        /// Builds a new <see cref="BracketExpression"/> instance.
-        /// </summary>
-        /// <param name="values"></param>
-        public BracketExpression(params BracketValue[] values)
+        if (values is null)
         {
-            if (values is null)
-            {
-                throw new ArgumentNullException(nameof(values));
-            }
-
-            Values = values.Where(value => value is not null)
-                           .ToArray();
+            throw new ArgumentNullException(nameof(values));
         }
 
-        /// <summary>
-        /// Values of the original regex
-        /// </summary>
-        public IEnumerable<BracketValue> Values { get; }
-
-        ///<inheritdoc/>
-        public bool Equals(BracketExpression other) => other is not null
-                                                       && EqualityComparer.Equals(Values.ToArray(), other.Values.ToArray());
-
-        ///<inheritdoc/>
-        public override bool Equals(object obj) => obj switch
-        {
-            BracketExpression bracket => Equals(bracket),
-            FilterExpression expression => IsEquivalentTo(expression),
-            _ => false
-        };
-
-        ///<inheritdoc/>
-        public override int GetHashCode() => EqualityComparer.GetHashCode([.. Values]);
-
-        ///<inheritdoc/>
-        public override string ToString() => $"{nameof(BracketExpression)} : [{string.Join(",", Values)}]";
-
-        ///<inheritdoc/>
-        public override double Complexity => Values.Select(x => x.Complexity)
-                                                   .Aggregate((initial, current) => initial * current);
-
-        ///<inheritdoc/>
-        public override bool IsEquivalentTo(FilterExpression other)
-        {
-            bool equivalent = false;
-            if (other is not null)
-            {
-                if (ReferenceEquals(this, other))
-                {
-                    equivalent = true;
-                }
-                else if (other is BracketExpression bracketExpression)
-                {
-                    equivalent = Equals(bracketExpression);
-                }
-                else if (other is OneOfExpression oneOf)
-                {
-                    equivalent = oneOf.Values.Exactly(oneOf.Values.OfType<StringValueExpression>().Count())
-                        && oneOf.Values.All(x => x is StringValueExpression)
-                        && Values.All(value => value switch
-                        {
-                            ConstantBracketValue constant => constant.Value.All(chr => oneOf.Values.Any(expr => expr.As<StringValueExpression>().Value.Equals(chr.ToString()))),
-                            RangeBracketValue range => Enumerable.Range(range.Start, range.End - range.Start + 1)
-                                                                 .Select(ascii => (char)ascii)
-                                                                 .All(chr => oneOf.Values.Any(expr => expr.As<StringValueExpression>().Value.Equals(chr.ToString()))),
-                            _ => throw new NotSupportedException("Unsupported value")
-                        });
-                }
-            }
-
-            return equivalent;
-        }
-
-        ///<inheritdoc/>
-        public override string EscapedParseableString => $"[{string.Join(",", Values)}]";
+        Values = values.Where(value => value is not null)
+            .ToArray();
     }
+
+    /// <summary>
+    /// Values of the original regex
+    /// </summary>
+    public IEnumerable<BracketValue> Values { get; }
+
+    ///<inheritdoc/>
+    public bool Equals(BracketExpression other) => other is not null
+                                                   && EqualityComparer.Equals(Values.ToArray(), other.Values.ToArray());
+
+    ///<inheritdoc/>
+    public override bool Equals(object obj) => obj switch
+    {
+        BracketExpression bracket => Equals(bracket),
+        FilterExpression expression => IsEquivalentTo(expression),
+        _ => false
+    };
+
+    ///<inheritdoc/>
+    public override int GetHashCode() => EqualityComparer.GetHashCode([.. Values]);
+
+    ///<inheritdoc/>
+    public override string ToString() => $"{nameof(BracketExpression)} : [{string.Join(",", Values)}]";
+
+    ///<inheritdoc/>
+    public override double Complexity => Values.Select(x => x.Complexity)
+        .Aggregate((initial, current) => initial * current);
+
+    ///<inheritdoc/>
+    public override bool IsEquivalentTo(FilterExpression other)
+    {
+        bool equivalent = false;
+        if (other is not null)
+        {
+            if (ReferenceEquals(this, other))
+            {
+                equivalent = true;
+            }
+            else if (other is BracketExpression bracketExpression)
+            {
+                equivalent = Equals(bracketExpression);
+            }
+            else if (other is OneOfExpression oneOf)
+            {
+                equivalent = oneOf.Values.Exactly(oneOf.Values.OfType<StringValueExpression>().Count())
+                             && oneOf.Values.All(x => x is StringValueExpression)
+                             && Values.All(value => value switch
+                             {
+                                 ConstantBracketValue constant => constant.Value.All(chr => oneOf.Values.Any(expr => expr.As<StringValueExpression>().Value.Equals(chr.ToString()))),
+                                 RangeBracketValue range => Enumerable.Range(range.Start, range.End - range.Start + 1)
+                                     .Select(ascii => (char)ascii)
+                                     .All(chr => oneOf.Values.Any(expr => expr.As<StringValueExpression>().Value.Equals(chr.ToString()))),
+                                 _ => throw new NotSupportedException("Unsupported value")
+                             });
+            }
+        }
+
+        return equivalent;
+    }
+
+    ///<inheritdoc/>
+    public override string EscapedParseableString => $"[{string.Join(",", Values)}]";
 }

--- a/src/DataFilters/Grammar/Syntax/BracketValue.cs
+++ b/src/DataFilters/Grammar/Syntax/BracketValue.cs
@@ -1,20 +1,19 @@
-﻿namespace DataFilters.Grammar.Syntax
+﻿namespace DataFilters.Grammar.Syntax;
+
+/// <summary>
+/// Building block for <see cref="BracketExpression"/>.
+/// </summary>
+public abstract class BracketValue : IParseableString, IHaveComplexity
 {
-    /// <summary>
-    /// Building block for <see cref="BracketExpression"/>.
-    /// </summary>
-    public abstract class BracketValue : IParseableString, IHaveComplexity
-    {
-        ///<inheritdoc/>
-        public abstract string EscapedParseableString { get; }
+    ///<inheritdoc/>
+    public abstract string EscapedParseableString { get; }
 
-        ///<inheritdoc/>
-        public abstract string OriginalString { get; }
+    ///<inheritdoc/>
+    public abstract string OriginalString { get; }
 
-        ///<inheritdoc/>
-        public abstract double Complexity { get; }
+    ///<inheritdoc/>
+    public abstract double Complexity { get; }
 
-        ///<inheritdoc/>
-        public override string ToString() => EscapedParseableString;
-    }
+    ///<inheritdoc/>
+    public override string ToString() => EscapedParseableString;
 }

--- a/src/DataFilters/Grammar/Syntax/ConstantBracketValue.cs
+++ b/src/DataFilters/Grammar/Syntax/ConstantBracketValue.cs
@@ -1,59 +1,58 @@
-﻿namespace DataFilters.Grammar.Syntax
+﻿namespace DataFilters.Grammar.Syntax;
+
+using System;
+using System.Collections.Generic;
+
+/// <summary>
+/// Stores a constant value used in a bracket expression
+/// </summary>
+public sealed class ConstantBracketValue : BracketValue, IEquatable<ConstantBracketValue>
 {
-    using System;
-    using System.Collections.Generic;
+    private readonly Lazy<string> _lazyEscapedParseableString;
 
     /// <summary>
-    /// Stores a constant value used in a bracket expression
+    /// Builds a new <see cref="ConstantBracketValue"/> instance.
     /// </summary>
-    public sealed class ConstantBracketValue : BracketValue, IEquatable<ConstantBracketValue>
+    /// <param name="value"></param>
+    public ConstantBracketValue(string value)
     {
-        private readonly Lazy<string> _lazyEscapedParseableString;
-
-        /// <summary>
-        /// Builds a new <see cref="ConstantBracketValue"/> instance.
-        /// </summary>
-        /// <param name="value"></param>
-        public ConstantBracketValue(string value)
-        {
-            Value = value;
-            _lazyEscapedParseableString = new(() => $"[{Value}]");
-        }
-
-        /// <summary>
-        /// Constant value of the regex
-        /// </summary>
-        public string Value { get; }
-
-        ///<inheritdoc/>
-        public bool Equals(ConstantBracketValue other) => Value.Equals(other?.Value);
-
-        ///<inheritdoc/>
-        public override bool Equals(object obj)
-        {
-            return obj switch
-            {
-                RangeBracketValue rangeBracket => rangeBracket.Equals(this),
-                _ => Equals(obj as ConstantBracketValue),
-            };
-        }
-
-        ///<inheritdoc />
-        public static bool operator ==(ConstantBracketValue left, ConstantBracketValue right) => EqualityComparer<ConstantBracketValue>.Default.Equals(left, right);
-
-        ///<inheritdoc />
-        public static bool operator !=(ConstantBracketValue left, ConstantBracketValue right) => !(left == right);
-
-        ///<inheritdoc />
-        public override int GetHashCode() => Value.GetHashCode();
-
-        ///<inheritdoc />
-        public override string EscapedParseableString => _lazyEscapedParseableString.Value;
-
-        ///<inheritdoc/>
-        public override string OriginalString => $"[{Value}]";
-
-        ///<inheritdoc/>
-        public override double Complexity => 1 + Math.Pow(2, Value.Length);
+        Value = value;
+        _lazyEscapedParseableString = new(() => $"[{Value}]");
     }
+
+    /// <summary>
+    /// Constant value of the regex
+    /// </summary>
+    public string Value { get; }
+
+    ///<inheritdoc/>
+    public bool Equals(ConstantBracketValue other) => Value.Equals(other?.Value);
+
+    ///<inheritdoc/>
+    public override bool Equals(object obj)
+    {
+        return obj switch
+        {
+            RangeBracketValue rangeBracket => rangeBracket.Equals(this),
+            _ => Equals(obj as ConstantBracketValue),
+        };
+    }
+
+    ///<inheritdoc />
+    public static bool operator ==(ConstantBracketValue left, ConstantBracketValue right) => EqualityComparer<ConstantBracketValue>.Default.Equals(left, right);
+
+    ///<inheritdoc />
+    public static bool operator !=(ConstantBracketValue left, ConstantBracketValue right) => !(left == right);
+
+    ///<inheritdoc />
+    public override int GetHashCode() => Value.GetHashCode();
+
+    ///<inheritdoc />
+    public override string EscapedParseableString => _lazyEscapedParseableString.Value;
+
+    ///<inheritdoc/>
+    public override string OriginalString => $"[{Value}]";
+
+    ///<inheritdoc/>
+    public override double Complexity => 1 + Math.Pow(2, Value.Length);
 }

--- a/src/DataFilters/Grammar/Syntax/ConstantValueExpression.cs
+++ b/src/DataFilters/Grammar/Syntax/ConstantValueExpression.cs
@@ -1,60 +1,59 @@
-﻿namespace DataFilters.Grammar.Syntax
+﻿namespace DataFilters.Grammar.Syntax;
+
+using System;
+
+/// <summary>
+/// An expression that holds a constant value
+/// </summary>
+public abstract class ConstantValueExpression : FilterExpression, IEquatable<ConstantValueExpression>
 {
-    using System;
+    /// <summary>
+    /// Gets the "raw" value hold by the current instance.
+    /// </summary>
+    public string Value { get; }
 
     /// <summary>
-    /// An expression that holds a constant value
+    /// Builds a new <see cref="ConstantValueExpression"/> that holds the specified <paramref name="value"/>.
     /// </summary>
-    public abstract class ConstantValueExpression : FilterExpression, IEquatable<ConstantValueExpression>
+    /// <param name="value">raw unescaped value.</param>
+    /// <exception cref="ArgumentOutOfRangeException"><paramref name="value"/> is <see cref="string.Empty"/> or <paramref name="value"/> is not currently supported.
+    /// </exception>
+    /// <exception cref="ArgumentNullException"><paramref name="value"/> is <see langword="null"/>.</exception>
+    protected ConstantValueExpression(string value)
     {
-        /// <summary>
-        /// Gets the "raw" value hold by the current instance.
-        /// </summary>
-        public string Value { get; }
-
-        /// <summary>
-        /// Builds a new <see cref="ConstantValueExpression"/> that holds the specified <paramref name="value"/>.
-        /// </summary>
-        /// <param name="value">raw unescaped value.</param>
-        /// <exception cref="ArgumentOutOfRangeException"><paramref name="value"/> is <see cref="string.Empty"/> or <paramref name="value"/> is not currently supported.
-        /// </exception>
-        /// <exception cref="ArgumentNullException"><paramref name="value"/> is <c>null</c>.</exception>
-        protected ConstantValueExpression(string value)
+        Value = value switch
         {
-            Value = value switch
-            {
-                null => throw new ArgumentNullException(nameof(value)),
-                { Length: 0 } => throw new ArgumentOutOfRangeException(nameof(value)),
-                _ => value
-            };
-        }
-
-        ///<inheritdoc/>
-        public virtual bool Equals(ConstantValueExpression other) => Equals(Value, other?.Value);
-
-        ///<inheritdoc/>
-        public override bool Equals(object obj) => ReferenceEquals(this, obj) || Equals(obj as ConstantValueExpression);
-
-        ///<inheritdoc/>
-        public override int GetHashCode() => Value.GetHashCode();
-
-        ///<inheritdoc/>
-        public override double Complexity => 1;
-
-        ///<inheritdoc/>
-        public static bool operator ==(ConstantValueExpression left, ConstantValueExpression right)
-            => left?.Equals(right) ?? false;
-
-        ///<inheritdoc/>
-        public static bool operator !=(ConstantValueExpression left, ConstantValueExpression right)
-            => !(left == right);
-
-        /// <summary>
-        /// Combines <see cref="ConstantValueExpression"/> and <see cref="EndsWithExpression"/> into a <see cref="AndExpression"/>.
-        /// </summary>
-        /// <param name="left">a <see cref="ConstantValueExpression"/></param>
-        /// <param name="right">a <see cref="EndsWithExpression"/></param>
-        /// <returns><see cref="AndExpression"/></returns>
-        public static AndExpression operator +(ConstantValueExpression left, EndsWithExpression right) => new StartsWithExpression(left.Value) & right;
+            null => throw new ArgumentNullException(nameof(value)),
+            { Length: 0 } => throw new ArgumentOutOfRangeException(nameof(value)),
+            _ => value
+        };
     }
+
+    ///<inheritdoc/>
+    public virtual bool Equals(ConstantValueExpression other) => Equals(Value, other?.Value);
+
+    ///<inheritdoc/>
+    public override bool Equals(object obj) => ReferenceEquals(this, obj) || Equals(obj as ConstantValueExpression);
+
+    ///<inheritdoc/>
+    public override int GetHashCode() => Value.GetHashCode();
+
+    ///<inheritdoc/>
+    public override double Complexity => 1;
+
+    ///<inheritdoc/>
+    public static bool operator ==(ConstantValueExpression left, ConstantValueExpression right)
+        => left?.Equals(right) ?? false;
+
+    ///<inheritdoc/>
+    public static bool operator !=(ConstantValueExpression left, ConstantValueExpression right)
+        => !(left == right);
+
+    /// <summary>
+    /// Combines <see cref="ConstantValueExpression"/> and <see cref="EndsWithExpression"/> into a <see cref="AndExpression"/>.
+    /// </summary>
+    /// <param name="left">a <see cref="ConstantValueExpression"/></param>
+    /// <param name="right">a <see cref="EndsWithExpression"/></param>
+    /// <returns><see cref="AndExpression"/></returns>
+    public static AndExpression operator +(ConstantValueExpression left, EndsWithExpression right) => new StartsWithExpression(left.Value) & right;
 }

--- a/src/DataFilters/Grammar/Syntax/ContainsExpression.cs
+++ b/src/DataFilters/Grammar/Syntax/ContainsExpression.cs
@@ -1,123 +1,122 @@
 ﻿using System.Linq.Expressions;
 
-namespace DataFilters.Grammar.Syntax
+namespace DataFilters.Grammar.Syntax;
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+
+using static Parsing.FilterTokenizer;
+
+/// <summary>
+/// A <see cref="FilterExpression"/> that holds a string value
+/// </summary>
+public sealed class ContainsExpression : FilterExpression, IEquatable<ContainsExpression>
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Linq;
-    using System.Text;
+    /// <summary>
+    /// The value that was between two <see cref="AsteriskExpression"/>
+    /// </summary>
+    public string Value { get; }
 
-
-    using static Parsing.FilterTokenizer;
+    private readonly Lazy<string> _lazyEscapedParseableString;
 
     /// <summary>
-    /// A <see cref="FilterExpression"/> that holds a string value
+    /// Builds a new <see cref="ContainsExpression"/> that holds the specified <paramref name="value"/>.
     /// </summary>
-    public sealed class ContainsExpression : FilterExpression, IEquatable<ContainsExpression>
+    /// <param name="value"></param>
+    /// <exception cref="ArgumentNullException">if <paramref name="value"/> is <see langword="null"/></exception>
+    /// <exception cref="ArgumentOutOfRangeException">if <paramref name="value"/> is <c>empty</c></exception>
+    public ContainsExpression(string value)
     {
-        /// <summary>
-        /// The value that was between two <see cref="AsteriskExpression"/>
-        /// </summary>
-        public string Value { get; }
-
-        private readonly Lazy<string> _lazyEscapedParseableString;
-
-        /// <summary>
-        /// Builds a new <see cref="ContainsExpression"/> that holds the specified <paramref name="value"/>.
-        /// </summary>
-        /// <param name="value"></param>
-        /// <exception cref="ArgumentNullException">if <paramref name="value"/> is <see langword="null"/></exception>
-        /// <exception cref="ArgumentOutOfRangeException">if <paramref name="value"/> is <c>empty</c></exception>
-        public ContainsExpression(string value)
+        Value = value switch
         {
-            Value = value switch
-            {
-                null => throw new ArgumentNullException(nameof(value)),
-                {Length: 0} => throw new ArgumentOutOfRangeException(nameof(value)),
-                _ => value
-            };
+            null => throw new ArgumentNullException(nameof(value)),
+            {Length: 0} => throw new ArgumentOutOfRangeException(nameof(value)),
+            _ => value
+        };
 
-            _lazyEscapedParseableString = new Lazy<string>(() =>
-            {
-                // The length of the final parseable string in worst case scenarios will double (1 backlash for each special character from the original input)
-                // Also we need two extra positions for '*' that will be prepended and appended in all cases
-                bool requireEscapingCharacters = Value.AtLeastOnce(chr => SpecialCharacters.Contains(chr));
-                StringBuilder parseableString;
-
-                if (requireEscapingCharacters)
-                {
-                    parseableString = new StringBuilder(( Value.Length * 2 ) + 2);
-                    foreach (char chr in Value)
-                    {
-                        if (SpecialCharacters.Contains(chr))
-                        {
-                            parseableString = parseableString.Append('\\');
-                        }
-
-                        parseableString = parseableString.Append(chr);
-                    }
-                }
-                else
-                {
-                    parseableString = new StringBuilder(Value, Value.Length + 2);
-                }
-
-                return parseableString.Insert(0, "*").Append('*').ToString();
-            });
-        }
-
-        /// <summary>
-        /// Builds a new <see cref="ContainsExpression"/> that holds the specified <paramref name="text"/>.
-        /// </summary>
-        /// <param name="text"></param>
-        /// <exception cref="ArgumentNullException"><paramref name="text"/> is <see langword="null"/>.</exception>
-        public ContainsExpression(TextExpression text)
-            : this(text switch
-            {
-                null => throw new ArgumentNullException(nameof(text)),
-                _ =>  text.OriginalString,
-            })
+        _lazyEscapedParseableString = new Lazy<string>(() =>
         {
-            _lazyEscapedParseableString = new Lazy<string>(() =>
-            {
-                StringBuilder sb = new StringBuilder((text.OriginalString.Length *  2) + 2);
+            // The length of the final parseable string in worst case scenarios will double (1 backlash for each special character from the original input)
+            // Also we need two extra positions for '*' that will be prepended and appended in all cases
+            bool requireEscapingCharacters = Value.AtLeastOnce(chr => SpecialCharacters.Contains(chr));
+            StringBuilder parseableString;
 
-                foreach (char chr in text.OriginalString)
+            if (requireEscapingCharacters)
+            {
+                parseableString = new StringBuilder(( Value.Length * 2 ) + 2);
+                foreach (char chr in Value)
                 {
-                    if (chr is '\\' or '\"')
+                    if (SpecialCharacters.Contains(chr))
                     {
-                        sb = sb.Append('\\');
+                        parseableString = parseableString.Append('\\');
                     }
-                    sb.Append(chr);
+
+                    parseableString = parseableString.Append(chr);
                 }
-
-                return sb.Insert(0, "*\"").Append('\"').Append('*').ToString();
-            });
-        }
-
-        ///<inheritdoc/>
-        public override double Complexity => 1.5;
-
-        ///<inheritdoc/>
-        public override bool Equals(object obj) => Equals(obj as ContainsExpression);
-
-        ///<inheritdoc/>
-        public bool Equals(ContainsExpression other) => Value == other?.Value;
-
-        ///<inheritdoc/>
-        public override int GetHashCode() => Value.GetHashCode();
-
-        ///<inheritdoc/>
-        public override string EscapedParseableString => _lazyEscapedParseableString.Value;
-
-        ///<inheritdoc/>
-        public override bool IsEquivalentTo(FilterExpression other)
-            => other switch
+            }
+            else
             {
-                ContainsExpression contains => Equals(contains),
-                GroupExpression { Expression: var innerExpression } => innerExpression.IsEquivalentTo(this),
-                ISimplifiable simplifiable => simplifiable.Simplify().IsEquivalentTo(this),
-                _ => false
-            };
+                parseableString = new StringBuilder(Value, Value.Length + 2);
+            }
+
+            return parseableString.Insert(0, "*").Append('*').ToString();
+        });
     }
+
+    /// <summary>
+    /// Builds a new <see cref="ContainsExpression"/> that holds the specified <paramref name="text"/>.
+    /// </summary>
+    /// <param name="text"></param>
+    /// <exception cref="ArgumentNullException"><paramref name="text"/> is <see langword="null"/>.</exception>
+    public ContainsExpression(TextExpression text)
+        : this(text switch
+        {
+            null => throw new ArgumentNullException(nameof(text)),
+            _ =>  text.OriginalString,
+        })
+    {
+        _lazyEscapedParseableString = new Lazy<string>(() =>
+        {
+            StringBuilder sb = new StringBuilder((text.OriginalString.Length *  2) + 2);
+
+            foreach (char chr in text.OriginalString)
+            {
+                if (chr is '\\' or '\"')
+                {
+                    sb = sb.Append('\\');
+                }
+                sb.Append(chr);
+            }
+
+            return sb.Insert(0, "*\"").Append('\"').Append('*').ToString();
+        });
+    }
+
+    ///<inheritdoc/>
+    public override double Complexity => 1.5;
+
+    ///<inheritdoc/>
+    public override bool Equals(object obj) => Equals(obj as ContainsExpression);
+
+    ///<inheritdoc/>
+    public bool Equals(ContainsExpression other) => Value == other?.Value;
+
+    ///<inheritdoc/>
+    public override int GetHashCode() => Value.GetHashCode();
+
+    ///<inheritdoc/>
+    public override string EscapedParseableString => _lazyEscapedParseableString.Value;
+
+    ///<inheritdoc/>
+    public override bool IsEquivalentTo(FilterExpression other)
+        => other switch
+        {
+            ContainsExpression contains => Equals(contains),
+            GroupExpression { Expression: var innerExpression } => innerExpression.IsEquivalentTo(this),
+            ISimplifiable simplifiable => simplifiable.Simplify().IsEquivalentTo(this),
+            _ => false
+        };
 }

--- a/src/DataFilters/Grammar/Syntax/DateExpression.cs
+++ b/src/DataFilters/Grammar/Syntax/DateExpression.cs
@@ -1,86 +1,85 @@
-﻿namespace DataFilters.Grammar.Syntax
+﻿namespace DataFilters.Grammar.Syntax;
+
+using System;
+
+/// <summary>
+/// A <see cref="FilterExpression"/> that holds a date.
+/// </summary>
+public sealed class DateExpression : FilterExpression, IEquatable<DateExpression>, IBoundaryExpression, IFormattable
 {
-    using System;
+    /// <summary>
+    /// Year part of the date
+    /// </summary>
+    public int Year { get; }
 
     /// <summary>
-    /// A <see cref="FilterExpression"/> that holds a date.
+    /// Month part of the date
     /// </summary>
-    public sealed class DateExpression : FilterExpression, IEquatable<DateExpression>, IBoundaryExpression, IFormattable
+    public int Month { get; }
+
+    /// <summary>
+    /// Day part of the date
+    /// </summary>
+    public int Day { get; }
+
+    /// <summary>
+    /// Builds a new <see cref="DateExpression"/> instance.
+    /// </summary>
+    /// <param name="year"></param>
+    /// <param name="month"></param>
+    /// <param name="day"></param>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// either <paramref name="year"/> / <paramref name="month"/> or <paramref name="day"/> is less than <c>1</c>.
+    /// </exception>
+    public DateExpression(int year = 1, int month = 1, int day = 1)
     {
-        /// <summary>
-        /// Year part of the date
-        /// </summary>
-        public int Year { get; }
-
-        /// <summary>
-        /// Month part of the date
-        /// </summary>
-        public int Month { get; }
-
-        /// <summary>
-        /// Day part of the date
-        /// </summary>
-        public int Day { get; }
-
-        /// <summary>
-        /// Builds a new <see cref="DateExpression"/> instance.
-        /// </summary>
-        /// <param name="year"></param>
-        /// <param name="month"></param>
-        /// <param name="day"></param>
-        /// <exception cref="ArgumentOutOfRangeException">
-        /// either <paramref name="year"/> / <paramref name="month"/> or <paramref name="day"/> is less than <c>1</c>.
-        /// </exception>
-        public DateExpression(int year = 1, int month = 1, int day = 1)
+        if (year < 1)
         {
-            if (year < 1)
-            {
-                throw new ArgumentOutOfRangeException(nameof(year));
-            }
-
-            if (month < 1)
-            {
-                throw new ArgumentOutOfRangeException(nameof(month));
-            }
-
-            if (day < 1)
-            {
-                throw new ArgumentOutOfRangeException(nameof(day));
-            }
-
-            Year = year;
-            Month = month;
-            Day = day;
+            throw new ArgumentOutOfRangeException(nameof(year));
         }
 
-        /// <inheritdoc />
-        public bool Equals(DateExpression other) => (Year, Month, Day) == (other?.Year, other?.Month, other?.Day);
-
-        /// <inheritdoc/>
-        public override bool Equals(object obj) => Equals(obj as DateExpression);
-
-        /// <inheritdoc />
-        public override bool IsEquivalentTo(FilterExpression other) => other switch
+        if (month < 1)
         {
-            DateExpression date => Equals(date),
-            DateTimeExpression { Date: var date, Time: null, Offset: null } => Equals(date),
-            _ => Equals((other as ISimplifiable)?.Simplify() ?? other)
-        };
+            throw new ArgumentOutOfRangeException(nameof(month));
+        }
 
-        /// <inheritdoc />
-        public override int GetHashCode() => (Year, Month, Day).GetHashCode();
-
-        /// <inheritdoc />
-        public override string EscapedParseableString => $"{Year:D4}-{Month:D2}-{Day:D2}";
-
-        /// <inheritdoc />
-        public static bool operator ==(DateExpression left, DateExpression right) => left switch
+        if (day < 1)
         {
-            null => right is null,
-            _ => left.Equals(right)
-        };
+            throw new ArgumentOutOfRangeException(nameof(day));
+        }
 
-        /// <inheritdoc />
-        public static bool operator !=(DateExpression left, DateExpression right) => !(left == right);
+        Year = year;
+        Month = month;
+        Day = day;
     }
+
+    /// <inheritdoc />
+    public bool Equals(DateExpression other) => (Year, Month, Day) == (other?.Year, other?.Month, other?.Day);
+
+    /// <inheritdoc/>
+    public override bool Equals(object obj) => Equals(obj as DateExpression);
+
+    /// <inheritdoc />
+    public override bool IsEquivalentTo(FilterExpression other) => other switch
+    {
+        DateExpression date => Equals(date),
+        DateTimeExpression { Date: var date, Time: null, Offset: null } => Equals(date),
+        _ => Equals((other as ISimplifiable)?.Simplify() ?? other)
+    };
+
+    /// <inheritdoc />
+    public override int GetHashCode() => (Year, Month, Day).GetHashCode();
+
+    /// <inheritdoc />
+    public override string EscapedParseableString => $"{Year:D4}-{Month:D2}-{Day:D2}";
+
+    /// <inheritdoc />
+    public static bool operator ==(DateExpression left, DateExpression right) => left switch
+    {
+        null => right is null,
+        _ => left.Equals(right)
+    };
+
+    /// <inheritdoc />
+    public static bool operator !=(DateExpression left, DateExpression right) => !(left == right);
 }

--- a/src/DataFilters/Grammar/Syntax/DateTimeExpression.cs
+++ b/src/DataFilters/Grammar/Syntax/DateTimeExpression.cs
@@ -1,147 +1,146 @@
-﻿namespace DataFilters.Grammar.Syntax
+﻿namespace DataFilters.Grammar.Syntax;
+
+using System;
+
+/// <summary>
+/// A <see cref="FilterExpression"/> implementation that can holds a datetime value
+/// </summary>
+/// <remarks>
+/// This class guaranties that one of the <see cref="Date"/> / <see cref="Time"/>
+/// </remarks>
+public sealed class DateTimeExpression : FilterExpression, IEquatable<DateTimeExpression>, IBoundaryExpression
 {
-    using System;
+    private readonly Lazy<string> _lazyEscapedParseableString;
 
     /// <summary>
-    /// A <see cref="FilterExpression"/> implementation that can holds a datetime value
+    /// Date part of the expression.
     /// </summary>
-    /// <remarks>
-    /// This class guaranties that one of the <see cref="Date"/> / <see cref="Time"/>
-    /// </remarks>
-    public sealed class DateTimeExpression : FilterExpression, IEquatable<DateTimeExpression>, IBoundaryExpression
+    public DateExpression Date { get; }
+
+    /// <summary>
+    /// Time part of the expression
+    /// </summary>
+    public TimeExpression Time { get; }
+
+    /// <summary>
+    /// Offset with the UTC.
+    /// </summary>
+    public OffsetExpression Offset { get; }
+
+    /// <summary>
+    /// Defines the kind of the current <see cref="DateTimeExpression"/> instance.
+    /// </summary>
+    public DateTimeExpressionKind Kind { get; }
+
+    /// <summary>
+    /// Builds a new <see cref="DateTimeExpression"/> instance where only <see cref="Date"/> part is set
+    /// </summary>
+    /// <param name="date"></param>
+    /// <exception cref="ArgumentNullException">if <paramref name="date"/> is <see langword="null"/>.</exception>
+    public DateTimeExpression(DateExpression date) : this(date, null)
     {
-        private readonly Lazy<string> _lazyEscapedParseableString;
-
-        /// <summary>
-        /// Date part of the expression.
-        /// </summary>
-        public DateExpression Date { get; }
-
-        /// <summary>
-        /// Time part of the expression
-        /// </summary>
-        public TimeExpression Time { get; }
-
-        /// <summary>
-        /// Offset with the UTC.
-        /// </summary>
-        public OffsetExpression Offset { get; }
-
-        /// <summary>
-        /// Defines the kind of the current <see cref="DateTimeExpression"/> instance.
-        /// </summary>
-        public DateTimeExpressionKind Kind { get; }
-
-        /// <summary>
-        /// Builds a new <see cref="DateTimeExpression"/> instance where only <see cref="Date"/> part is set
-        /// </summary>
-        /// <param name="date"></param>
-        /// <exception cref="ArgumentNullException">if <paramref name="date"/> is <see langword="null"/>.</exception>
-        public DateTimeExpression(DateExpression date) : this(date, null)
-        {
-        }
-
-        /// <summary>
-        /// Builds a new <see cref="DateTimeExpression"/> where only the <see cref="Time"/> part is specified
-        /// </summary>
-        /// <param name="time"></param>
-        /// <exception cref="ArgumentNullException">if <paramref name="time"/> is <see langword="null"/>.</exception>
-        public DateTimeExpression(TimeExpression time) : this(null, time) { }
-
-        /// <summary>
-        /// Builds a new <see cref="DateTimeExpression"/> with both <paramref name="date"/> and <paramref name="time"/>
-        /// specified.
-        /// </summary>
-        /// <param name="date">date part of the expression</param>
-        /// <param name="time">time part of the expression</param>
-        /// <exception cref="ArgumentException">if both <paramref name="date"/> and <paramref name="time"/> are <see langword="null"/>.</exception>
-        public DateTimeExpression(DateExpression date, TimeExpression time) : this(date, time, null)
-        {
-        }
-
-        /// <summary>
-        /// Builds a new <see cref="DateTimeExpression"/> with both <paramref name="date"/> and <paramref name="time"/>
-        /// specified.
-        /// </summary>
-        /// <param name="date">date part of the expression</param>
-        /// <param name="time">time part of the expression</param>
-        /// <param name="offset">offset with the UTC time</param>
-        /// <exception cref="ArgumentException">if both <paramref name="date"/> and <paramref name="time"/> are <see langword="null"/>.</exception>
-        public DateTimeExpression(DateExpression date, TimeExpression time, OffsetExpression offset)
-        {
-            if (date is null && time is null)
-            {
-                throw new ArgumentException($"Both {nameof(date)} and {nameof(time)} cannot be null at the same time ");
-            }
-
-            Date = date;
-            Time = time;
-            Offset = offset;
-            Kind = offset is not null
-                ? DateTimeExpressionKind.Utc
-                : DateTimeExpressionKind.Unspecified;
-
-            _lazyEscapedParseableString = new(() => (date, time, offset) switch
-           {
-               (not null, not null, not null) => $"{date.EscapedParseableString}T{time.EscapedParseableString}{offset.EscapedParseableString}",
-               (not null, not null, null) => $"{date.EscapedParseableString}T{time.EscapedParseableString}",
-               (null, not null, _) => $"T{time.EscapedParseableString}",
-               _ => date.EscapedParseableString
-           });
-        }
-
-        /// <summary>
-        /// Builds a new <see cref="DateTimeExpression"/> with both <see cref="Date"/> and <see cref="Time"/> values
-        /// extracted from .
-        /// </summary>
-        /// <param name="localDateTime"><see cref="DateTime"/> value to use as source of the current instance</param>
-        public DateTimeExpression(DateTime localDateTime) : this(new DateExpression(localDateTime.Year, localDateTime.Month, localDateTime.Day), new TimeExpression(localDateTime.Hour, localDateTime.Minute, localDateTime.Second))
-        {
-        }
-
-        /// <inheritdoc/>
-        public void Deconstruct(out DateExpression date, out TimeExpression time, out OffsetExpression offset, out DateTimeExpressionKind kind)
-        {
-            date = Date;
-            time = Time;
-            offset = Offset;
-            kind = Offset is null
-                ? DateTimeExpressionKind.Unspecified
-                : DateTimeExpressionKind.Utc;
-        }
-
-        /// <inheritdoc/>
-        public bool Equals(DateTimeExpression other) => Equals(Date, other?.Date)
-                                                        && Equals(Time, other?.Time)
-                                                        && Equals(Offset, other?.Offset)
-            ;
-
-        /// <inheritdoc/>
-        public override bool Equals(object obj) => obj switch
-        {
-            DateTimeExpression dateTime => Equals(dateTime),
-            DateExpression date => Time is null && Offset is null && Date.Equals(date),
-            TimeExpression time => Date is null && Offset is null && Time.Equals(time),
-            _ => false
-        };
-
-        /// <inheritdoc/>
-        public override int GetHashCode() => (Date, Time, Offset).GetHashCode();
-
-        ///<inheritdoc/>
-        public override string EscapedParseableString => _lazyEscapedParseableString.Value;
-
-        ///<inheritdoc/>
-        public override double Complexity => (Date?.Complexity ?? 1) + (Time?.Complexity ?? 1) + (Offset?.Complexity ?? 1);
-
-        /// <inheritdoc />
-        public static bool operator ==(DateTimeExpression left, DateTimeExpression right) => left switch
-        {
-            null => right is null,
-            _ => left.Equals(right)
-        };
-
-        /// <inheritdoc />
-        public static bool operator !=(DateTimeExpression left, DateTimeExpression right) => !(left == right);
     }
+
+    /// <summary>
+    /// Builds a new <see cref="DateTimeExpression"/> where only the <see cref="Time"/> part is specified
+    /// </summary>
+    /// <param name="time"></param>
+    /// <exception cref="ArgumentNullException">if <paramref name="time"/> is <see langword="null"/>.</exception>
+    public DateTimeExpression(TimeExpression time) : this(null, time) { }
+
+    /// <summary>
+    /// Builds a new <see cref="DateTimeExpression"/> with both <paramref name="date"/> and <paramref name="time"/>
+    /// specified.
+    /// </summary>
+    /// <param name="date">date part of the expression</param>
+    /// <param name="time">time part of the expression</param>
+    /// <exception cref="ArgumentException">if both <paramref name="date"/> and <paramref name="time"/> are <see langword="null"/>.</exception>
+    public DateTimeExpression(DateExpression date, TimeExpression time) : this(date, time, null)
+    {
+    }
+
+    /// <summary>
+    /// Builds a new <see cref="DateTimeExpression"/> with both <paramref name="date"/> and <paramref name="time"/>
+    /// specified.
+    /// </summary>
+    /// <param name="date">date part of the expression</param>
+    /// <param name="time">time part of the expression</param>
+    /// <param name="offset">offset with the UTC time</param>
+    /// <exception cref="ArgumentException">if both <paramref name="date"/> and <paramref name="time"/> are <see langword="null"/>.</exception>
+    public DateTimeExpression(DateExpression date, TimeExpression time, OffsetExpression offset)
+    {
+        if (date is null && time is null)
+        {
+            throw new ArgumentException($"Both {nameof(date)} and {nameof(time)} cannot be null at the same time ");
+        }
+
+        Date = date;
+        Time = time;
+        Offset = offset;
+        Kind = offset is not null
+            ? DateTimeExpressionKind.Utc
+            : DateTimeExpressionKind.Unspecified;
+
+        _lazyEscapedParseableString = new(() => (date, time, offset) switch
+        {
+            (not null, not null, not null) => $"{date.EscapedParseableString}T{time.EscapedParseableString}{offset.EscapedParseableString}",
+            (not null, not null, null) => $"{date.EscapedParseableString}T{time.EscapedParseableString}",
+            (null, not null, _) => $"T{time.EscapedParseableString}",
+            _ => date.EscapedParseableString
+        });
+    }
+
+    /// <summary>
+    /// Builds a new <see cref="DateTimeExpression"/> with both <see cref="Date"/> and <see cref="Time"/> values
+    /// extracted from .
+    /// </summary>
+    /// <param name="localDateTime"><see cref="DateTime"/> value to use as source of the current instance</param>
+    public DateTimeExpression(DateTime localDateTime) : this(new DateExpression(localDateTime.Year, localDateTime.Month, localDateTime.Day), new TimeExpression(localDateTime.Hour, localDateTime.Minute, localDateTime.Second))
+    {
+    }
+
+    /// <inheritdoc/>
+    public void Deconstruct(out DateExpression date, out TimeExpression time, out OffsetExpression offset, out DateTimeExpressionKind kind)
+    {
+        date = Date;
+        time = Time;
+        offset = Offset;
+        kind = Offset is null
+            ? DateTimeExpressionKind.Unspecified
+            : DateTimeExpressionKind.Utc;
+    }
+
+    /// <inheritdoc/>
+    public bool Equals(DateTimeExpression other) => Equals(Date, other?.Date)
+                                                    && Equals(Time, other?.Time)
+                                                    && Equals(Offset, other?.Offset)
+    ;
+
+    /// <inheritdoc/>
+    public override bool Equals(object obj) => obj switch
+    {
+        DateTimeExpression dateTime => Equals(dateTime),
+        DateExpression date => Time is null && Offset is null && Date.Equals(date),
+        TimeExpression time => Date is null && Offset is null && Time.Equals(time),
+        _ => false
+    };
+
+    /// <inheritdoc/>
+    public override int GetHashCode() => (Date, Time, Offset).GetHashCode();
+
+    ///<inheritdoc/>
+    public override string EscapedParseableString => _lazyEscapedParseableString.Value;
+
+    ///<inheritdoc/>
+    public override double Complexity => (Date?.Complexity ?? 1) + (Time?.Complexity ?? 1) + (Offset?.Complexity ?? 1);
+
+    /// <inheritdoc />
+    public static bool operator ==(DateTimeExpression left, DateTimeExpression right) => left switch
+    {
+        null => right is null,
+        _ => left.Equals(right)
+    };
+
+    /// <inheritdoc />
+    public static bool operator !=(DateTimeExpression left, DateTimeExpression right) => !(left == right);
 }

--- a/src/DataFilters/Grammar/Syntax/DateTimeExpressionKind.cs
+++ b/src/DataFilters/Grammar/Syntax/DateTimeExpressionKind.cs
@@ -1,23 +1,22 @@
-﻿namespace DataFilters.Grammar.Syntax
+﻿namespace DataFilters.Grammar.Syntax;
+
+/// <summary>
+/// Defines a type of <see cref="DateTimeExpression"/> instance
+/// </summary>
+public enum DateTimeExpressionKind
 {
     /// <summary>
-    /// Defines a type of <see cref="DateTimeExpression"/> instance
+    /// Default value
     /// </summary>
-    public enum DateTimeExpressionKind
-    {
-        /// <summary>
-        /// Default value
-        /// </summary>
-        Unspecified,
+    Unspecified,
 
-        /// <summary>
-        /// Inidcates that the <see cref="DateTimeExpression"/> is a local date/time.
-        /// </summary>
-        Local,
+    /// <summary>
+    /// Inidcates that the <see cref="DateTimeExpression"/> is a local date/time.
+    /// </summary>
+    Local,
 
-        /// <summary>
-        /// Inidcates that the <see cref="DateTimeExpression"/> is a UTC datetime.
-        /// </summary>
-        Utc
-    }
+    /// <summary>
+    /// Inidcates that the <see cref="DateTimeExpression"/> is a UTC datetime.
+    /// </summary>
+    Utc
 }

--- a/src/DataFilters/Grammar/Syntax/DurationExpression.cs
+++ b/src/DataFilters/Grammar/Syntax/DurationExpression.cs
@@ -1,145 +1,144 @@
-namespace DataFilters.Grammar.Syntax
+namespace DataFilters.Grammar.Syntax;
+
+using System;
+
+/// <summary>
+/// A <see cref="FilterExpression"/> implementation that contains values associated to a duration (see "https://en.wikipedia.org/wiki/ISO_8601#Durations")
+/// </summary>
+public sealed class DurationExpression : FilterExpression, IEquatable<DurationExpression>, IFormattable
 {
-    using System;
+    /// <summary>
+    /// Years part of the expression
+    /// </summary>
+    public int Years { get; }
 
     /// <summary>
-    /// A <see cref="FilterExpression"/> implementation that contains values associated to a duration (see "https://en.wikipedia.org/wiki/ISO_8601#Durations")
+    /// "Months" part of the expression
     /// </summary>
-    public sealed class DurationExpression : FilterExpression, IEquatable<DurationExpression>, IFormattable
+    public int Months { get; }
+
+    /// <summary>
+    /// "Days" part of the expression
+    /// </summary>
+    public int Days { get; }
+
+    /// <summary>
+    /// "Hours" part of the expression
+    /// </summary>
+    public int Hours { get; }
+
+    /// <summary>
+    /// "Minutes" part of the expression
+    /// </summary>
+    public int Minutes { get; }
+
+    /// <summary>
+    /// Seconds part of the expression
+    /// </summary>
+    public int Seconds { get; }
+
+    private readonly Lazy<string> _lazyEscapedParseableString;
+
+    /// <summary>
+    /// Weeks part of the expression
+    /// </summary>
+    public int Weeks { get; }
+
+    /// <summary>
+    /// Builds a new <see cref="DurationExpression"/> instance
+    /// </summary>
+    /// <param name="years"></param>
+    /// <param name="months"></param>
+    /// <param name="weeks"></param>
+    /// <param name="days"></param>
+    /// <param name="hours"></param>
+    /// <param name="minutes"></param>
+    /// <param name="seconds"></param>
+    public DurationExpression(int years = 0, int months = 0, int weeks = 0, int days = 0, int hours = 0, int minutes = 0, int seconds = 0)
     {
-        /// <summary>
-        /// Years part of the expression
-        /// </summary>
-        public int Years { get; }
-
-        /// <summary>
-        /// "Months" part of the expression
-        /// </summary>
-        public int Months { get; }
-
-        /// <summary>
-        /// "Days" part of the expression
-        /// </summary>
-        public int Days { get; }
-
-        /// <summary>
-        /// "Hours" part of the expression
-        /// </summary>
-        public int Hours { get; }
-
-        /// <summary>
-        /// "Minutes" part of the expression
-        /// </summary>
-        public int Minutes { get; }
-
-        /// <summary>
-        /// Seconds part of the expression
-        /// </summary>
-        public int Seconds { get; }
-
-        private readonly Lazy<string> _lazyEscapedParseableString;
-
-        /// <summary>
-        /// Weeks part of the expression
-        /// </summary>
-        public int Weeks { get; }
-
-        /// <summary>
-        /// Builds a new <see cref="DurationExpression"/> instance
-        /// </summary>
-        /// <param name="years"></param>
-        /// <param name="months"></param>
-        /// <param name="weeks"></param>
-        /// <param name="days"></param>
-        /// <param name="hours"></param>
-        /// <param name="minutes"></param>
-        /// <param name="seconds"></param>
-        public DurationExpression(int years = 0, int months = 0, int weeks = 0, int days = 0, int hours = 0, int minutes = 0, int seconds = 0)
+        if (years < 0)
         {
-            if (years < 0)
-            {
-                throw new ArgumentOutOfRangeException(nameof(years), years, $"{nameof(years)} cannot be negative");
-            }
-
-            if (months < 0)
-            {
-                throw new ArgumentOutOfRangeException(nameof(months), months, $"{nameof(months)} cannot be negative");
-            }
-
-            if (weeks < 0)
-            {
-                throw new ArgumentOutOfRangeException(nameof(weeks), weeks, $"{nameof(weeks)} cannot be negative");
-            }
-
-            if (days < 0)
-            {
-                throw new ArgumentOutOfRangeException(nameof(days), days, $"{nameof(days)} cannot be negative");
-            }
-
-            if (hours < 0)
-            {
-                throw new ArgumentOutOfRangeException(nameof(hours), hours, $"{nameof(hours)} cannot be negative");
-            }
-
-            if (minutes < 0)
-            {
-                throw new ArgumentOutOfRangeException(nameof(minutes), minutes, $"{nameof(minutes)} cannot be negative");
-            }
-
-            if (seconds < 0)
-            {
-                throw new ArgumentOutOfRangeException(nameof(seconds), seconds, $"{nameof(seconds)} cannot be negative");
-            }
-
-            (Years, Months, Weeks, Days, Hours, Minutes, Seconds) = (years, months, weeks, days, hours, minutes, seconds);
-
-            _lazyEscapedParseableString = new Lazy<string>(() => (Years, Months, Weeks, Days, Hours, Minutes, Seconds) switch
-            {
-                (0, 0, 0, 0, 0, 0, 0) => "PT0S",
-                _ => $"P{(Years > 0 ? $"{Years}Y" : string.Empty)}{(Months > 0 ? $"{Months}M" : string.Empty)}{(Weeks > 0 ? $"{Weeks}W" : string.Empty)}{(Days > 0 ? $"{Days}D" : string.Empty)}T{(Hours > 0 ? $"{Hours}H" : string.Empty)}{(Minutes > 0 ? $"{Minutes}M" : string.Empty)}{(Seconds > 0 ? $"{Seconds}S" : string.Empty)}"
-            });
+            throw new ArgumentOutOfRangeException(nameof(years), years, $"{nameof(years)} cannot be negative");
         }
 
-        ///<inheritdoc/>
-        public override bool IsEquivalentTo(FilterExpression other)
+        if (months < 0)
         {
-            bool equivalent = false;
-
-            if (((other as ISimplifiable)?.Simplify() ?? other) is DurationExpression otherDuration)
-            {
-                equivalent = Equals(otherDuration);
-                if (!equivalent)
-                {
-                    DateTime otherDateTime = ConvertToDateTime(otherDuration);
-                    DateTime current = ConvertToDateTime(this);
-
-                    equivalent = (current - otherDateTime) == TimeSpan.Zero;
-                }
-            }
-
-            return equivalent;
-
-            static DateTime ConvertToDateTime(DurationExpression duration)
-            {
-                return DateTime.MinValue.AddYears(duration.Years)
-                                        .AddMonths(duration.Months)
-                                        .AddDays((duration.Weeks * 7) + duration.Days)
-                                        .AddHours(duration.Hours)
-                                        .AddMinutes(duration.Minutes)
-                                        .AddSeconds(duration.Seconds);
-            }
+            throw new ArgumentOutOfRangeException(nameof(months), months, $"{nameof(months)} cannot be negative");
         }
 
-        ///<inheritdoc/>
-        public override bool Equals(object obj) => Equals(obj as DurationExpression);
+        if (weeks < 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(weeks), weeks, $"{nameof(weeks)} cannot be negative");
+        }
 
-        ///<inheritdoc/>
-        public bool Equals(DurationExpression other) => (Years, Months, Weeks, Days, Hours, Minutes, Seconds) == (other?.Years, other?.Months, other?.Weeks, other?.Days, other?.Hours, other?.Minutes, other?.Seconds);
+        if (days < 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(days), days, $"{nameof(days)} cannot be negative");
+        }
 
-        ///<inheritdoc/>
-        public override int GetHashCode() => (Years, Months, Weeks, Days, Hours, Minutes, Seconds).GetHashCode();
+        if (hours < 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(hours), hours, $"{nameof(hours)} cannot be negative");
+        }
 
-        ///<inheritdoc/>
-        public override string EscapedParseableString => _lazyEscapedParseableString.Value;
+        if (minutes < 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(minutes), minutes, $"{nameof(minutes)} cannot be negative");
+        }
+
+        if (seconds < 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(seconds), seconds, $"{nameof(seconds)} cannot be negative");
+        }
+
+        (Years, Months, Weeks, Days, Hours, Minutes, Seconds) = (years, months, weeks, days, hours, minutes, seconds);
+
+        _lazyEscapedParseableString = new Lazy<string>(() => (Years, Months, Weeks, Days, Hours, Minutes, Seconds) switch
+        {
+            (0, 0, 0, 0, 0, 0, 0) => "PT0S",
+            _ => $"P{(Years > 0 ? $"{Years}Y" : string.Empty)}{(Months > 0 ? $"{Months}M" : string.Empty)}{(Weeks > 0 ? $"{Weeks}W" : string.Empty)}{(Days > 0 ? $"{Days}D" : string.Empty)}T{(Hours > 0 ? $"{Hours}H" : string.Empty)}{(Minutes > 0 ? $"{Minutes}M" : string.Empty)}{(Seconds > 0 ? $"{Seconds}S" : string.Empty)}"
+        });
     }
+
+    ///<inheritdoc/>
+    public override bool IsEquivalentTo(FilterExpression other)
+    {
+        bool equivalent = false;
+
+        if (((other as ISimplifiable)?.Simplify() ?? other) is DurationExpression otherDuration)
+        {
+            equivalent = Equals(otherDuration);
+            if (!equivalent)
+            {
+                DateTime otherDateTime = ConvertToDateTime(otherDuration);
+                DateTime current = ConvertToDateTime(this);
+
+                equivalent = (current - otherDateTime) == TimeSpan.Zero;
+            }
+        }
+
+        return equivalent;
+
+        static DateTime ConvertToDateTime(DurationExpression duration)
+        {
+            return DateTime.MinValue.AddYears(duration.Years)
+                .AddMonths(duration.Months)
+                .AddDays((duration.Weeks * 7) + duration.Days)
+                .AddHours(duration.Hours)
+                .AddMinutes(duration.Minutes)
+                .AddSeconds(duration.Seconds);
+        }
+    }
+
+    ///<inheritdoc/>
+    public override bool Equals(object obj) => Equals(obj as DurationExpression);
+
+    ///<inheritdoc/>
+    public bool Equals(DurationExpression other) => (Years, Months, Weeks, Days, Hours, Minutes, Seconds) == (other?.Years, other?.Months, other?.Weeks, other?.Days, other?.Hours, other?.Minutes, other?.Seconds);
+
+    ///<inheritdoc/>
+    public override int GetHashCode() => (Years, Months, Weeks, Days, Hours, Minutes, Seconds).GetHashCode();
+
+    ///<inheritdoc/>
+    public override string EscapedParseableString => _lazyEscapedParseableString.Value;
 }

--- a/src/DataFilters/Grammar/Syntax/EndsWithExpression.cs
+++ b/src/DataFilters/Grammar/Syntax/EndsWithExpression.cs
@@ -1,84 +1,84 @@
 ﻿using DataFilters.Grammar.Parsing;
 
-namespace DataFilters.Grammar.Syntax
-{
-    using System;
-    using System.Collections.Generic;
-    using System.Linq;
-    using System.Text;
+namespace DataFilters.Grammar.Syntax;
 
-    using static Parsing.FilterTokenizer;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+using static Parsing.FilterTokenizer;
 
 #if !NETSTANDARD1_3
-    using Ardalis.GuardClauses;
+using Ardalis.GuardClauses;
 #endif
 
+/// <summary>
+/// A <see cref="FilterExpression"/> that holds a string value
+/// </summary>
+public sealed class EndsWithExpression : FilterExpression, IEquatable<EndsWithExpression>
+{
     /// <summary>
-    /// A <see cref="FilterExpression"/> that holds a string value
+    /// The value of the expression
     /// </summary>
-    public sealed class EndsWithExpression : FilterExpression, IEquatable<EndsWithExpression>
+    public string Value { get; }
+
+    private readonly Lazy<string> _lazyEscapedParseableString;
+
+    /// <summary>
+    /// Builds a new <see cref="EndsWithExpression"/> that holds the specified <paramref name="value"/>.
+    /// </summary>
+    /// <param name="value"></param>
+    /// <exception cref="ArgumentNullException"><paramref name="value"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentOutOfRangeException"><paramref name="value"/>'s length is <c>0</c>.</exception>
+    public EndsWithExpression(string value)
     {
-        /// <summary>
-        /// The value of the expression
-        /// </summary>
-        public string Value { get; }
-
-        private readonly Lazy<string> _lazyEscapedParseableString;
-
-        /// <summary>
-        /// Builds a new <see cref="EndsWithExpression"/> that holds the specified <paramref name="value"/>.
-        /// </summary>
-        /// <param name="value"></param>
-        /// <exception cref="ArgumentNullException"><paramref name="value"/> is <c>null</c>.</exception>
-        /// <exception cref="ArgumentOutOfRangeException"><paramref name="value"/>'s length is <c>0</c>.</exception>
-        public EndsWithExpression(string value)
+        Value = value switch
         {
-            Value = value switch
-            {
-                null => throw new ArgumentNullException(nameof(value)),
-                {Length: 0} => throw new ArgumentOutOfRangeException(nameof(value)),
-                _ => value
-            };
+            null => throw new ArgumentNullException(nameof(value)),
+            {Length: 0} => throw new ArgumentOutOfRangeException(nameof(value)),
+            _ => value
+        };
 
-            _lazyEscapedParseableString = new Lazy<string>(() =>
-            {
-                // The length of the final parseable string in worst cases scenario will double (1 backlash + the escaped character)
-                // Also we need an extra position for the final '*' that will be appended in all cases
-                bool requireEscapingCharacters = value.AtLeastOnce(chr => SpecialCharacters.Contains(chr));
-                StringBuilder parseableString;
+        _lazyEscapedParseableString = new Lazy<string>(() =>
+        {
+            // The length of the final parseable string in worst cases scenario will double (1 backlash + the escaped character)
+            // Also we need an extra position for the final '*' that will be appended in all cases
+            bool requireEscapingCharacters = value.AtLeastOnce(chr => SpecialCharacters.Contains(chr));
+            StringBuilder parseableString;
 
-                if (requireEscapingCharacters)
+            if (requireEscapingCharacters)
+            {
+                parseableString = new StringBuilder((value.Length * 2) + 1);
+                foreach (char chr in value)
                 {
-                    parseableString = new StringBuilder((value.Length * 2) + 1);
-                    foreach (char chr in value)
+                    if (SpecialCharacters.Contains(chr))
                     {
-                        if (SpecialCharacters.Contains(chr))
-                        {
-                            parseableString = parseableString.Append(BackSlash);
-                        }
-                        parseableString = parseableString.Append(chr);
+                        parseableString = parseableString.Append(BackSlash);
                     }
+                    parseableString = parseableString.Append(chr);
                 }
-                else
-                {
-                    parseableString = new StringBuilder(value, value.Length + 1);
-                }
+            }
+            else
+            {
+                parseableString = new StringBuilder(value, value.Length + 1);
+            }
 
-                return parseableString.Insert(0, Asterisk).ToString();
-            });
-        }
+            return parseableString.Insert(0, Asterisk).ToString();
+        });
+    }
 
-        /// <summary>
-        /// Builds a new <see cref="EndsWithExpression"/> that holds the specified <paramref name="text"/>.
-        /// </summary>
-        /// <param name="text"></param>
-        /// <exception cref="ArgumentNullException"><paramref name="text"/> is <c>null</c>.</exception>
-        public EndsWithExpression(TextExpression text)
+    /// <summary>
+    /// Builds a new <see cref="EndsWithExpression"/> that holds the specified <paramref name="text"/>.
+    /// </summary>
+    /// <param name="text"></param>
+    /// <exception cref="ArgumentNullException"><paramref name="text"/> is <see langword="null"/>.</exception>
+    public EndsWithExpression(TextExpression text)
 #if !NETSTANDARD1_3
-            : this(Guard.Against.Null(text, nameof(text)).OriginalString)
-        {
-            _lazyEscapedParseableString = new(() => $"{Asterisk}{text.EscapedParseableString}");
-        }
+        : this(Guard.Against.Null(text, nameof(text)).OriginalString)
+    {
+        _lazyEscapedParseableString = new(() => $"{Asterisk}{text.EscapedParseableString}");
+    }
 #else
         {
             if (text is null)
@@ -89,27 +89,26 @@ namespace DataFilters.Grammar.Syntax
         }
 #endif
 
-        ///<inheritdoc/>
-        public bool Equals(EndsWithExpression other) => Value == other?.Value;
+    ///<inheritdoc/>
+    public bool Equals(EndsWithExpression other) => Value == other?.Value;
 
-        ///<inheritdoc/>
-        public override bool Equals(object obj) => Equals(obj as EndsWithExpression);
+    ///<inheritdoc/>
+    public override bool Equals(object obj) => Equals(obj as EndsWithExpression);
 
-        ///<inheritdoc/>
-        public override int GetHashCode() => Value.GetHashCode();
+    ///<inheritdoc/>
+    public override int GetHashCode() => Value.GetHashCode();
 
-        ///<inheritdoc/>
-        public override string EscapedParseableString => _lazyEscapedParseableString.Value;
+    ///<inheritdoc/>
+    public override string EscapedParseableString => _lazyEscapedParseableString.Value;
 
-        ///<inheritdoc/>
-        public override double Complexity => 1.5;
+    ///<inheritdoc/>
+    public override double Complexity => 1.5;
 
-        /// <summary>
-        /// Constructs a new <see cref="ContainsExpression"/> by adding an <see cref="AsteriskExpression"/> to a <see cref="EndsWithExpression"/>>.
-        /// </summary>
-        /// <param name="left">The left operand</param>
-        /// <param name="_"></param>
-        /// <returns></returns>
-        public static ContainsExpression operator +(EndsWithExpression left, AsteriskExpression _) => new(left.Value);
-    }
+    /// <summary>
+    /// Constructs a new <see cref="ContainsExpression"/> by adding an <see cref="AsteriskExpression"/> to a <see cref="EndsWithExpression"/>>.
+    /// </summary>
+    /// <param name="left">The left operand</param>
+    /// <param name="_"></param>
+    /// <returns></returns>
+    public static ContainsExpression operator +(EndsWithExpression left, AsteriskExpression _) => new(left.Value);
 }

--- a/src/DataFilters/Grammar/Syntax/EndsWithExpression.cs
+++ b/src/DataFilters/Grammar/Syntax/EndsWithExpression.cs
@@ -1,4 +1,6 @@
-﻿namespace DataFilters.Grammar.Syntax
+﻿using DataFilters.Grammar.Parsing;
+
+namespace DataFilters.Grammar.Syntax
 {
     using System;
     using System.Collections.Generic;
@@ -52,7 +54,7 @@
                     {
                         if (SpecialCharacters.Contains(chr))
                         {
-                            parseableString = parseableString.Append('\\');
+                            parseableString = parseableString.Append(BackSlash);
                         }
                         parseableString = parseableString.Append(chr);
                     }
@@ -62,7 +64,7 @@
                     parseableString = new StringBuilder(value, value.Length + 1);
                 }
 
-                return parseableString.Insert(0, '*').ToString();
+                return parseableString.Insert(0, Asterisk).ToString();
             });
         }
 
@@ -75,7 +77,7 @@
 #if !NETSTANDARD1_3
             : this(Guard.Against.Null(text, nameof(text)).OriginalString)
         {
-            _lazyEscapedParseableString = new(() => $"*{text.EscapedParseableString}");
+            _lazyEscapedParseableString = new(() => $"{Asterisk}{text.EscapedParseableString}");
         }
 #else
         {

--- a/src/DataFilters/Grammar/Syntax/FilterExpression.cs
+++ b/src/DataFilters/Grammar/Syntax/FilterExpression.cs
@@ -1,97 +1,96 @@
 ﻿using System;
 
-namespace DataFilters.Grammar.Syntax
+namespace DataFilters.Grammar.Syntax;
+
+/// <summary>
+/// Base class for filter expression
+/// </summary>
+/// <para>
+/// <see cref="FilterExpression"/>s can take many forms : from the simplest <see cref="ConstantValueExpression"/> to more complex <see cref="GroupExpression"/>s.
+/// </para>
+public abstract class FilterExpression : IHaveComplexity, IParseableString, IFormattable
 {
     /// <summary>
-    /// Base class for filter expression
+    /// Tests if <paramref name="other"/> is equivalent to the current instance.
     /// </summary>
-    /// <para>
-    /// <see cref="FilterExpression"/>s can take many forms : from the simplest <see cref="ConstantValueExpression"/> to more complex <see cref="GroupExpression"/>s.
-    /// </para>
-    public abstract class FilterExpression : IHaveComplexity, IParseableString, IFormattable
+    /// <param name="other"><see cref="FilterExpression"/> against which the current instance will test is equivalency.</param>
+    /// <remarks>
+    /// The default implementation defers to <see cref="object.Equals(object)"/> implementation.
+    /// The meaning of the equivalency of two <see cref="FilterExpression"/>s is left to the implementor.
+    /// </remarks>
+    /// <returns>
+    /// <c>true</c> if <paramref name="other"/> is "equivalent" to the current instance.
+    /// </returns>
+    public virtual bool IsEquivalentTo(FilterExpression other) => Equals(other) || Equals(other.As<ISimplifiable>()?.Simplify());
+
+    ///<inheritdoc/>
+    public virtual double Complexity => 1;
+
+    ///<inheritdoc/>
+    public override string ToString() => $"{GetType().Name}: '{OriginalString}'";
+
+    /// <inheritdoc />
+    public virtual string ToString(string format, IFormatProvider formatProvider)
     {
-        /// <summary>
-        /// Tests if <paramref name="other"/> is equivalent to the current instance.
-        /// </summary>
-        /// <param name="other"><see cref="FilterExpression"/> against which the current instance will test is equivalency.</param>
-        /// <remarks>
-        /// The default implementation defers to <see cref="object.Equals(object)"/> implementation.
-        /// The meaning of the equivalency of two <see cref="FilterExpression"/>s is left to the implementor.
-        /// </remarks>
-        /// <returns>
-        /// <c>true</c> if <paramref name="other"/> is "equivalent" to the current instance.
-        /// </returns>
-        public virtual bool IsEquivalentTo(FilterExpression other) => Equals(other) || Equals(other.As<ISimplifiable>()?.Simplify());
-
-        ///<inheritdoc/>
-        public virtual double Complexity => 1;
-
-        ///<inheritdoc/>
-        public override string ToString() => $"{GetType().Name}: '{OriginalString}'";
-
-        /// <inheritdoc />
-        public virtual string ToString(string format, IFormatProvider formatProvider)
+        FormattableString formattable = (format ?? "d") switch
         {
-            FormattableString formattable = (format ?? "d") switch
-            {
-                "d" or "D" => $"@{GetType().Name}",
-                "f" or "F" => $"@{GetType().Name}(value : {EscapedParseableString})",
-                //null or "" => $"{ToString()}",
-                _ => throw new ArgumentOutOfRangeException(nameof(format), $"Unsupported '{format}' format")
-            };
+            "d" or "D" => $"@{GetType().Name}",
+            "f" or "F" => $"@{GetType().Name}(value : {EscapedParseableString})",
+            //null or "" => $"{ToString()}",
+            _ => throw new ArgumentOutOfRangeException(nameof(format), $"Unsupported '{format}' format")
+        };
 
-            return formattable.ToString(formatProvider);
-        }
-
-        ///<inheritdoc/>
-        public abstract string EscapedParseableString { get; }
-
-        ///<inheritdoc/>
-        public virtual string OriginalString => EscapedParseableString;
-
-        /// <summary>
-        /// Returns a <see cref="FilterExpression"/> that is the result of applying the NOT logical operator to the specified <paramref name="expression"/>.
-        /// </summary>
-        public static NotExpression operator !(FilterExpression expression) => new(expression);
-
-        /// <summary>
-        /// This utility method will simplify the given <paramref name="expression"/>
-        /// </summary>
-        /// <param name="expression">The expression to "simplify"</param>
-        /// <returns>The simplified version of <paramref name="expression"/> if it implements <see cref="ISimplifiable"/> or <paramref name="expression"/> if it cannot be simplified </returns>
-        /// <remarks>
-        /// The method will try to recursively simplify <paramref name="expression"/>
-        /// </remarks>
-        protected static FilterExpression SimplifyLocal(FilterExpression expression)
-        {
-            FilterExpression current = expression;
-            FilterExpression previous;
-
-            do
-            {
-                previous = current;
-                current = current.As<ISimplifiable>()?.Simplify() ?? current;
-            } while (current.Complexity < previous.Complexity && current is ISimplifiable);
-
-            return current;
-        }
-
-        /// <summary>
-        /// Creates an <see cref="OrExpression"/>.
-        /// </summary>
-        /// <param name="left">The left operand</param>
-        /// <param name="right">The right operand</param>
-        /// <returns>An <see cref="OrExpression"/> which <see cref="BinaryFilterExpression.Left"/> is <paramref name="left"/>
-        /// and <see cref="BinaryFilterExpression.Right"/> is <paramref name="right"/>.</returns>
-        public static OrExpression operator |(FilterExpression left, FilterExpression right) => new (left, right);
-
-        /// <summary>
-        /// Creates an <see cref="AndExpression"/>.
-        /// </summary>
-        /// <param name="left">The left operand</param>
-        /// <param name="right">The right operand</param>
-        /// <returns>An <see cref="AndExpression"/> which <see cref="BinaryFilterExpression.Left"/> is <paramref name="left"/>
-        /// and <see cref="BinaryFilterExpression.Right"/> is <paramref name="right"/>.</returns>
-        public static AndExpression operator &(FilterExpression left, FilterExpression right) => new (left, right);
+        return formattable.ToString(formatProvider);
     }
+
+    ///<inheritdoc/>
+    public abstract string EscapedParseableString { get; }
+
+    ///<inheritdoc/>
+    public virtual string OriginalString => EscapedParseableString;
+
+    /// <summary>
+    /// Returns a <see cref="FilterExpression"/> that is the result of applying the NOT logical operator to the specified <paramref name="expression"/>.
+    /// </summary>
+    public static NotExpression operator !(FilterExpression expression) => new(expression);
+
+    /// <summary>
+    /// This utility method will simplify the given <paramref name="expression"/>
+    /// </summary>
+    /// <param name="expression">The expression to "simplify"</param>
+    /// <returns>The simplified version of <paramref name="expression"/> if it implements <see cref="ISimplifiable"/> or <paramref name="expression"/> if it cannot be simplified </returns>
+    /// <remarks>
+    /// The method will try to recursively simplify <paramref name="expression"/>
+    /// </remarks>
+    protected static FilterExpression SimplifyLocal(FilterExpression expression)
+    {
+        FilterExpression current = expression;
+        FilterExpression previous;
+
+        do
+        {
+            previous = current;
+            current = current.As<ISimplifiable>()?.Simplify() ?? current;
+        } while (current.Complexity < previous.Complexity && current is ISimplifiable);
+
+        return current;
+    }
+
+    /// <summary>
+    /// Creates an <see cref="OrExpression"/>.
+    /// </summary>
+    /// <param name="left">The left operand</param>
+    /// <param name="right">The right operand</param>
+    /// <returns>An <see cref="OrExpression"/> which <see cref="BinaryFilterExpression.Left"/> is <paramref name="left"/>
+    /// and <see cref="BinaryFilterExpression.Right"/> is <paramref name="right"/>.</returns>
+    public static OrExpression operator |(FilterExpression left, FilterExpression right) => new (left, right);
+
+    /// <summary>
+    /// Creates an <see cref="AndExpression"/>.
+    /// </summary>
+    /// <param name="left">The left operand</param>
+    /// <param name="right">The right operand</param>
+    /// <returns>An <see cref="AndExpression"/> which <see cref="BinaryFilterExpression.Left"/> is <paramref name="left"/>
+    /// and <see cref="BinaryFilterExpression.Right"/> is <paramref name="right"/>.</returns>
+    public static AndExpression operator &(FilterExpression left, FilterExpression right) => new (left, right);
 }

--- a/src/DataFilters/Grammar/Syntax/GroupExpression.cs
+++ b/src/DataFilters/Grammar/Syntax/GroupExpression.cs
@@ -1,82 +1,81 @@
-﻿namespace DataFilters.Grammar.Syntax
+﻿namespace DataFilters.Grammar.Syntax;
+
+using System;
+
+/// <summary>
+/// Allows to treat several expressions as a single unit.
+/// </summary>
+/// <remarks>
+/// <para>
+/// A group expression can be used whenever there is a need to apply a logical operator to several expressions at once.
+/// </para>
+/// <para>
+/// The <see cref="Complexity"/> value of a <see cref="GroupExpression"/> is equivalent to the complexity of its inner <see cref="Expression"/>
+/// plus a marginal overhead.
+/// </para>
+/// </remarks>
+public sealed class GroupExpression : FilterExpression, IEquatable<GroupExpression>, ISimplifiable
 {
-    using System;
+    private readonly Lazy<string> _lazyEscapedString;
 
     /// <summary>
-    /// Allows to treat several expressions as a single unit.
+    /// Builds a new <see cref="GroupExpression"/> that holds the specified <paramref name="expression"/>.
     /// </summary>
-    /// <remarks>
-    /// <para>
-    /// A group expression can be used whenever there is a need to apply a logical operator to several expressions at once.
-    /// </para>
-    /// <para>
-    /// The <see cref="Complexity"/> value of a <see cref="GroupExpression"/> is equivalent to the complexity of its inner <see cref="Expression"/>
-    /// plus a marginal overhead.
-    /// </para>
-    /// </remarks>
-    public sealed class GroupExpression : FilterExpression, IEquatable<GroupExpression>, ISimplifiable
+    /// <param name="expression">the expression to group</param>
+    /// <exception cref="ArgumentNullException"><paramref name="expression"/> is <see langword="null"/>.</exception>
+    public GroupExpression(FilterExpression expression)
     {
-        private readonly Lazy<string> _lazyEscapedString;
+        Expression = expression ?? throw new ArgumentNullException(nameof(expression));
+        _lazyEscapedString = new Lazy<string>(() => $"({Expression.EscapedParseableString})");
+    }
 
-        /// <summary>
-        /// Builds a new <see cref="GroupExpression"/> that holds the specified <paramref name="expression"/>.
-        /// </summary>
-        /// <param name="expression">the expression to group</param>
-        /// <exception cref="ArgumentNullException"><paramref name="expression"/> is <see langword="null"/>.</exception>
-        public GroupExpression(FilterExpression expression)
+    /// <summary>
+    /// <see cref="FilterExpression"/> that the current instance is applied onto.
+    /// </summary>
+    public FilterExpression Expression { get; }
+
+    ///<inheritdoc/>
+    public bool Equals(GroupExpression other) => Expression.Equals(other?.Expression);
+
+    ///<inheritdoc/>
+    public override bool Equals(object obj) => Equals(obj as GroupExpression);
+
+    ///<inheritdoc/>
+    public override int GetHashCode() => Expression.GetHashCode();
+
+    /// <inheritdoc />
+    public override string ToString(string format, IFormatProvider formatProvider)
+    {
+        FormattableString formattable = format switch
         {
-            Expression = expression ?? throw new ArgumentNullException(nameof(expression));
-            _lazyEscapedString = new Lazy<string>(() => $"({Expression.EscapedParseableString})");
-        }
-
-        /// <summary>
-        /// <see cref="FilterExpression"/> that the current instance is applied onto.
-        /// </summary>
-        public FilterExpression Expression { get; }
-
-        ///<inheritdoc/>
-        public bool Equals(GroupExpression other) => Expression.Equals(other?.Expression);
-
-        ///<inheritdoc/>
-        public override bool Equals(object obj) => Equals(obj as GroupExpression);
-
-        ///<inheritdoc/>
-        public override int GetHashCode() => Expression.GetHashCode();
-
-        /// <inheritdoc />
-        public override string ToString(string format, IFormatProvider formatProvider)
-        {
-            FormattableString formattable = format switch
-            {
-                "d" or "D" => $"@{nameof(GroupExpression)}({Expression:d})",
-                "f" or "F" => $"@{nameof(GroupExpression)}({Expression:d})",
-                null or "" => $"{EscapedParseableString}",
-                _ => throw new ArgumentOutOfRangeException(nameof(format), $"Unsupported '{format}' format")
-            };
-
-            return formattable.ToString(formatProvider);
-        }
-
-        ///<inheritdoc/>
-        public override string EscapedParseableString => _lazyEscapedString.Value;
-
-        ///<inheritdoc/>
-        public override double Complexity => 0.1 + Expression.Complexity;
-
-        ///<inheritdoc/>
-        public override bool IsEquivalentTo(FilterExpression other) => other switch
-        {
-            GroupExpression {Expression: var innerExpression } => Expression.IsEquivalentTo(innerExpression),
-            _ => Expression.IsEquivalentTo(other)
+            "d" or "D" => $"@{nameof(GroupExpression)}({Expression:d})",
+            "f" or "F" => $"@{nameof(GroupExpression)}({Expression:d})",
+            null or "" => $"{EscapedParseableString}",
+            _ => throw new ArgumentOutOfRangeException(nameof(format), $"Unsupported '{format}' format")
         };
 
-        ///<inheritdoc/>
-        public FilterExpression Simplify()
-            => Expression switch
-            {
-                //ConstantValueExpression constant => constant,
-                ISimplifiable simplify => simplify.Simplify(),
-                _ => Expression
-            };
+        return formattable.ToString(formatProvider);
     }
+
+    ///<inheritdoc/>
+    public override string EscapedParseableString => _lazyEscapedString.Value;
+
+    ///<inheritdoc/>
+    public override double Complexity => 0.1 + Expression.Complexity;
+
+    ///<inheritdoc/>
+    public override bool IsEquivalentTo(FilterExpression other) => other switch
+    {
+        GroupExpression {Expression: var innerExpression } => Expression.IsEquivalentTo(innerExpression),
+        _ => Expression.IsEquivalentTo(other)
+    };
+
+    ///<inheritdoc/>
+    public FilterExpression Simplify()
+        => Expression switch
+        {
+            //ConstantValueExpression constant => constant,
+            ISimplifiable simplify => simplify.Simplify(),
+            _ => Expression
+        };
 }

--- a/src/DataFilters/Grammar/Syntax/GuidValueExpression.cs
+++ b/src/DataFilters/Grammar/Syntax/GuidValueExpression.cs
@@ -1,16 +1,15 @@
 ﻿
-namespace DataFilters.Grammar.Syntax
+namespace DataFilters.Grammar.Syntax;
+
+/// <summary>
+/// Wraps a string that represents a <see cref="System.Guid"/>
+/// </summary>
+/// <remarks>
+/// Builds a new <see cref="GuidValueExpression"/> instance that can wrap a <see cref="System.Guid"/>
+/// </remarks>
+/// <param name="value"></param>
+public class GuidValueExpression(string value) : ConstantValueExpression(value)
 {
-    /// <summary>
-    /// Wraps a string that represents a <see cref="System.Guid"/>
-    /// </summary>
-    /// <remarks>
-    /// Builds a new <see cref="GuidValueExpression"/> instance that can wrap a <see cref="System.Guid"/>
-    /// </remarks>
-    /// <param name="value"></param>
-    public class GuidValueExpression(string value) : ConstantValueExpression(value)
-    {
-        ///<inheritdoc/>
-        public override string EscapedParseableString => Value;
-    }
+    ///<inheritdoc/>
+    public override string EscapedParseableString => Value;
 }

--- a/src/DataFilters/Grammar/Syntax/IBoundaryExpression.cs
+++ b/src/DataFilters/Grammar/Syntax/IBoundaryExpression.cs
@@ -1,7 +1,6 @@
-﻿namespace DataFilters.Grammar.Syntax
-{
-    /// <summary>
-    /// Marker interface that identifies types that can be used as <see cref="IntervalExpression"/>'s boundaries
-    /// </summary>
-    public interface IBoundaryExpression : IHaveComplexity, IParseableString;
-}
+﻿namespace DataFilters.Grammar.Syntax;
+
+/// <summary>
+/// Marker interface that identifies types that can be used as <see cref="IntervalExpression"/>'s boundaries
+/// </summary>
+public interface IBoundaryExpression : IHaveComplexity, IParseableString;

--- a/src/DataFilters/Grammar/Syntax/IHaveComplexity.cs
+++ b/src/DataFilters/Grammar/Syntax/IHaveComplexity.cs
@@ -1,24 +1,23 @@
-﻿namespace DataFilters.Grammar.Syntax
+﻿namespace DataFilters.Grammar.Syntax;
+
+/// <summary>
+/// Marks an expression that have a complexity value.
+/// </summary>
+public interface IHaveComplexity
 {
     /// <summary>
-    /// Marks an expression that have a complexity value.
+    /// Gets the "complexity" of the current instance.
     /// </summary>
-    public interface IHaveComplexity
-    {
-        /// <summary>
-        /// Gets the "complexity" of the current instance.
-        /// </summary>
-        /// <remarks>
-        /// <para>
-        /// The complexity is a hint, given two <see cref="FilterExpression"/>s, of which one is the cheapest to compute.
-        /// For example, <c>*[Mm]an</c> and <c>*Man|*man</c> are semantically equivalent but the latter is less "complex" than the first because it a combination of 3 primary
-        /// <see cref="FilterExpression"/>s (<c>starts with</c>, <c>Bracket</c> and <c>constant</c>).
-        /// </para>
-        /// </remarks>
+    /// <remarks>
+    /// <para>
+    /// The complexity is a hint, given two <see cref="FilterExpression"/>s, of which one is the cheapest to compute.
+    /// For example, <c>*[Mm]an</c> and <c>*Man|*man</c> are semantically equivalent but the latter is less "complex" than the first because it a combination of 3 primary
+    /// <see cref="FilterExpression"/>s (<c>starts with</c>, <c>Bracket</c> and <c>constant</c>).
+    /// </para>
+    /// </remarks>
 #if NET5_0_OR_GREATER
-        public virtual double Complexity => 0;
+    public virtual double Complexity => 0;
 #else
         double Complexity { get; }
 #endif
-    }
 }

--- a/src/DataFilters/Grammar/Syntax/IParseableString.cs
+++ b/src/DataFilters/Grammar/Syntax/IParseableString.cs
@@ -1,21 +1,20 @@
-﻿namespace DataFilters.Grammar.Syntax
+﻿namespace DataFilters.Grammar.Syntax;
+
+/// <summary>
+/// Defines <see cref="EscapedParseableString"/> property.
+/// </summary>
+public interface IParseableString
 {
     /// <summary>
-    /// Defines <see cref="EscapedParseableString"/> property.
+    /// The string that, if parsed, will give the current expression.
     /// </summary>
-    public interface IParseableString
-    {
-        /// <summary>
-        /// The string that, if parsed, will give the current expression.
-        /// </summary>
-        string EscapedParseableString { get; }
+    string EscapedParseableString { get; }
 
-        /// <summary>
-        /// Unescaped version of the parseable string.
-        /// </summary>
-        /// <remarks>
-        /// This is the raw version which <see cref="EscapedParseableString"/> is computed from.
-        /// </remarks>
-        string OriginalString { get; }
-    }
+    /// <summary>
+    /// Unescaped version of the parseable string.
+    /// </summary>
+    /// <remarks>
+    /// This is the raw version which <see cref="EscapedParseableString"/> is computed from.
+    /// </remarks>
+    string OriginalString { get; }
 }

--- a/src/DataFilters/Grammar/Syntax/ISimplifiable.cs
+++ b/src/DataFilters/Grammar/Syntax/ISimplifiable.cs
@@ -1,16 +1,15 @@
-﻿namespace DataFilters.Grammar.Syntax
+﻿namespace DataFilters.Grammar.Syntax;
+
+/// <summary>
+/// Defines a <see cref="Simplify"/> method which rewrites an instance to a "simpler" form.
+/// </summary>
+public interface ISimplifiable
 {
     /// <summary>
-    /// Defines a <see cref="Simplify"/> method which rewrites an instance to a "simpler" form.
+    /// Builds a <see cref="FilterExpression"/> which is equivalent to the current instance but which
+    /// <see cref="FilterExpression.Complexity"/> should be lower than the initial <see cref="FilterExpression"/>.
     /// </summary>
-    public interface ISimplifiable
-    {
-        /// <summary>
-        /// Builds a <see cref="FilterExpression"/> which is equivalent to the current instance but which
-        /// <see cref="FilterExpression.Complexity"/> should be lower than the initial <see cref="FilterExpression"/>.
-        /// </summary>
-        /// <returns>a rewritten version of the current <see cref="FilterExpression"/> which
-        /// <see cref="FilterExpression.Complexity"/> should be lower.</returns>
-        FilterExpression Simplify();
-    }
+    /// <returns>a rewritten version of the current <see cref="FilterExpression"/> which
+    /// <see cref="FilterExpression.Complexity"/> should be lower.</returns>
+    FilterExpression Simplify();
 }

--- a/src/DataFilters/Grammar/Syntax/IntervalExpression.cs
+++ b/src/DataFilters/Grammar/Syntax/IntervalExpression.cs
@@ -1,226 +1,225 @@
 ﻿using System.Runtime.CompilerServices;
 
-namespace DataFilters.Grammar.Syntax
+namespace DataFilters.Grammar.Syntax;
+
+using System;
+using Exceptions;
+
+/// <summary>
+/// A <see cref="FilterExpression"/> that holds an interval between <see cref="Min"/> and <see cref="Max"/> values.
+/// </summary>
+public sealed class IntervalExpression : FilterExpression, IEquatable<IntervalExpression>, ISimplifiable, IFormattable
 {
-    using System;
-    using Exceptions;
+    /// <summary>
+    /// Lower bound of the current instance
+    /// </summary>
+    public BoundaryExpression Min { get; }
 
     /// <summary>
-    /// A <see cref="FilterExpression"/> that holds an interval between <see cref="Min"/> and <see cref="Max"/> values.
+    /// Upper bound of the current instance
     /// </summary>
-    public sealed class IntervalExpression : FilterExpression, IEquatable<IntervalExpression>, ISimplifiable, IFormattable
+    public BoundaryExpression Max { get; }
+
+    private readonly Lazy<string> _lazyToString;
+    private readonly Lazy<string> _lazyParseableString;
+
+    /// <summary>
+    /// Builds a new <see cref="IntervalExpression"/> instance
+    /// </summary>
+    /// <param name="min">Lower bound of the interval</param>
+    /// <param name="max">Upper bound of the interval</param>
+    /// <exception cref="ArgumentNullException">if both <paramref name="min"/> and <paramref name="max"/> are <see langword="null"/>.</exception>
+    /// <exception cref="BoundariesTypeMismatchException">if <paramref name="min"/> and <paramref name="max"/> types are not "compatible".</exception>
+    /// <exception cref="IncorrectBoundaryException">if
+    /// <list type="bullet">
+    ///     <item>both<paramref name="min"/> and <paramref name="max"/> types are <see cref="AsteriskExpression"/>.</item>
+    ///     <item>both<paramref name="min"/> is <see cref="AsteriskExpression"/> and <paramref name="max"/> <see langword="null"/>.</item>
+    /// </list>
+    /// </exception>
+    /// <remarks>
+    ///     Either <paramref name="min"/> or <paramref name="max"/> can be null to indicate and unbounded lower (respectively upper) bound.
+    /// </remarks>
+    public IntervalExpression(BoundaryExpression min = null, BoundaryExpression max = null)
     {
-        /// <summary>
-        /// Lower bound of the current instance
-        /// </summary>
-        public BoundaryExpression Min { get; }
-
-        /// <summary>
-        /// Upper bound of the current instance
-        /// </summary>
-        public BoundaryExpression Max { get; }
-
-        private readonly Lazy<string> _lazyToString;
-        private readonly Lazy<string> _lazyParseableString;
-
-        /// <summary>
-        /// Builds a new <see cref="IntervalExpression"/> instance
-        /// </summary>
-        /// <param name="min">Lower bound of the interval</param>
-        /// <param name="max">Upper bound of the interval</param>
-        /// <exception cref="ArgumentNullException">if both <paramref name="min"/> and <paramref name="max"/> are <c>null</c>.</exception>
-        /// <exception cref="BoundariesTypeMismatchException">if <paramref name="min"/> and <paramref name="max"/> types are not "compatible".</exception>
-        /// <exception cref="IncorrectBoundaryException">if
-        /// <list type="bullet">
-        ///     <item>both<paramref name="min"/> and <paramref name="max"/> types are <see cref="AsteriskExpression"/>.</item>
-        ///     <item>both<paramref name="min"/> is <see cref="AsteriskExpression"/> and <paramref name="max"/> <c>null</c>.</item>
-        /// </list>
-        /// </exception>
-        /// <remarks>
-        ///     Either <paramref name="min"/> or <paramref name="max"/> can be null to indicate and unbounded lower (respectively upper) bound.
-        /// </remarks>
-        public IntervalExpression(BoundaryExpression min = null, BoundaryExpression max = null)
+        switch (min?.Expression)
         {
-            switch (min?.Expression)
-            {
-                case AsteriskExpression when max?.Expression is AsteriskExpression expression:
-                    throw new IncorrectBoundaryException($"{nameof(min)} and {nameof(max)} cannot be both {nameof(AsteriskExpression)}");
-                case AsteriskExpression when max is null:
-                    throw new IncorrectBoundaryException($"{nameof(max)} cannot be null when {nameof(min)} is {nameof(AsteriskExpression)}");
-                case DateExpression when max is not null && !(max.Expression is AsteriskExpression || max.Expression is DateExpression || max.Expression is TimeExpression || max.Expression is DateTimeExpression):
-                    throw new BoundariesTypeMismatchException($"{nameof(min)}[{min?.Expression?.GetType()}] and {nameof(max)}[{max?.Expression?.GetType()}] types are not compatible", nameof(max));
-                case ConstantValueExpression when !(max is null || max.Expression is ConstantValueExpression || max.Expression is AsteriskExpression):
-                    throw new BoundariesTypeMismatchException($"{nameof(min)}[{min?.Expression?.GetType()}] and {nameof(max)}[{max?.Expression?.GetType()}] types are not compatible", nameof(max));
-            }
+            case AsteriskExpression when max?.Expression is AsteriskExpression expression:
+                throw new IncorrectBoundaryException($"{nameof(min)} and {nameof(max)} cannot be both {nameof(AsteriskExpression)}");
+            case AsteriskExpression when max is null:
+                throw new IncorrectBoundaryException($"{nameof(max)} cannot be null when {nameof(min)} is {nameof(AsteriskExpression)}");
+            case DateExpression when max is not null && !(max.Expression is AsteriskExpression || max.Expression is DateExpression || max.Expression is TimeExpression || max.Expression is DateTimeExpression):
+                throw new BoundariesTypeMismatchException($"{nameof(min)}[{min?.Expression?.GetType()}] and {nameof(max)}[{max?.Expression?.GetType()}] types are not compatible", nameof(max));
+            case ConstantValueExpression when !(max is null || max.Expression is ConstantValueExpression || max.Expression is AsteriskExpression):
+                throw new BoundariesTypeMismatchException($"{nameof(min)}[{min?.Expression?.GetType()}] and {nameof(max)}[{max?.Expression?.GetType()}] types are not compatible", nameof(max));
+        }
 
-            if (min is null && max is null)
-            {
-                throw new IncorrectBoundaryException($"{nameof(min)} or {nameof(max)} must not be null.");
-            }
+        if (min is null && max is null)
+        {
+            throw new IncorrectBoundaryException($"{nameof(min)} or {nameof(max)} must not be null.");
+        }
 
-            if (min?.Expression is TimeExpression && max is not null && max.Expression is not TimeExpression && max.Expression is not AsteriskExpression)
-            {
-                throw new BoundariesTypeMismatchException($"{nameof(max)} must be either {nameof(TimeExpression)} or {nameof(AsteriskExpression)} when min is {nameof(TimeExpression)}", nameof(max));
-            }
+        if (min?.Expression is TimeExpression && max is not null && max.Expression is not TimeExpression && max.Expression is not AsteriskExpression)
+        {
+            throw new BoundariesTypeMismatchException($"{nameof(max)} must be either {nameof(TimeExpression)} or {nameof(AsteriskExpression)} when min is {nameof(TimeExpression)}", nameof(max));
+        }
 
-            Min = min?.Expression switch
+        Min = min?.Expression switch
+        {
+            AsteriskExpression or null => null,
+            DateTimeExpression { Date: var date, Time: var time, Offset: var offset } => (date, time, offset) switch
             {
-                AsteriskExpression or null => null,
-                DateTimeExpression { Date: var date, Time: var time, Offset: var offset } => (date, time, offset) switch
-                {
-                    (null, not null, _) => new BoundaryExpression(time, included: min.Included),
-                    (not null, null, _) => new BoundaryExpression(date, included: min.Included),
-                    _ => new BoundaryExpression(new DateTimeExpression(date, time, offset), included: min.Included)
-                },
-                _ => min
-            };
+                (null, not null, _) => new BoundaryExpression(time, included: min.Included),
+                (not null, null, _) => new BoundaryExpression(date, included: min.Included),
+                _ => new BoundaryExpression(new DateTimeExpression(date, time, offset), included: min.Included)
+            },
+            _ => min
+        };
 
-            Max = max?.Expression switch
+        Max = max?.Expression switch
+        {
+            AsteriskExpression or null => null,
+            DateTimeExpression { Date: var date, Time: var time, Offset: var offset } => (date, time, offset) switch
             {
-                AsteriskExpression or null => null,
-                DateTimeExpression { Date: var date, Time: var time, Offset: var offset } => (date, time, offset) switch
-                {
-                    (null, not null, _) => new BoundaryExpression(time, included: max.Included),
-                    (not null, null, _) => new BoundaryExpression(date, included: max.Included),
-                    _ => new BoundaryExpression(new DateTimeExpression(date, time, offset), included: max.Included)
-                },
-                TimeExpression time when Min?.Expression is DateTimeExpression dateTime => new BoundaryExpression(new DateTimeExpression(dateTime.Date, time, dateTime.Offset), max.Included),
-                TimeExpression time => new BoundaryExpression(time, included: max.Included),
-                _ => max
-            };
+                (null, not null, _) => new BoundaryExpression(time, included: max.Included),
+                (not null, null, _) => new BoundaryExpression(date, included: max.Included),
+                _ => new BoundaryExpression(new DateTimeExpression(date, time, offset), included: max.Included)
+            },
+            TimeExpression time when Min?.Expression is DateTimeExpression dateTime => new BoundaryExpression(new DateTimeExpression(dateTime.Date, time, dateTime.Offset), max.Included),
+            TimeExpression time => new BoundaryExpression(time, included: max.Included),
+            _ => max
+        };
 
-            _lazyParseableString = new Lazy<string>(() => $"{GetMinBracket(Min?.Included)}{Min?.Expression?.EscapedParseableString ?? "*"} TO {Max?.Expression?.EscapedParseableString ?? "*"}{GetMaxBracket(Max?.Included)}");
-            _lazyToString = new Lazy<string>(() => new
-            {
-                Min = new
-                {
-                    Min?.Included,
-                    Min?.Expression?.EscapedParseableString,
-                    Type = Min?.Expression?.GetType().Name
-                },
-                Max = new
-                {
-                    Max?.Included,
-                    Max?.Expression?.EscapedParseableString,
-                    Type = Max?.Expression?.GetType().Name
-                },
-                EscapedParseableString
-            }
+        _lazyParseableString = new Lazy<string>(() => $"{GetMinBracket(Min?.Included)}{Min?.Expression?.EscapedParseableString ?? "*"} TO {Max?.Expression?.EscapedParseableString ?? "*"}{GetMaxBracket(Max?.Included)}");
+        _lazyToString = new Lazy<string>(() => new
+                    {
+                        Min = new
+                        {
+                            Min?.Included,
+                            Min?.Expression?.EscapedParseableString,
+                            Type = Min?.Expression?.GetType().Name
+                        },
+                        Max = new
+                        {
+                            Max?.Included,
+                            Max?.Expression?.EscapedParseableString,
+                            Type = Max?.Expression?.GetType().Name
+                        },
+                        EscapedParseableString
+                    }
 #if NETSTANDARD1_3
         .Jsonify(new Newtonsoft.Json.JsonSerializerSettings() { Formatting = Newtonsoft.Json.Formatting.Indented })
 #elif NETSTANDARD2_0_OR_GREATER || NET6_0_OR_GREATER
-        .Jsonify(new() { WriteIndented = true, DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull })
+                    .Jsonify(new() { WriteIndented = true, DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull })
 #endif
-                )
-        ;
+            )
+            ;
 
-            static string GetMinBracket(bool? included) => true.Equals(included) ? "[" : "]";
-            static string GetMaxBracket(bool? included) => true.Equals(included) ? "]" : "[";
-        }
+        static string GetMinBracket(bool? included) => true.Equals(included) ? "[" : "]";
+        static string GetMaxBracket(bool? included) => true.Equals(included) ? "]" : "[";
+    }
 
-        ///<inheritdoc/>
-        public override bool Equals(object obj) => Equals(obj as IntervalExpression);
+    ///<inheritdoc/>
+    public override bool Equals(object obj) => Equals(obj as IntervalExpression);
 
-        ///<inheritdoc/>
-        public bool Equals(IntervalExpression other)
+    ///<inheritdoc/>
+    public bool Equals(IntervalExpression other)
+    {
+        bool equals = false;
+
+        if (other is not null)
         {
-            bool equals = false;
-
-            if (other is not null)
+            if (Min is null)
             {
-                if (Min is null)
-                {
-                    if (other.Min is null)
-                    {
-                        equals = Max?.Equals(other.Max) ?? other.Max is null;
-                    }
-                }
-                else if (Min.Equals(other.Min))
+                if (other.Min is null)
                 {
                     equals = Max?.Equals(other.Max) ?? other.Max is null;
                 }
             }
-
-            return equals;
-        }
-
-        ///<inheritdoc/>
-        public override int GetHashCode() => (Min, Max).GetHashCode();
-
-        ///<inheritdoc/>
-        public override string ToString() => _lazyToString.Value;
-
-        ///<inheritdoc/>
-        public override string EscapedParseableString => _lazyParseableString.Value;
-
-        ///<inheritdoc/>
-        public override bool IsEquivalentTo(FilterExpression other)
-        {
-            bool equivalent = false;
-            if (other is not null)
+            else if (Min.Equals(other.Min))
             {
-                if (ReferenceEquals(this, other))
-                {
-                    equivalent = true;
-                }
-                else if (other is IntervalExpression range)
-                {
-                    equivalent = Equals(range);
-                }
-                else if (other is ISimplifiable simplifiable)
-                {
-                    equivalent = Simplify().Equals(simplifiable.Simplify());
-                }
-                else
-                {
-                    equivalent = Min?.Included == true && Max?.Included == true && Min.Equals(Max) && Min.Expression.Equals(other);
-                }
+                equals = Max?.Equals(other.Max) ?? other.Max is null;
             }
-
-            return equivalent;
         }
 
-        /// <summary>
-        /// Deconstruction method
-        /// </summary>
-        /// <param name="min">lower bound of the interval</param>
-        /// <param name="max">Upper bound of the interval</param>
-        public void Deconstruct(out BoundaryExpression min, out BoundaryExpression max)
+        return equals;
+    }
+
+    ///<inheritdoc/>
+    public override int GetHashCode() => (Min, Max).GetHashCode();
+
+    ///<inheritdoc/>
+    public override string ToString() => _lazyToString.Value;
+
+    ///<inheritdoc/>
+    public override string EscapedParseableString => _lazyParseableString.Value;
+
+    ///<inheritdoc/>
+    public override bool IsEquivalentTo(FilterExpression other)
+    {
+        bool equivalent = false;
+        if (other is not null)
         {
-            min = Min;
-            max = Max;
-        }
-
-        /// <inheritdoc/>
-        public override double Complexity => (Min?.Expression?.Complexity ?? 0) + (Max?.Expression?.Complexity ?? 0);
-
-        /// <inheritdoc/>
-        public FilterExpression Simplify()
-        {
-            FilterExpression simplified = this;
-
-            if (Min is not null && Max is not null && Min.Included && Max.Included && Min.Equals(Max))
+            if (ReferenceEquals(this, other))
             {
-                simplified = ((FilterExpression)Min.Expression).Complexity < ((FilterExpression)Max.Expression).Complexity
-                    ? (FilterExpression)Min.Expression
-                    : (FilterExpression)Max.Expression;
+                equivalent = true;
             }
-
-            return simplified;
-        }
-
-        /// <inheritdoc />
-        public override string ToString(string format, IFormatProvider formatProvider)
-        {
-            FormattableString formattable = format switch
+            else if (other is IntervalExpression range)
             {
-                "d" or "D" => $"@{nameof(IntervalExpression)}({Min?.Expression:d}:{Min?.Included},{Max?.Expression:d}:{Max?.Included})",
-                "f" or "F" => $"@{nameof(IntervalExpression)}({Min?.Expression:d}:{Min?.Included},{Max?.Expression:d}:{Max?.Included})",
-                null or "" => $"{ToString()}",
-                _ => throw new NotSupportedException($"Unknown '{format}' format")
-            };
-
-            return formattable.ToString(formatProvider);
+                equivalent = Equals(range);
+            }
+            else if (other is ISimplifiable simplifiable)
+            {
+                equivalent = Simplify().Equals(simplifiable.Simplify());
+            }
+            else
+            {
+                equivalent = Min?.Included == true && Max?.Included == true && Min.Equals(Max) && Min.Expression.Equals(other);
+            }
         }
+
+        return equivalent;
+    }
+
+    /// <summary>
+    /// Deconstruction method
+    /// </summary>
+    /// <param name="min">lower bound of the interval</param>
+    /// <param name="max">Upper bound of the interval</param>
+    public void Deconstruct(out BoundaryExpression min, out BoundaryExpression max)
+    {
+        min = Min;
+        max = Max;
+    }
+
+    /// <inheritdoc/>
+    public override double Complexity => (Min?.Expression?.Complexity ?? 0) + (Max?.Expression?.Complexity ?? 0);
+
+    /// <inheritdoc/>
+    public FilterExpression Simplify()
+    {
+        FilterExpression simplified = this;
+
+        if (Min is not null && Max is not null && Min.Included && Max.Included && Min.Equals(Max))
+        {
+            simplified = ((FilterExpression)Min.Expression).Complexity < ((FilterExpression)Max.Expression).Complexity
+                ? (FilterExpression)Min.Expression
+                : (FilterExpression)Max.Expression;
+        }
+
+        return simplified;
+    }
+
+    /// <inheritdoc />
+    public override string ToString(string format, IFormatProvider formatProvider)
+    {
+        FormattableString formattable = format switch
+        {
+            "d" or "D" => $"@{nameof(IntervalExpression)}({Min?.Expression:d}:{Min?.Included},{Max?.Expression:d}:{Max?.Included})",
+            "f" or "F" => $"@{nameof(IntervalExpression)}({Min?.Expression:d}:{Min?.Included},{Max?.Expression:d}:{Max?.Included})",
+            null or "" => $"{ToString()}",
+            _ => throw new NotSupportedException($"Unknown '{format}' format")
+        };
+
+        return formattable.ToString(formatProvider);
     }
 }

--- a/src/DataFilters/Grammar/Syntax/NotExpression.cs
+++ b/src/DataFilters/Grammar/Syntax/NotExpression.cs
@@ -1,83 +1,82 @@
-﻿namespace DataFilters.Grammar.Syntax
+﻿namespace DataFilters.Grammar.Syntax;
+
+using System;
+
+/// <summary>
+/// An expression that negate whatever <see cref="FilterExpression"/> wrapped inside.
+/// </summary>
+public sealed class NotExpression : FilterExpression, IEquatable<NotExpression>, ISimplifiable
 {
-    using System;
+    /// <summary>
+    /// Expression that the NOT logical is applied to
+    /// </summary>
+    public FilterExpression Expression { get; }
 
     /// <summary>
-    /// An expression that negate whatever <see cref="FilterExpression"/> wrapped inside.
+    /// Builds a new <see cref="NotExpression"/> that holds the specified <paramref name="expression"/>.
     /// </summary>
-    public sealed class NotExpression : FilterExpression, IEquatable<NotExpression>, ISimplifiable
+    /// <param name="expression">The expression onto which the <c>not</c> operator will be applied</param>
+    /// <exception cref="ArgumentNullException"><paramref name="expression"/> is <see langword="null"/>.</exception>
+    /// <remarks>
+    /// <paramref name="expression"/> will be automatically wrapped inside a <see cref="GroupExpression"/> if it's a <see cref="BinaryFilterExpression"/>
+    /// in order to keep the semantic
+    /// .
+    /// </remarks>
+    public NotExpression(FilterExpression expression)
     {
-        /// <summary>
-        /// Expression that the NOT logical is applied to
-        /// </summary>
-        public FilterExpression Expression { get; }
-
-        /// <summary>
-        /// Builds a new <see cref="NotExpression"/> that holds the specified <paramref name="expression"/>.
-        /// </summary>
-        /// <param name="expression">The expression onto which the <c>not</c> operator will be applied</param>
-        /// <exception cref="ArgumentNullException"><paramref name="expression"/> is <see langword="null"/>.</exception>
-        /// <remarks>
-        /// <paramref name="expression"/> will be automatically wrapped inside a <see cref="GroupExpression"/> if it's a <see cref="BinaryFilterExpression"/>
-        /// in order to keep the semantic
-        /// .
-        /// </remarks>
-        public NotExpression(FilterExpression expression)
+        (EscapedParseableString, Expression) = expression switch
         {
-            (EscapedParseableString, Expression) = expression switch
-            {
-                null => throw new ArgumentNullException(nameof(expression)),
-                BinaryFilterExpression expr => ($"!({expr.EscapedParseableString})", new GroupExpression(expr)),
-                _ => ($"!{expression.EscapedParseableString}", expression)
-            };
-        }
+            null => throw new ArgumentNullException(nameof(expression)),
+            BinaryFilterExpression expr => ($"!({expr.EscapedParseableString})", new GroupExpression(expr)),
+            _ => ($"!{expression.EscapedParseableString}", expression)
+        };
+    }
 
-        ///<inheritdoc/>
-        public bool Equals(NotExpression other) => Expression.Equals(other?.Expression);
+    ///<inheritdoc/>
+    public bool Equals(NotExpression other) => Expression.Equals(other?.Expression);
 
-        ///<inheritdoc/>
-        public override bool Equals(object obj) => Equals(obj as NotExpression);
+    ///<inheritdoc/>
+    public override bool Equals(object obj) => Equals(obj as NotExpression);
 
-        ///<inheritdoc/>
-        public override int GetHashCode() => Expression.GetHashCode();
+    ///<inheritdoc/>
+    public override int GetHashCode() => Expression.GetHashCode();
 
-        /// <inheritdoc />
-        public override string ToString(string format, IFormatProvider formatProvider)
+    /// <inheritdoc />
+    public override string ToString(string format, IFormatProvider formatProvider)
+    {
+        FormattableString formattable = format switch
         {
-            FormattableString formattable = format switch
-            {
-                "d" or "D" => $"@{nameof(NotExpression)}({Expression:d})",
-                "f" or "F" => $"@{nameof(NotExpression)}[{Expression:f}]",
-                null or "" => $"{EscapedParseableString}",
-                _ => throw new ArgumentOutOfRangeException(nameof(format), $"Unsupported '{format}' format")
-            };
-
-            return formattable.ToString(formatProvider);
-        }
-
-        ///<inheritdoc/>
-        public FilterExpression Simplify()
-            => Expression switch
-            {
-                NotExpression innerNotExpression => innerNotExpression.Expression,
-                ISimplifiable simplifiable => !simplifiable.Simplify(),
-                _ => this
-            };
-
-        ///<inheritdoc/>
-        public override string EscapedParseableString { get; }
-
-        ///<inheritdoc/>
-        public override double Complexity => Expression.Complexity;
-
-        ///<inheritdoc/>
-        public static bool operator ==(NotExpression left, NotExpression right) => left switch
-        {
-            null => right is null,
-            _ => left.Equals(right)
+            "d" or "D" => $"@{nameof(NotExpression)}({Expression:d})",
+            "f" or "F" => $"@{nameof(NotExpression)}[{Expression:f}]",
+            null or "" => $"{EscapedParseableString}",
+            _ => throw new ArgumentOutOfRangeException(nameof(format), $"Unsupported '{format}' format")
         };
 
-        ///<inheritdoc/>
-        public static bool operator !=(NotExpression left, NotExpression right) => !(left == right);
+        return formattable.ToString(formatProvider);
     }
+
+    ///<inheritdoc/>
+    public FilterExpression Simplify()
+        => Expression switch
+        {
+            NotExpression innerNotExpression => innerNotExpression.Expression,
+            ISimplifiable simplifiable => !simplifiable.Simplify(),
+            _ => this
+        };
+
+    ///<inheritdoc/>
+    public override string EscapedParseableString { get; }
+
+    ///<inheritdoc/>
+    public override double Complexity => Expression.Complexity;
+
+    ///<inheritdoc/>
+    public static bool operator ==(NotExpression left, NotExpression right) => left switch
+    {
+        null => right is null,
+        _ => left.Equals(right)
+    };
+
+    ///<inheritdoc/>
+    public static bool operator !=(NotExpression left, NotExpression right) => !(left == right);
 }

--- a/src/DataFilters/Grammar/Syntax/NumericSign.cs
+++ b/src/DataFilters/Grammar/Syntax/NumericSign.cs
@@ -1,18 +1,17 @@
-﻿namespace DataFilters.Grammar.Syntax
+﻿namespace DataFilters.Grammar.Syntax;
+
+/// <summary>
+/// Sign of the offset
+/// </summary>
+public enum NumericSign
 {
     /// <summary>
-    /// Sign of the offset
+    /// <c>+</c> sign
     /// </summary>
-    public enum NumericSign
-    {
-        /// <summary>
-        /// <c>+</c> sign
-        /// </summary>
-        Plus = 0,
+    Plus = 0,
 
-        /// <summary>
-        /// <c>-</c> sign
-        /// </summary>
-        Minus = 1
-    }
+    /// <summary>
+    /// <c>-</c> sign
+    /// </summary>
+    Minus = 1
 }

--- a/src/DataFilters/Grammar/Syntax/NumericValueExpression.cs
+++ b/src/DataFilters/Grammar/Syntax/NumericValueExpression.cs
@@ -2,51 +2,50 @@
 using System;
 using System.Diagnostics;
 
-namespace DataFilters.Grammar.Syntax
+namespace DataFilters.Grammar.Syntax;
+
+/// <summary>
+/// Wraps a string that represents a numeric value of some sort
+/// </summary>
+/// <remarks>
+/// Builds a new <see cref="NumericValueExpression"/> instance that can wrap a numeric value of some sort
+/// </remarks>
+/// <param name="value"></param>
+/// <exception cref="ArgumentNullException"><paramref name="value"/> is <see langword="null"/></exception>
+/// <exception cref="ArgumentOutOfRangeException"><paramref name="value"/> is <see cref="string.Empty"/></exception>
+[DebuggerDisplay("{Value}")]
+public class NumericValueExpression(string value) : ConstantValueExpression(value), IEquatable<NumericValueExpression>, IBoundaryExpression
 {
-    /// <summary>
-    /// Wraps a string that represents a numeric value of some sort
-    /// </summary>
-    /// <remarks>
-    /// Builds a new <see cref="NumericValueExpression"/> instance that can wrap a numeric value of some sort
-    /// </remarks>
-    /// <param name="value"></param>
-    /// <exception cref="ArgumentNullException"><paramref name="value"/> is <c>null</c></exception>
-    /// <exception cref="ArgumentOutOfRangeException"><paramref name="value"/> is <see cref="string.Empty"/></exception>
-    [DebuggerDisplay("{Value}")]
-    public class NumericValueExpression(string value) : ConstantValueExpression(value), IEquatable<NumericValueExpression>, IBoundaryExpression
+    ///<inheritdoc/>
+    public override string EscapedParseableString => Value;
+
+    ///<inheritdoc/>
+    public virtual bool Equals(NumericValueExpression other) => Value.Equals(other?.Value);
+
+    ///<inheritdoc/>
+    public override int GetHashCode() => Value.GetHashCode();
+
+    ///<inheritdoc/>
+    public override bool IsEquivalentTo(FilterExpression other) => other switch
     {
-        ///<inheritdoc/>
-        public override string EscapedParseableString => Value;
+        NumericValueExpression numericValue => Equals(numericValue),
+        ConstantValueExpression constant => base.Equals(constant),
+        ISimplifiable simplifiable => Equals(simplifiable.Simplify()),
+        _ => false
+    };
 
-        ///<inheritdoc/>
-        public virtual bool Equals(NumericValueExpression other) => Value.Equals(other?.Value);
+    ///<inheritdoc/>
+    public static bool operator ==(NumericValueExpression left, NumericValueExpression right) => Equals(left, right);
 
-        ///<inheritdoc/>
-        public override int GetHashCode() => Value.GetHashCode();
+    ///<inheritdoc/>
+    public static bool operator !=(NumericValueExpression left, NumericValueExpression right) => !(left == right);
 
-        ///<inheritdoc/>
-        public override bool IsEquivalentTo(FilterExpression other) => other switch
+    ///<inheritdoc/>
+    public override bool Equals(object obj)  =>
+        obj switch
         {
-            NumericValueExpression numericValue => Equals(numericValue),
-            ConstantValueExpression constant => base.Equals(constant),
-            ISimplifiable simplifiable => Equals(simplifiable.Simplify()),
+            StringValueExpression stringValue => Value.Equals(stringValue.Value),
+            not null => ReferenceEquals(this, obj) || Equals(obj as NumericValueExpression),
             _ => false
         };
-
-        ///<inheritdoc/>
-        public static bool operator ==(NumericValueExpression left, NumericValueExpression right) => Equals(left, right);
-
-        ///<inheritdoc/>
-        public static bool operator !=(NumericValueExpression left, NumericValueExpression right) => !(left == right);
-
-        ///<inheritdoc/>
-        public override bool Equals(object obj)  =>
-            obj switch
-            {
-                StringValueExpression stringValue => Value.Equals(stringValue.Value),
-                not null => ReferenceEquals(this, obj) || Equals(obj as NumericValueExpression),
-                _ => false
-            };
-    }
 }

--- a/src/DataFilters/Grammar/Syntax/OffsetExpression.cs
+++ b/src/DataFilters/Grammar/Syntax/OffsetExpression.cs
@@ -1,82 +1,82 @@
-namespace DataFilters.Grammar.Syntax
+namespace DataFilters.Grammar.Syntax;
+
+using System;
+
+/// <summary>
+/// <see cref="OffsetExpression"/> records the offset between a time and the UTC time
+/// </summary>
+public sealed class OffsetExpression : FilterExpression, IEquatable<OffsetExpression>
 {
-    using System;
+    /// <summary>
+    /// Gets the number of hours of offset with the UTC time
+    /// </summary>
+    public int Hours { get; }
 
     /// <summary>
-    /// <see cref="OffsetExpression"/> records the offset between a time and the UTC time
+    /// Get the number of minutes of offset with the UTC time
     /// </summary>
-    public sealed class OffsetExpression : FilterExpression, IEquatable<OffsetExpression>
+    public int Minutes { get; }
+
+    /// <summary>
+    /// Sign associated with offset
+    /// </summary>
+    public NumericSign Sign { get; }
+
+    /// <summary>
+    /// The Zero time offset
+    /// </summary>
+    public static OffsetExpression Zero => new();
+
+    private readonly Lazy<string> _lazyParseableString;
+
+    /// <summary>
+    /// Builds a new <see cref="OffsetExpression"/> instance
+    /// </summary>
+    /// <param name="sign"></param>
+    /// <param name="hours"></param>
+    /// <param name="minutes">The sign of </param>
+    public OffsetExpression(NumericSign sign = NumericSign.Plus, uint hours = 0, uint minutes = 0)
     {
-        /// <summary>
-        /// Gets the number of hours of offset with the UTC time
-        /// </summary>
-        public int Hours { get; }
-
-        /// <summary>
-        /// Get the number of minutes of offset with the UTC time
-        /// </summary>
-        public int Minutes { get; }
-
-        /// <summary>
-        /// Sign associated with offset
-        /// </summary>
-        public NumericSign Sign { get; }
-
-        /// <summary>
-        /// The Zero time offset
-        /// </summary>
-        public static OffsetExpression Zero => new();
-
-        private readonly Lazy<string> _lazyParseableString;
-
-        /// <summary>
-        /// Builds a new <see cref="OffsetExpression"/> instance
-        /// </summary>
-        /// <param name="sign"></param>
-        /// <param name="hours"></param>
-        /// <param name="minutes">The sign of </param>
-        public OffsetExpression(NumericSign sign = NumericSign.Plus, uint hours = 0, uint minutes = 0)
+        if (hours > 23)
         {
-            if (hours > 23)
-            {
-                throw new ArgumentOutOfRangeException(nameof(hours),
-                    $"{nameof(hours)} must be between 0 and 23 inclusive");
-            }
-
-            if (minutes > 59)
-            {
-                throw new ArgumentOutOfRangeException(nameof(minutes),
-                    $"{nameof(minutes)} must be between 0 and 59 inclusive");
-            }
-
-            Hours = (int)hours;
-            Minutes = (int)minutes;
-            Sign = sign;
-
-            _lazyParseableString = new(() => ( Hours, Minutes, Sign ) switch
-            {
-                (0, 0, _) => "Z",
-                (_, _, NumericSign.Minus) => $"-{Hours:D2}:{Minutes:D2}",
-                _ => $"+{Hours:D2}:{Minutes:D2}",
-            });
+            throw new ArgumentOutOfRangeException(nameof(hours),
+                $"{nameof(hours)} must be between 0 and 23 inclusive");
         }
 
-        ///<inheritdoc/>
-        public override string EscapedParseableString => _lazyParseableString.Value;
-
-        ///<inheritdoc/>
-        public override bool Equals(object obj) => Equals(obj as OffsetExpression);
-
-        ///<inheritdoc/>
-        public bool Equals(OffsetExpression other) => ( Hours, Minutes, Sign ) switch
+        if (minutes > 59)
         {
-            (0, 0, _) => other?.Hours == 0 && other?.Minutes == 0,
-            _ => ( Hours, Minutes, Sign ) == ( other?.Hours, other?.Minutes, other?.Sign )
-        };
+            throw new ArgumentOutOfRangeException(nameof(minutes),
+                $"{nameof(minutes)} must be between 0 and 59 inclusive");
+        }
 
-        ///<inheritdoc/>
+        Hours = (int)hours;
+        Minutes = (int)minutes;
+        Sign = sign;
+
+        _lazyParseableString = new(() => ( Hours, Minutes, Sign ) switch
+        {
+            (0, 0, _) => "Z",
+            (_, _, NumericSign.Minus) => $"-{Hours:D2}:{Minutes:D2}",
+            _ => $"+{Hours:D2}:{Minutes:D2}",
+        });
+    }
+
+    ///<inheritdoc/>
+    public override string EscapedParseableString => _lazyParseableString.Value;
+
+    ///<inheritdoc/>
+    public override bool Equals(object obj) => Equals(obj as OffsetExpression);
+
+    ///<inheritdoc/>
+    public bool Equals(OffsetExpression other) => ( Hours, Minutes, Sign ) switch
+    {
+        (0, 0, _) => other?.Hours == 0 && other?.Minutes == 0,
+        _ => ( Hours, Minutes, Sign ) == ( other?.Hours, other?.Minutes, other?.Sign )
+    };
+
+    ///<inheritdoc/>
 #if NETSTANDARD2_1_OR_GREATER || NET5_0_OR_GREATER
-        public override int GetHashCode() => HashCode.Combine(Hours, Minutes, Sign);
+    public override int GetHashCode() => HashCode.Combine(Hours, Minutes, Sign);
 #else
         public override int GetHashCode()
         {
@@ -88,25 +88,24 @@ namespace DataFilters.Grammar.Syntax
         }
 #endif
 
-        ///<inheritdoc/>
-        public void Deconstruct(out NumericSign sign, out int hours, out int minutes, out string escapedParseableString,
-            out string originalString)
-        {
-            sign = Sign;
-            hours = Hours;
-            minutes = Minutes;
-            escapedParseableString = EscapedParseableString;
-            originalString = OriginalString;
-        }
-
-        /// <inheritdoc />
-        public static bool operator ==(OffsetExpression left, OffsetExpression right) => left switch
-        {
-            null => right is null,
-            _ => left.Equals(right)
-        };
-
-        /// <inheritdoc />
-        public static bool operator !=(OffsetExpression left, OffsetExpression right) => !( left == right );
+    ///<inheritdoc/>
+    public void Deconstruct(out NumericSign sign, out int hours, out int minutes, out string escapedParseableString,
+        out string originalString)
+    {
+        sign = Sign;
+        hours = Hours;
+        minutes = Minutes;
+        escapedParseableString = EscapedParseableString;
+        originalString = OriginalString;
     }
+
+    /// <inheritdoc />
+    public static bool operator ==(OffsetExpression left, OffsetExpression right) => left switch
+    {
+        null => right is null,
+        _ => left.Equals(right)
+    };
+
+    /// <inheritdoc />
+    public static bool operator !=(OffsetExpression left, OffsetExpression right) => !( left == right );
 }

--- a/src/DataFilters/Grammar/Syntax/OneOfExpression.cs
+++ b/src/DataFilters/Grammar/Syntax/OneOfExpression.cs
@@ -1,160 +1,159 @@
-﻿namespace DataFilters.Grammar.Syntax
-{
-    using System;
-    using System.Collections.Generic;
-    using System.Linq;
+﻿namespace DataFilters.Grammar.Syntax;
 
-    using Utilities;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+using Utilities;
+
+/// <summary>
+/// a <see cref="FilterExpression"/> that contains multiple <see cref="FilterExpression"/>s as <see cref="Values"/>.
+/// </summary>
+public sealed class OneOfExpression : FilterExpression, IEquatable<OneOfExpression>, ISimplifiable, IEnumerable<FilterExpression>
+{
+    private static readonly ArrayEqualityComparer<FilterExpression> EqualityComparer = new();
 
     /// <summary>
-    /// a <see cref="FilterExpression"/> that contains multiple <see cref="FilterExpression"/>s as <see cref="Values"/>.
+    /// Collection of <see cref="FilterExpression"/> that the current instance holds.
     /// </summary>
-    public sealed class OneOfExpression : FilterExpression, IEquatable<OneOfExpression>, ISimplifiable, IEnumerable<FilterExpression>
+    public IReadOnlyList<FilterExpression> Values => [ .. _values];
+
+    private readonly FilterExpression[] _values;
+
+    private readonly Lazy<string> _lazyEscapedParseableString;
+    private readonly Lazy<string> _lazyOriginalString;
+
+    /// <summary>
+    /// Builds a new <see cref="OneOfExpression"/> instance.
+    /// </summary>
+    /// <param name="values"></param>
+    /// <exception cref="ArgumentNullException"><paramref name="values"/> is <see langword="null"/>.</exception>
+    /// <exception cref="InvalidOperationException"><paramref name="values"/> is empty. </exception>
+    public OneOfExpression(params FilterExpression[] values)
     {
-        private static readonly ArrayEqualityComparer<FilterExpression> EqualityComparer = new();
-
-        /// <summary>
-        /// Collection of <see cref="FilterExpression"/> that the current instance holds.
-        /// </summary>
-        public IReadOnlyList<FilterExpression> Values => [ .. _values];
-
-        private readonly FilterExpression[] _values;
-
-        private readonly Lazy<string> _lazyEscapedParseableString;
-        private readonly Lazy<string> _lazyOriginalString;
-
-        /// <summary>
-        /// Builds a new <see cref="OneOfExpression"/> instance.
-        /// </summary>
-        /// <param name="values"></param>
-        /// <exception cref="ArgumentNullException"><paramref name="values"/> is <c>null</c>.</exception>
-        /// <exception cref="InvalidOperationException"><paramref name="values"/> is empty. </exception>
-        public OneOfExpression(params FilterExpression[] values)
+        if (values is null)
         {
-            if (values is null)
-            {
-                throw new ArgumentNullException(nameof(values));
-            }
-
-            if (values.Length == 0)
-            {
-                throw new InvalidOperationException($"{nameof(OneOfExpression)} cannot be empty");
-            }
-
-            _values = [.. values.Where(x => x is not null)];
-
-            _lazyEscapedParseableString = new Lazy<string>(() => $"{{{string.Join("|", Values.Select(v => v.EscapedParseableString))}}}");
-            _lazyOriginalString = new Lazy<string>(() => $"{{{string.Join("|", Values.Select(v => v.OriginalString))}}}");
+            throw new ArgumentNullException(nameof(values));
         }
 
-        /// <inheritdoc/>
-        public override bool IsEquivalentTo(FilterExpression other)
+        if (values.Length == 0)
         {
-            bool equivalent;
-            if (ReferenceEquals(this, other))
-            {
-                equivalent = true;
-            }
-            else
-            {
-                equivalent = other is OneOfExpression oneOfExpression
-                    ? EqualityComparer.Equals([.. oneOfExpression._values], [.. _values])
-                                    || !(_values.Except(oneOfExpression._values).Any() || oneOfExpression._values.Except(_values).Any())
-                    : other switch
-                    {
-                        AsteriskExpression asterisk => Values.All(x => x is AsteriskExpression),
-                        ConstantValueExpression constant => Values.All(value => value.IsEquivalentTo(constant)),
-                        DateExpression date => Values.All(value => value.IsEquivalentTo(date)),
-                        DateTimeExpression dateTime => Values.All(value => value.Equals(dateTime) || value.IsEquivalentTo(dateTime)),
-                        OrExpression or => Values.All(value => value.Equals(or.Left) || value.Equals(or.Right) || value.IsEquivalentTo(or.Left) || value.IsEquivalentTo(or.Right)),
-                        ISimplifiable simplifiable => Values.All(value => value.IsEquivalentTo(simplifiable.Simplify())),
-                        _ => false
-                    };
-            }
-
-            return equivalent;
+            throw new InvalidOperationException($"{nameof(OneOfExpression)} cannot be empty");
         }
 
-        ///<inheritdoc/>
-        public bool Equals(OneOfExpression other) => other is not null && EqualityComparer.Equals(_values, other._values);
+        _values = [.. values.Where(x => x is not null)];
 
-        /// <inheritdoc/>
-        public override bool Equals(object obj) => Equals(obj as OneOfExpression);
+        _lazyEscapedParseableString = new Lazy<string>(() => $"{{{string.Join("|", Values.Select(v => v.EscapedParseableString))}}}");
+        _lazyOriginalString = new Lazy<string>(() => $"{{{string.Join("|", Values.Select(v => v.OriginalString))}}}");
+    }
 
-        /// <inheritdoc/>
-        public override int GetHashCode() => EqualityComparer.GetHashCode(_values);
-
-        ///<inheritdoc/>
-        public static bool operator ==(OneOfExpression left, OneOfExpression right) => left?.Equals(right) ?? false;
-
-        ///<inheritdoc/>
-        public static bool operator !=(OneOfExpression left, OneOfExpression right) => !(left == right);
-
-        ///<inheritdoc/>
-        public override double Complexity => Values.Sum(expression => expression.Complexity);
-
-        /// <inheritdoc/>
-        public FilterExpression Simplify()
+    /// <inheritdoc/>
+    public override bool IsEquivalentTo(FilterExpression other)
+    {
+        bool equivalent;
+        if (ReferenceEquals(this, other))
         {
-            HashSet<FilterExpression> curatedExpressions = [];
+            equivalent = true;
+        }
+        else
+        {
+            equivalent = other is OneOfExpression oneOfExpression
+                ? EqualityComparer.Equals([.. oneOfExpression._values], [.. _values])
+                  || !(_values.Except(oneOfExpression._values).Any() || oneOfExpression._values.Except(_values).Any())
+                : other switch
+                {
+                    AsteriskExpression asterisk => Values.All(x => x is AsteriskExpression),
+                    ConstantValueExpression constant => Values.All(value => value.IsEquivalentTo(constant)),
+                    DateExpression date => Values.All(value => value.IsEquivalentTo(date)),
+                    DateTimeExpression dateTime => Values.All(value => value.Equals(dateTime) || value.IsEquivalentTo(dateTime)),
+                    OrExpression or => Values.All(value => value.Equals(or.Left) || value.Equals(or.Right) || value.IsEquivalentTo(or.Left) || value.IsEquivalentTo(or.Right)),
+                    ISimplifiable simplifiable => Values.All(value => value.IsEquivalentTo(simplifiable.Simplify())),
+                    _ => false
+                };
+        }
+
+        return equivalent;
+    }
+
+    ///<inheritdoc/>
+    public bool Equals(OneOfExpression other) => other is not null && EqualityComparer.Equals(_values, other._values);
+
+    /// <inheritdoc/>
+    public override bool Equals(object obj) => Equals(obj as OneOfExpression);
+
+    /// <inheritdoc/>
+    public override int GetHashCode() => EqualityComparer.GetHashCode(_values);
+
+    ///<inheritdoc/>
+    public static bool operator ==(OneOfExpression left, OneOfExpression right) => left?.Equals(right) ?? false;
+
+    ///<inheritdoc/>
+    public static bool operator !=(OneOfExpression left, OneOfExpression right) => !(left == right);
+
+    ///<inheritdoc/>
+    public override double Complexity => Values.Sum(expression => expression.Complexity);
+
+    /// <inheritdoc/>
+    public FilterExpression Simplify()
+    {
+        HashSet<FilterExpression> curatedExpressions = [];
             
-            foreach (FilterExpression expression in Values)
-            {
-                FilterExpression simplified = expression.As<ISimplifiable>()?.Simplify() ?? expression;
-
-                curatedExpressions.RemoveWhere(val => val.Equals(simplified) || (val.IsEquivalentTo(simplified) 
-                                                      && val.Complexity > simplified.Complexity)); 
-                curatedExpressions.Add(simplified);
-
-            }
-
-            FilterExpression simplifiedResult;
-            switch (curatedExpressions.Count)
-            {
-                case 1:
-                    simplifiedResult = curatedExpressions.Single();
-                    break;
-                case 2:
-                    FilterExpression first = curatedExpressions.First();
-                    FilterExpression other = curatedExpressions.Last();
-                    simplifiedResult = new OrExpression(first, other);
-                    break;
-                default:
-                    simplifiedResult = new OneOfExpression([.. curatedExpressions]);
-                    break;
-            }
-
-            return simplifiedResult;
-        }
-
-        ///<inheritdoc/>
-        public override string EscapedParseableString => _lazyEscapedParseableString.Value;
-
-        /// <inheritdoc />
-        public override string ToString() => _lazyOriginalString.Value;
-
-        /// <inheritdoc />
-        IEnumerator<FilterExpression> IEnumerable<FilterExpression>.GetEnumerator()
+        foreach (FilterExpression expression in Values)
         {
-            foreach (FilterExpression expression in _values)
-            {
-                yield return expression;
-            }
+            FilterExpression simplified = expression.As<ISimplifiable>()?.Simplify() ?? expression;
+
+            curatedExpressions.RemoveWhere(val => val.Equals(simplified) || (val.IsEquivalentTo(simplified) 
+                                                                             && val.Complexity > simplified.Complexity)); 
+            curatedExpressions.Add(simplified);
+
         }
 
-        /// <inheritdoc />
-        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => _values.GetEnumerator();
-
-        /// <inheritdoc />
-        public override string ToString(string format, IFormatProvider formatProvider)
+        FilterExpression simplifiedResult;
+        switch (curatedExpressions.Count)
         {
-            FormattableString formattable = format switch
-            {
-                "D" or "d" => $"{{{string.Join(", ", Values.Select(expression => $"{expression:d}"))}}}",
-                _ => $"{_lazyOriginalString.Value}"
-            };
-
-            return formattable.ToString(formatProvider);
+            case 1:
+                simplifiedResult = curatedExpressions.Single();
+                break;
+            case 2:
+                FilterExpression first = curatedExpressions.First();
+                FilterExpression other = curatedExpressions.Last();
+                simplifiedResult = new OrExpression(first, other);
+                break;
+            default:
+                simplifiedResult = new OneOfExpression([.. curatedExpressions]);
+                break;
         }
+
+        return simplifiedResult;
+    }
+
+    ///<inheritdoc/>
+    public override string EscapedParseableString => _lazyEscapedParseableString.Value;
+
+    /// <inheritdoc />
+    public override string ToString() => _lazyOriginalString.Value;
+
+    /// <inheritdoc />
+    IEnumerator<FilterExpression> IEnumerable<FilterExpression>.GetEnumerator()
+    {
+        foreach (FilterExpression expression in _values)
+        {
+            yield return expression;
+        }
+    }
+
+    /// <inheritdoc />
+    System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => _values.GetEnumerator();
+
+    /// <inheritdoc />
+    public override string ToString(string format, IFormatProvider formatProvider)
+    {
+        FormattableString formattable = format switch
+        {
+            "D" or "d" => $"{{{string.Join(", ", Values.Select(expression => $"{expression:d}"))}}}",
+            _ => $"{_lazyOriginalString.Value}"
+        };
+
+        return formattable.ToString(formatProvider);
     }
 }

--- a/src/DataFilters/Grammar/Syntax/OrExpression.cs
+++ b/src/DataFilters/Grammar/Syntax/OrExpression.cs
@@ -1,113 +1,112 @@
-﻿namespace DataFilters.Grammar.Syntax
+﻿namespace DataFilters.Grammar.Syntax;
+
+using System;
+
+/// <summary>
+/// Combines two <see cref="FilterExpression"/>s using the logical <c>OR</c> operator
+/// </summary>
+public sealed class OrExpression : BinaryFilterExpression, IEquatable<OrExpression>
 {
-    using System;
+    private readonly Lazy<string> _lazyToString;
+    private readonly Lazy<string> _lazyEscapedParseableString;
 
     /// <summary>
-    /// Combines two <see cref="FilterExpression"/>s using the logical <c>OR</c> operator
+    /// Builds a new <see cref="OrExpression"/> that combines <paramref name="left"/> and <paramref name="right"/> using the logical
+    /// <c>OR</c> operator
     /// </summary>
-    public sealed class OrExpression : BinaryFilterExpression, IEquatable<OrExpression>
+    /// <remarks>
+    /// The constructor will wrap <paramref name="left"/> (respectively  <paramref name="right"/>) inside a <see cref="GroupExpression"/> when <paramref name="left"/> is either
+    /// a <see cref="AndExpression"/> or a <see cref="OrExpression"/>.
+    /// </remarks>
+    /// <param name="left">Left member of the expression</param>
+    /// <param name="right">Right member of the expression</param>
+    /// <exception cref="ArgumentNullException">if either <paramref name="left"/> or <paramref name="right"/> is <see langword="null"/>.</exception>
+    public OrExpression(FilterExpression left, FilterExpression right) : base(left, right)
     {
-        private readonly Lazy<string> _lazyToString;
-        private readonly Lazy<string> _lazyEscapedParseableString;
+        _lazyToString = new Lazy<string>(() => $@"[""{nameof(Left)} ({Left.GetType().Name})"": {Left.EscapedParseableString}; ""{nameof(Right)} ({Right.GetType().Name})"": {Right.EscapedParseableString}]");
+        _lazyEscapedParseableString = new Lazy<string>(() => $"{Left.EscapedParseableString}|{Right.EscapedParseableString}");
+    }
 
-        /// <summary>
-        /// Builds a new <see cref="OrExpression"/> that combines <paramref name="left"/> and <paramref name="right"/> using the logical
-        /// <c>OR</c> operator
-        /// </summary>
-        /// <remarks>
-        /// The constructor will wrap <paramref name="left"/> (respectively  <paramref name="right"/>) inside a <see cref="GroupExpression"/> when <paramref name="left"/> is either
-        /// a <see cref="AndExpression"/> or a <see cref="OrExpression"/>.
-        /// </remarks>
-        /// <param name="left">Left member of the expression</param>
-        /// <param name="right">Right member of the expression</param>
-        /// <exception cref="ArgumentNullException">if either <paramref name="left"/> or <paramref name="right"/> is <see langword="null"/>.</exception>
-        public OrExpression(FilterExpression left, FilterExpression right) : base(left, right)
-        {
-            _lazyToString = new Lazy<string>(() => $@"[""{nameof(Left)} ({Left.GetType().Name})"": {Left.EscapedParseableString}; ""{nameof(Right)} ({Right.GetType().Name})"": {Right.EscapedParseableString}]");
-            _lazyEscapedParseableString = new Lazy<string>(() => $"{Left.EscapedParseableString}|{Right.EscapedParseableString}");
-        }
+    ///<inheritdoc/>
+    public bool Equals(OrExpression other) => other is not null && ( ( Left.Equals(other.Left) && Right.Equals(other.Right) ) || ( Left.Equals(other.Right) && Right.Equals(other.Left) ) );
 
-        ///<inheritdoc/>
-        public bool Equals(OrExpression other) => other is not null && ( ( Left.Equals(other.Left) && Right.Equals(other.Right) ) || ( Left.Equals(other.Right) && Right.Equals(other.Left) ) );
+    ///<inheritdoc/>
+    public override bool Equals(object obj) => Equals(obj as OrExpression);
 
-        ///<inheritdoc/>
-        public override bool Equals(object obj) => Equals(obj as OrExpression);
-
-        ///<inheritdoc/>
+    ///<inheritdoc/>
 #if NETSTANDARD1_3 || NETSTANDARD2_0
         public override int GetHashCode() => (Left, Right).GetHashCode();
 #else
-        public override int GetHashCode() => HashCode.Combine(Left, Right);
+    public override int GetHashCode() => HashCode.Combine(Left, Right);
 #endif
 
-        ///<inheritdoc/>
-        public override string ToString() => _lazyToString.Value;
+    ///<inheritdoc/>
+    public override string ToString() => _lazyToString.Value;
 
         
-        ///<inheritdoc/>
-        public override string EscapedParseableString => _lazyEscapedParseableString.Value;
+    ///<inheritdoc/>
+    public override string EscapedParseableString => _lazyEscapedParseableString.Value;
 
-        /// <inheritdoc/>
-        public override bool IsEquivalentTo(FilterExpression other)
+    /// <inheritdoc/>
+    public override bool IsEquivalentTo(FilterExpression other)
+    {
+        bool isEquivalent = false;
+
+        if (other is not null)
         {
-            bool isEquivalent = false;
-
-            if (other is not null)
+            switch (other)
             {
-                switch (other)
+                case GroupExpression { Expression : OrExpression expression }:
+                    isEquivalent = IsEquivalentTo(expression);
+                    break;
+                case OrExpression or:
+                    isEquivalent = ( or.Right.IsEquivalentTo(Right) && or.Left.IsEquivalentTo(Left) ) || ( or.Left.IsEquivalentTo(Right) && or.Right.IsEquivalentTo(Left) );
+                    break;
+                case OneOfExpression oneOf:
                 {
-                    case GroupExpression { Expression : OrExpression expression }:
-                        isEquivalent = IsEquivalentTo(expression);
-                        break;
-                    case OrExpression or:
-                        isEquivalent = ( or.Right.IsEquivalentTo(Right) && or.Left.IsEquivalentTo(Left) ) || ( or.Left.IsEquivalentTo(Right) && or.Right.IsEquivalentTo(Left) );
-                        break;
-                    case OneOfExpression oneOf:
+                    FilterExpression simplifiedOneOf = oneOf.Simplify();
+                    isEquivalent = simplifiedOneOf switch
                     {
-                        FilterExpression simplifiedOneOf = oneOf.Simplify();
-                        isEquivalent = simplifiedOneOf switch
-                        {
-                            OrExpression orExpression => IsEquivalentTo(orExpression),
-                            OneOfExpression _ => false,
-                            _ => Left.IsEquivalentTo(Right) && ( Left.IsEquivalentTo(simplifiedOneOf) || Right.IsEquivalentTo(simplifiedOneOf) )
-                        };
+                        OrExpression orExpression => IsEquivalentTo(orExpression),
+                        OneOfExpression _ => false,
+                        _ => Left.IsEquivalentTo(Right) && ( Left.IsEquivalentTo(simplifiedOneOf) || Right.IsEquivalentTo(simplifiedOneOf) )
+                    };
 
-                        break;
-                    }
-                    default:
-                        isEquivalent = Left.IsEquivalentTo(Right) && ( Left.IsEquivalentTo(other) || Right.IsEquivalentTo(other) );
-                        break;
+                    break;
                 }
+                default:
+                    isEquivalent = Left.IsEquivalentTo(Right) && ( Left.IsEquivalentTo(other) || Right.IsEquivalentTo(other) );
+                    break;
             }
-
-            return isEquivalent;
         }
 
-        ///<inheritdoc/>
-        public override double Complexity => Left.Complexity + Right.Complexity;
+        return isEquivalent;
+    }
 
-        /// <inheritdoc />
-        public override FilterExpression Simplify()
+    ///<inheritdoc/>
+    public override double Complexity => Left.Complexity + Right.Complexity;
+
+    /// <inheritdoc />
+    public override FilterExpression Simplify()
+    {
+        FilterExpression simplified;
+        if (ReferenceEquals(Left, Right) || Left.Equals(Right) || Left.IsEquivalentTo(Right))
         {
-            FilterExpression simplified;
-            if (ReferenceEquals(Left, Right) || Left.Equals(Right) || Left.IsEquivalentTo(Right))
-            {
-                simplified = Left.Complexity < Right.Complexity
-                    ? Left.As<ISimplifiable>()?.Simplify() ?? Left
-                    : Right.As<ISimplifiable>()?.Simplify() ?? Right;
-            }
-            else
-            {
-                simplified = ( Left, Right ) switch
-                {
-                    (GroupExpression { Expression: OrExpression left }, GroupExpression { Expression: OrExpression right }) => new OneOfExpression(left.Left, left.Right, right.Left, right.Right),
-                    (GroupExpression { Expression: OrExpression or }, _) => new OneOfExpression(or.Left, or.Right, Right),
-                    (_, GroupExpression { Expression: OrExpression or }) => new OneOfExpression(or.Left, or.Right, Right),
-                    _ => this
-                };
-            }
-
-            return simplified;
+            simplified = Left.Complexity < Right.Complexity
+                ? Left.As<ISimplifiable>()?.Simplify() ?? Left
+                : Right.As<ISimplifiable>()?.Simplify() ?? Right;
         }
+        else
+        {
+            simplified = ( Left, Right ) switch
+            {
+                (GroupExpression { Expression: OrExpression left }, GroupExpression { Expression: OrExpression right }) => new OneOfExpression(left.Left, left.Right, right.Left, right.Right),
+                (GroupExpression { Expression: OrExpression or }, _) => new OneOfExpression(or.Left, or.Right, Right),
+                (_, GroupExpression { Expression: OrExpression or }) => new OneOfExpression(or.Left, or.Right, Right),
+                _ => this
+            };
+        }
+
+        return simplified;
     }
 }

--- a/src/DataFilters/Grammar/Syntax/PropertyName.cs
+++ b/src/DataFilters/Grammar/Syntax/PropertyName.cs
@@ -1,41 +1,41 @@
-﻿namespace DataFilters.Grammar.Syntax
-{
-    using System;
+﻿namespace DataFilters.Grammar.Syntax;
 
-    /// <summary>
-    /// a <see cref="PropertyName"/> holds the name of a property a filter is build against.
-    /// </summary>
+using System;
+
+/// <summary>
+/// a <see cref="PropertyName"/> holds the name of a property a filter is build against.
+/// </summary>
 #if NETSTANDARD1_3
     public class PropertyName : IEquatable<PropertyName>
 #else
-    public record PropertyName
+public record PropertyName
 #endif
+{
+    /// <summary>
+    /// Name of the property a filter is applied to
+    /// </summary>
+    public string Name { get; }
+
+    /// <summary>
+    /// Builds a new <see cref="PropertyName"/> with the specified <paramref name="name"/>.
+    /// </summary>
+    /// <param name="name"></param>
+    /// <exception cref="ArgumentNullException"><paramref name="name"/> is <see langword="null"/></exception>
+    /// <exception cref="ArgumentOutOfRangeException"><paramref name="name"/> is <c>string.Empty</c> or contains only whitespaces.</exception>
+    public PropertyName(string name)
     {
-        /// <summary>
-        /// Name of the property a filter is applied to
-        /// </summary>
-        public string Name { get; }
-
-        /// <summary>
-        /// Builds a new <see cref="PropertyName"/> with the specified <paramref name="name"/>.
-        /// </summary>
-        /// <param name="name"></param>
-        /// <exception cref="ArgumentNullException"><paramref name="name"/> is <c>null</c></exception>
-        /// <exception cref="ArgumentOutOfRangeException"><paramref name="name"/> is <c>string.Empty</c> or contains only whitespaces.</exception>
-        public PropertyName(string name)
+        if (name is null)
         {
-            if (name is null)
-            {
-                throw new ArgumentNullException(nameof(name));
-            }
-
-            if (string.IsNullOrWhiteSpace(name))
-            {
-                throw new ArgumentOutOfRangeException(nameof(name));
-            }
-
-            Name = name;
+            throw new ArgumentNullException(nameof(name));
         }
+
+        if (string.IsNullOrWhiteSpace(name))
+        {
+            throw new ArgumentOutOfRangeException(nameof(name));
+        }
+
+        Name = name;
+    }
 
 #if NETSTANDARD1_3
         ///<inheritdoc/>
@@ -50,5 +50,4 @@
         ///<inheritdoc/>
         public override string ToString() => $"{nameof(PropertyName)}[{Name}]";
 #endif
-    }
 }

--- a/src/DataFilters/Grammar/Syntax/RangeBracketValue.cs
+++ b/src/DataFilters/Grammar/Syntax/RangeBracketValue.cs
@@ -1,75 +1,75 @@
-﻿namespace DataFilters.Grammar.Syntax
+﻿namespace DataFilters.Grammar.Syntax;
+
+using System;
+using System.Collections.Generic;
+
+/// <summary>
+/// stores a range value used in a bracket expression
+/// </summary>
+/// <remarks>
+/// Builds a new <see cref="RangeBracketValue"/> instance.
+/// </remarks>
+/// <param name="start"></param>
+/// <param name="end"></param>
+public sealed class RangeBracketValue(char start, char end) : BracketValue, IEquatable<RangeBracketValue>, IComparable<RangeBracketValue>
 {
-    using System;
-    using System.Collections.Generic;
+    /// <summary>
+    /// Start of the regex range
+    /// </summary>
+    public char Start { get; } = start;
 
     /// <summary>
-    /// stores a range value used in a bracket expression
+    /// Ends of the regex range
     /// </summary>
-    /// <remarks>
-    /// Builds a new <see cref="RangeBracketValue"/> instance.
-    /// </remarks>
-    /// <param name="start"></param>
-    /// <param name="end"></param>
-    public sealed class RangeBracketValue(char start, char end) : BracketValue, IEquatable<RangeBracketValue>, IComparable<RangeBracketValue>
+    public char End { get; } = end;
+
+    ///<inheritdoc/>
+    public bool Equals(RangeBracketValue other) => (Start, End) == (other?.Start, other?.End);
+
+    ///<inheritdoc/>
+    public override bool Equals(object obj)
     {
-        /// <summary>
-        /// Start of the regex range
-        /// </summary>
-        public char Start { get; } = start;
-
-        /// <summary>
-        /// Ends of the regex range
-        /// </summary>
-        public char End { get; } = end;
-
-        ///<inheritdoc/>
-        public bool Equals(RangeBracketValue other) => (Start, End) == (other?.Start, other?.End);
-
-        ///<inheritdoc/>
-        public override bool Equals(object obj)
+        bool equals;
+        switch (obj)
         {
-            bool equals;
-            switch (obj)
-            {
-                case ConstantBracketValue constantBracketValue:
-                    char[] chars = [.. constantBracketValue.Value];
-                    char head = chars[0];
+            case ConstantBracketValue constantBracketValue:
+                char[] chars = [.. constantBracketValue.Value];
+                char head = chars[0];
 #if NETSTANDARD2_1_OR_GREATER || NET5_0_OR_GREATER
-                    char tail = chars[^1];
+                char tail = chars[^1];
 #else
                     char tail = chars[chars.Length - 1];
 #endif
-                    equals = (Start, End).Equals((head, tail));
-                    break;
-                default:
-                    equals = Equals(obj as RangeBracketValue);
-                    break;
-            }
-            return equals;
+                equals = (Start, End).Equals((head, tail));
+                break;
+            default:
+                equals = Equals(obj as RangeBracketValue);
+                break;
         }
+        return equals;
+    }
 
-        ///<inheritdoc />
-        public static bool operator ==(RangeBracketValue left, RangeBracketValue right) => EqualityComparer<RangeBracketValue>.Default.Equals(left, right);
+    ///<inheritdoc />
+    public static bool operator ==(RangeBracketValue left, RangeBracketValue right) => EqualityComparer<RangeBracketValue>.Default.Equals(left, right);
 
-        ///<inheritdoc />
-        public static bool operator !=(RangeBracketValue left, RangeBracketValue right) => !(left == right);
+    ///<inheritdoc />
+    public static bool operator !=(RangeBracketValue left, RangeBracketValue right) => !(left == right);
 
-        ///<inheritdoc />
-        public static bool operator <(RangeBracketValue left, RangeBracketValue right) => left.Start < right.Start;
+    ///<inheritdoc />
+    public static bool operator <(RangeBracketValue left, RangeBracketValue right) => left.Start < right.Start;
 
-        ///<inheritdoc />
-        public static bool operator >(RangeBracketValue left, RangeBracketValue right) => left.Start > right.Start;
+    ///<inheritdoc />
+    public static bool operator >(RangeBracketValue left, RangeBracketValue right) => left.Start > right.Start;
 
-        ///<inheritdoc />
-        public static bool operator <=(RangeBracketValue left, RangeBracketValue right) => left < right || left == right;
+    ///<inheritdoc />
+    public static bool operator <=(RangeBracketValue left, RangeBracketValue right) => left < right || left == right;
 
-        ///<inheritdoc />
-        public static bool operator >=(RangeBracketValue left, RangeBracketValue right) => left > right || left == right;
+    ///<inheritdoc />
+    public static bool operator >=(RangeBracketValue left, RangeBracketValue right) => left > right || left == right;
 
-        ///<inheritdoc />
+    ///<inheritdoc />
 #if NETSTANDARD2_1_OR_GREATER || NET5_0_OR_GREATER
-        public override int GetHashCode() => HashCode.Combine(Start, End);
+    public override int GetHashCode() => HashCode.Combine(Start, End);
 #else
         public override int GetHashCode()
         {
@@ -81,16 +81,15 @@
 
 #endif
 
-        ///<inheritdoc />
-        public override string EscapedParseableString => $"[{Start}-{End}]";
+    ///<inheritdoc />
+    public override string EscapedParseableString => $"[{Start}-{End}]";
 
-        ///<inheritdoc />
-        public override string OriginalString => $"[{Start}-{End}]";
+    ///<inheritdoc />
+    public override string OriginalString => $"[{Start}-{End}]";
 
-        ///<inheritdoc />
-        public override double Complexity => 1 + Math.Pow(2, End - Start);
+    ///<inheritdoc />
+    public override double Complexity => 1 + Math.Pow(2, End - Start);
 
-        ///<inheritdoc />
-        public int CompareTo(RangeBracketValue other) => (Start, End).CompareTo((other.Start, other.End));
-    }
+    ///<inheritdoc />
+    public int CompareTo(RangeBracketValue other) => (Start, End).CompareTo((other.Start, other.End));
 }

--- a/src/DataFilters/Grammar/Syntax/StartsWithExpression.cs
+++ b/src/DataFilters/Grammar/Syntax/StartsWithExpression.cs
@@ -1,176 +1,175 @@
-﻿namespace DataFilters.Grammar.Syntax
-{
-    using System;
-    using System.Collections.Generic;
-    using System.Linq;
-    using System.Text;
-    using DataFilters.Grammar.Parsing;
+﻿namespace DataFilters.Grammar.Syntax;
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using DataFilters.Grammar.Parsing;
 #if !NETSTANDARD1_3
-    using Ardalis.GuardClauses;
+using Ardalis.GuardClauses;
 #endif
 
+/// <summary>
+/// A <see cref="FilterExpression"/> that defines a string that starts with a specified <see cref="Value"/>.
+/// </summary>
+public sealed class StartsWithExpression : FilterExpression, IEquatable<StartsWithExpression>
+{
     /// <summary>
-    /// A <see cref="FilterExpression"/> that defines a string that starts with a specified <see cref="Value"/>.
+    /// Value associated with the expression
     /// </summary>
-    public sealed class StartsWithExpression : FilterExpression, IEquatable<StartsWithExpression>
+    public string Value { get; }
+
+    private readonly Lazy<string> _lazyEscapedParseableString;
+
+    /// <summary>
+    /// Builds a new <see cref="StartsWithExpression"/> that holds the specified <paramref name="value"/>.
+    /// </summary>
+    /// <param name="value">The value associated with the expression</param>
+    /// <exception cref="ArgumentNullException">if <paramref name="value"/> is <see langword="null"/></exception>
+    /// <exception cref="ArgumentOutOfRangeException">if <paramref name="value"/> is <see cref="string.Empty"/>.</exception>
+    /// <remarks>
+    /// The constructor will take care of escaping all specific characters of <paramref name="value"/>
+    /// </remarks>
+    public StartsWithExpression(string value)
     {
-        /// <summary>
-        /// Value associated with the expression
-        /// </summary>
-        public string Value { get; }
-
-        private readonly Lazy<string> _lazyEscapedParseableString;
-
-        /// <summary>
-        /// Builds a new <see cref="StartsWithExpression"/> that holds the specified <paramref name="value"/>.
-        /// </summary>
-        /// <param name="value">The value associated with the expression</param>
-        /// <exception cref="ArgumentNullException">if <paramref name="value"/> is <c>null</c></exception>
-        /// <exception cref="ArgumentOutOfRangeException">if <paramref name="value"/> is <see cref="string.Empty"/>.</exception>
-        /// <remarks>
-        /// The constructor will take care of escaping all specific characters of <paramref name="value"/>
-        /// </remarks>
-        public StartsWithExpression(string value)
+        Value = value switch
         {
-            Value = value switch
-            {
-                null => throw new ArgumentNullException(nameof(value)),
-                {Length: 0} => throw new ArgumentOutOfRangeException(nameof(value)),
-                _ => value
-            };
+            null => throw new ArgumentNullException(nameof(value)),
+            {Length: 0} => throw new ArgumentOutOfRangeException(nameof(value)),
+            _ => value
+        };
 
-            _lazyEscapedParseableString = new Lazy<string>(() =>
-            {
-                // The length of the final parseable string in worst cases scenario will double (1 backlash + the escaped character)
-                // Also we need an extra position for the final '*' that will be appended in all cases
-                bool requireEscapingCharacters = Value.AtLeastOnce(chr => FilterTokenizer.SpecialCharacters.Contains(chr));
-                StringBuilder escapedParseableString;
+        _lazyEscapedParseableString = new Lazy<string>(() =>
+        {
+            // The length of the final parseable string in worst cases scenario will double (1 backlash + the escaped character)
+            // Also we need an extra position for the final '*' that will be appended in all cases
+            bool requireEscapingCharacters = Value.AtLeastOnce(chr => FilterTokenizer.SpecialCharacters.Contains(chr));
+            StringBuilder escapedParseableString;
 
-                if (requireEscapingCharacters)
+            if (requireEscapingCharacters)
+            {
+                escapedParseableString = new StringBuilder((Value.Length * 2) + 1);
+                foreach (char chr in Value)
                 {
-                    escapedParseableString = new StringBuilder((Value.Length * 2) + 1);
-                    foreach (char chr in Value)
+                    if (FilterTokenizer.SpecialCharacters.Contains(chr))
                     {
-                        if (FilterTokenizer.SpecialCharacters.Contains(chr))
-                        {
-                            escapedParseableString = escapedParseableString.Append('\\');
-                        }
-
-                        escapedParseableString = escapedParseableString.Append(chr);
+                        escapedParseableString = escapedParseableString.Append('\\');
                     }
+
+                    escapedParseableString = escapedParseableString.Append(chr);
                 }
-                else
-                {
-                    escapedParseableString = new StringBuilder(Value, Value.Length + 1);
-                }
+            }
+            else
+            {
+                escapedParseableString = new StringBuilder(Value, Value.Length + 1);
+            }
 
-                return escapedParseableString.Append('*').ToString();
-            });
-        }
-
-        /// <summary>
-        /// Builds a new <see cref="StartsWithExpression"/> that holds the specified <paramref name="text"/>.
-        /// </summary>
-        /// <param name="text"></param>
-        /// <exception cref="ArgumentNullException"><paramref name="text"/> is <c>null</c>.</exception>
-        public StartsWithExpression(TextExpression text)
-            : this (Guard.Against.Null(text, nameof(text)).OriginalString)
-        {
-            _lazyEscapedParseableString = new Lazy<string>(() => $"{text.EscapedParseableString}*");
-        }
-
-        ///<inheritdoc/>
-        public bool Equals(StartsWithExpression other) => Value == other?.Value;
-
-        ///<inheritdoc/>
-        public override bool Equals(object obj) => Equals(obj as StartsWithExpression);
-
-        ///<inheritdoc/>
-        public override int GetHashCode() => Value.GetHashCode();
-
-        ///<inheritdoc/>
-        public override string EscapedParseableString => _lazyEscapedParseableString.Value;
-
-        /// <summary>
-        /// Combines the specified <paramref name="left"/> and <paramref name="right"/> <see cref="StartsWithExpression"/>s into a new <see cref="AndExpression"/>.
-        /// </summary>
-        /// <param name="left">The left operand</param>
-        /// <param name="right">The right operand</param>
-        /// <returns>a <see cref="AndExpression"/> whose <see cref="BinaryFilterExpression.Left"/> is <paramref name="left"/> and <see cref="BinaryFilterExpression.Right"/> is
-        /// <paramref name="right"/></returns>
-        /// <exception cref="ArgumentNullException">if either <paramref name="left"/> or <paramref name="right"/> is <see langword="null"/>.</exception>
-        public static AndExpression operator +(StartsWithExpression left, EndsWithExpression right) => new AndExpression(left, right);
-
-        /// <summary>
-        /// Combines the specified <paramref name="left"/> and <paramref name="right"/>
-        /// </summary>
-        /// <param name="left">the left operand</param>
-        /// <param name="right">the right operand</param>
-        /// <returns>
-        /// A <see cref="OneOfExpression"/> that can either :
-        /// <list type="bullet">
-        ///     <item>exactly matches the concatenation of <paramref name="left"/>'s value and <paramref name="right"/>'s value.</item>
-        ///     <item>exactly starts with the concatenation of <paramref name="left"/>'s value and <paramref name="right"/>'s value.</item>
-        ///     <item>exactly starts with <paramref name="left"/>'s value and contains <paramref name="right"/>'s value.</item>
-        /// </list>
-        /// </returns>
-        public static OneOfExpression operator +(StartsWithExpression left, StartsWithExpression right) => new (new StringValueExpression(left.Value + right.Value), new StartsWithExpression(left.Value + right.Value), new AndExpression(left, new ContainsExpression(right.Value)));
-
-        /// <summary>
-        /// Combines the specified <paramref name="left"/> and <paramref name="right"/>
-        /// </summary>
-        /// <param name="left">the left operand</param>
-        /// <param name="right">the right operand</param>
-        /// <returns>
-        /// A <see cref="OneOfExpression"/> that can either :
-        /// <list type="bullet">
-        ///     <item>exactly matches the concatenation of <paramref name="left"/>'s value and <paramref name="right"/>'s value.</item>
-        ///     <item>exactly starts with the concatenation of <paramref name="left"/>'s value and <paramref name="right"/>'s value.</item>
-        ///     <item>exactly starts with <paramref name="left"/>'s value and contains <paramref name="right"/>'s value.</item>
-        /// </list>
-        /// </returns>
-        /// <example>
-        /// bat*,*man* &lt;==&gt; batman* | bat*man* | batman
-        /// </example>
-        public static OneOfExpression operator +(StartsWithExpression left, ContainsExpression right)
-        {
-            string value = $"{left.Value}{right.Value}";
-
-            return new OneOfExpression(new StartsWithExpression(value), new AndExpression(left, right), new StringValueExpression(value));
-        }
-
-        /// <summary>
-        /// Combines the specified <paramref name="left"/> and <paramref name="right"/>
-        /// </summary>
-        /// <param name="left">the left operand</param>
-        /// <param name="right">the right operand</param>
-        /// <returns>
-        /// A <see cref="AndExpression"/> that can match any <see langword="string"/> that starts with <paramref name="left"/>
-        /// and ends with <paramref name="right"/>.
-        /// </returns>
-        public static AndExpression operator +(StartsWithExpression left, StringValueExpression right) => left + new EndsWithExpression(right.Value);
-
-        /// <summary>
-        /// Combines the specified <paramref name="left"/> and <paramref name="right"/> into and <see cref="AndExpression"/> expression
-        /// </summary>
-        /// <param name="left"></param>
-        /// <param name="right"></param>
-        /// <returns></returns>
-        public static AndExpression operator &(StartsWithExpression left, StringValueExpression right) => left + right;
-
-        /// <summary>
-        /// Combines the specified <paramref name="left"/> and <paramref name="right"/> into and <see cref="AndExpression"/> expression
-        /// </summary>
-        /// <param name="left"></param>
-        /// <param name="right"></param>
-        /// <returns></returns>
-        public static AndExpression operator &(StartsWithExpression left, EndsWithExpression right) => left + right;
-
-        /// <summary>
-        /// Negates the specified <paramref name="expression"/>
-        /// </summary>
-        /// <param name="expression">The start expression</param>
-        /// <returns></returns>
-        public static NotExpression operator !(StartsWithExpression expression) => new (expression);
+            return escapedParseableString.Append('*').ToString();
+        });
     }
+
+    /// <summary>
+    /// Builds a new <see cref="StartsWithExpression"/> that holds the specified <paramref name="text"/>.
+    /// </summary>
+    /// <param name="text"></param>
+    /// <exception cref="ArgumentNullException"><paramref name="text"/> is <see langword="null"/>.</exception>
+    public StartsWithExpression(TextExpression text)
+        : this (Guard.Against.Null(text, nameof(text)).OriginalString)
+    {
+        _lazyEscapedParseableString = new Lazy<string>(() => $"{text.EscapedParseableString}*");
+    }
+
+    ///<inheritdoc/>
+    public bool Equals(StartsWithExpression other) => Value == other?.Value;
+
+    ///<inheritdoc/>
+    public override bool Equals(object obj) => Equals(obj as StartsWithExpression);
+
+    ///<inheritdoc/>
+    public override int GetHashCode() => Value.GetHashCode();
+
+    ///<inheritdoc/>
+    public override string EscapedParseableString => _lazyEscapedParseableString.Value;
+
+    /// <summary>
+    /// Combines the specified <paramref name="left"/> and <paramref name="right"/> <see cref="StartsWithExpression"/>s into a new <see cref="AndExpression"/>.
+    /// </summary>
+    /// <param name="left">The left operand</param>
+    /// <param name="right">The right operand</param>
+    /// <returns>a <see cref="AndExpression"/> whose <see cref="BinaryFilterExpression.Left"/> is <paramref name="left"/> and <see cref="BinaryFilterExpression.Right"/> is
+    /// <paramref name="right"/></returns>
+    /// <exception cref="ArgumentNullException">if either <paramref name="left"/> or <paramref name="right"/> is <see langword="null"/>.</exception>
+    public static AndExpression operator +(StartsWithExpression left, EndsWithExpression right) => new AndExpression(left, right);
+
+    /// <summary>
+    /// Combines the specified <paramref name="left"/> and <paramref name="right"/>
+    /// </summary>
+    /// <param name="left">the left operand</param>
+    /// <param name="right">the right operand</param>
+    /// <returns>
+    /// A <see cref="OneOfExpression"/> that can either :
+    /// <list type="bullet">
+    ///     <item>exactly matches the concatenation of <paramref name="left"/>'s value and <paramref name="right"/>'s value.</item>
+    ///     <item>exactly starts with the concatenation of <paramref name="left"/>'s value and <paramref name="right"/>'s value.</item>
+    ///     <item>exactly starts with <paramref name="left"/>'s value and contains <paramref name="right"/>'s value.</item>
+    /// </list>
+    /// </returns>
+    public static OneOfExpression operator +(StartsWithExpression left, StartsWithExpression right) => new (new StringValueExpression(left.Value + right.Value), new StartsWithExpression(left.Value + right.Value), new AndExpression(left, new ContainsExpression(right.Value)));
+
+    /// <summary>
+    /// Combines the specified <paramref name="left"/> and <paramref name="right"/>
+    /// </summary>
+    /// <param name="left">the left operand</param>
+    /// <param name="right">the right operand</param>
+    /// <returns>
+    /// A <see cref="OneOfExpression"/> that can either :
+    /// <list type="bullet">
+    ///     <item>exactly matches the concatenation of <paramref name="left"/>'s value and <paramref name="right"/>'s value.</item>
+    ///     <item>exactly starts with the concatenation of <paramref name="left"/>'s value and <paramref name="right"/>'s value.</item>
+    ///     <item>exactly starts with <paramref name="left"/>'s value and contains <paramref name="right"/>'s value.</item>
+    /// </list>
+    /// </returns>
+    /// <example>
+    /// bat*,*man* &lt;==&gt; batman* | bat*man* | batman
+    /// </example>
+    public static OneOfExpression operator +(StartsWithExpression left, ContainsExpression right)
+    {
+        string value = $"{left.Value}{right.Value}";
+
+        return new OneOfExpression(new StartsWithExpression(value), new AndExpression(left, right), new StringValueExpression(value));
+    }
+
+    /// <summary>
+    /// Combines the specified <paramref name="left"/> and <paramref name="right"/>
+    /// </summary>
+    /// <param name="left">the left operand</param>
+    /// <param name="right">the right operand</param>
+    /// <returns>
+    /// A <see cref="AndExpression"/> that can match any <see langword="string"/> that starts with <paramref name="left"/>
+    /// and ends with <paramref name="right"/>.
+    /// </returns>
+    public static AndExpression operator +(StartsWithExpression left, StringValueExpression right) => left + new EndsWithExpression(right.Value);
+
+    /// <summary>
+    /// Combines the specified <paramref name="left"/> and <paramref name="right"/> into and <see cref="AndExpression"/> expression
+    /// </summary>
+    /// <param name="left"></param>
+    /// <param name="right"></param>
+    /// <returns></returns>
+    public static AndExpression operator &(StartsWithExpression left, StringValueExpression right) => left + right;
+
+    /// <summary>
+    /// Combines the specified <paramref name="left"/> and <paramref name="right"/> into and <see cref="AndExpression"/> expression
+    /// </summary>
+    /// <param name="left"></param>
+    /// <param name="right"></param>
+    /// <returns></returns>
+    public static AndExpression operator &(StartsWithExpression left, EndsWithExpression right) => left + right;
+
+    /// <summary>
+    /// Negates the specified <paramref name="expression"/>
+    /// </summary>
+    /// <param name="expression">The start expression</param>
+    /// <returns></returns>
+    public static NotExpression operator !(StartsWithExpression expression) => new (expression);
 }

--- a/src/DataFilters/Grammar/Syntax/StartsWithExpression.cs
+++ b/src/DataFilters/Grammar/Syntax/StartsWithExpression.cs
@@ -1,13 +1,11 @@
-﻿namespace DataFilters.Grammar.Syntax;
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using DataFilters.Grammar.Parsing;
-#if !NETSTANDARD1_3
 using Ardalis.GuardClauses;
-#endif
+
+namespace DataFilters.Grammar.Syntax;
 
 /// <summary>
 /// A <see cref="FilterExpression"/> that defines a string that starts with a specified <see cref="Value"/>.
@@ -35,7 +33,7 @@ public sealed class StartsWithExpression : FilterExpression, IEquatable<StartsWi
         Value = value switch
         {
             null => throw new ArgumentNullException(nameof(value)),
-            {Length: 0} => throw new ArgumentOutOfRangeException(nameof(value)),
+            { Length: 0 } => throw new ArgumentOutOfRangeException(nameof(value)),
             _ => value
         };
 
@@ -48,12 +46,12 @@ public sealed class StartsWithExpression : FilterExpression, IEquatable<StartsWi
 
             if (requireEscapingCharacters)
             {
-                escapedParseableString = new StringBuilder((Value.Length * 2) + 1);
+                escapedParseableString = new StringBuilder(( Value.Length * 2 ) + 1);
                 foreach (char chr in Value)
                 {
                     if (FilterTokenizer.SpecialCharacters.Contains(chr))
                     {
-                        escapedParseableString = escapedParseableString.Append('\\');
+                        escapedParseableString = escapedParseableString.Append(FilterTokenizer.BackSlash);
                     }
 
                     escapedParseableString = escapedParseableString.Append(chr);
@@ -64,7 +62,7 @@ public sealed class StartsWithExpression : FilterExpression, IEquatable<StartsWi
                 escapedParseableString = new StringBuilder(Value, Value.Length + 1);
             }
 
-            return escapedParseableString.Append('*').ToString();
+            return escapedParseableString.Append(FilterTokenizer.Asterisk).ToString();
         });
     }
 
@@ -74,7 +72,7 @@ public sealed class StartsWithExpression : FilterExpression, IEquatable<StartsWi
     /// <param name="text"></param>
     /// <exception cref="ArgumentNullException"><paramref name="text"/> is <see langword="null"/>.</exception>
     public StartsWithExpression(TextExpression text)
-        : this (Guard.Against.Null(text, nameof(text)).OriginalString)
+        : this(Guard.Against.Null(text, nameof(text)).OriginalString)
     {
         _lazyEscapedParseableString = new Lazy<string>(() => $"{text.EscapedParseableString}*");
     }
@@ -99,7 +97,7 @@ public sealed class StartsWithExpression : FilterExpression, IEquatable<StartsWi
     /// <returns>a <see cref="AndExpression"/> whose <see cref="BinaryFilterExpression.Left"/> is <paramref name="left"/> and <see cref="BinaryFilterExpression.Right"/> is
     /// <paramref name="right"/></returns>
     /// <exception cref="ArgumentNullException">if either <paramref name="left"/> or <paramref name="right"/> is <see langword="null"/>.</exception>
-    public static AndExpression operator +(StartsWithExpression left, EndsWithExpression right) => new AndExpression(left, right);
+    public static AndExpression operator +(StartsWithExpression left, EndsWithExpression right) => new(left, right);
 
     /// <summary>
     /// Combines the specified <paramref name="left"/> and <paramref name="right"/>
@@ -114,7 +112,9 @@ public sealed class StartsWithExpression : FilterExpression, IEquatable<StartsWi
     ///     <item>exactly starts with <paramref name="left"/>'s value and contains <paramref name="right"/>'s value.</item>
     /// </list>
     /// </returns>
-    public static OneOfExpression operator +(StartsWithExpression left, StartsWithExpression right) => new (new StringValueExpression(left.Value + right.Value), new StartsWithExpression(left.Value + right.Value), new AndExpression(left, new ContainsExpression(right.Value)));
+    public static OneOfExpression operator +(StartsWithExpression left, StartsWithExpression right) => new(
+        new StringValueExpression(left.Value + right.Value), new StartsWithExpression(left.Value + right.Value),
+        new AndExpression(left, new ContainsExpression(right.Value)));
 
     /// <summary>
     /// Combines the specified <paramref name="left"/> and <paramref name="right"/>
@@ -136,7 +136,8 @@ public sealed class StartsWithExpression : FilterExpression, IEquatable<StartsWi
     {
         string value = $"{left.Value}{right.Value}";
 
-        return new OneOfExpression(new StartsWithExpression(value), new AndExpression(left, right), new StringValueExpression(value));
+        return new OneOfExpression(new StartsWithExpression(value), new AndExpression(left, right),
+            new StringValueExpression(value));
     }
 
     /// <summary>
@@ -148,7 +149,8 @@ public sealed class StartsWithExpression : FilterExpression, IEquatable<StartsWi
     /// A <see cref="AndExpression"/> that can match any <see langword="string"/> that starts with <paramref name="left"/>
     /// and ends with <paramref name="right"/>.
     /// </returns>
-    public static AndExpression operator +(StartsWithExpression left, StringValueExpression right) => left + new EndsWithExpression(right.Value);
+    public static AndExpression operator +(StartsWithExpression left, StringValueExpression right) =>
+        left + new EndsWithExpression(right.Value);
 
     /// <summary>
     /// Combines the specified <paramref name="left"/> and <paramref name="right"/> into and <see cref="AndExpression"/> expression
@@ -171,5 +173,5 @@ public sealed class StartsWithExpression : FilterExpression, IEquatable<StartsWi
     /// </summary>
     /// <param name="expression">The start expression</param>
     /// <returns></returns>
-    public static NotExpression operator !(StartsWithExpression expression) => new (expression);
+    public static NotExpression operator !(StartsWithExpression expression) => new(expression);
 }

--- a/src/DataFilters/Grammar/Syntax/StringValueExpression.cs
+++ b/src/DataFilters/Grammar/Syntax/StringValueExpression.cs
@@ -5,87 +5,86 @@ using System.Linq;
 using System.Text;
 using DataFilters.Grammar.Parsing;
 
-namespace DataFilters.Grammar.Syntax
+namespace DataFilters.Grammar.Syntax;
+
+using static FilterTokenizer;
+
+/// <summary>
+/// Wraps a string that represents a constant string value
+/// </summary>
+/// <remarks>
+/// Builds a new <see cref="StringValueExpression"/> instance that can wrap a string value
+/// </remarks>
+/// <param name="value">value of the expression.</param>
+/// <remarks>
+/// The <see cref="EscapedParseableString"/> property automatically escapes <see cref="SpecialCharacters"/> from <paramref name="value"/>.
+/// </remarks>
+public class StringValueExpression(string value) : ConstantValueExpression(value), IEquatable<StringValueExpression>
 {
-    using static FilterTokenizer;
-
-    /// <summary>
-    /// Wraps a string that represents a constant string value
-    /// </summary>
-    /// <remarks>
-    /// Builds a new <see cref="StringValueExpression"/> instance that can wrap a string value
-    /// </remarks>
-    /// <param name="value">value of the expression.</param>
-    /// <remarks>
-    /// The <see cref="EscapedParseableString"/> property automatically escapes <see cref="SpecialCharacters"/> from <paramref name="value"/>.
-    /// </remarks>
-    public class StringValueExpression(string value) : ConstantValueExpression(value), IEquatable<StringValueExpression>
+    private readonly Lazy<string> _lazyParseableString = new(() =>
     {
-        private readonly Lazy<string> _lazyParseableString = new(() =>
-            {
-                // The length of the final parseable string in worst cases scenario will double (1 backlash + the escaped character)
-                bool requireEscapingCharacters = value.AtLeastOnce(chr => SpecialCharacters.Contains(chr));
-                StringBuilder parseableString;
+        // The length of the final parseable string in worst cases scenario will double (1 backlash + the escaped character)
+        bool requireEscapingCharacters = value.AtLeastOnce(chr => SpecialCharacters.Contains(chr));
+        StringBuilder parseableString;
 
-                if (requireEscapingCharacters)
+        if (requireEscapingCharacters)
+        {
+            parseableString = new StringBuilder(value.Length * 2);
+            foreach (char chr in value)
+            {
+                if (SpecialCharacters.Contains(chr))
                 {
-                    parseableString = new StringBuilder(value.Length * 2);
-                    foreach (char chr in value)
-                    {
-                        if (SpecialCharacters.Contains(chr))
-                        {
-                            parseableString = parseableString.Append('\\');
-                        }
-                        parseableString = parseableString.Append(chr);
-                    }
+                    parseableString = parseableString.Append('\\');
                 }
-                else
-                {
-                    parseableString = new StringBuilder(value);
-                }
+                parseableString = parseableString.Append(chr);
+            }
+        }
+        else
+        {
+            parseableString = new StringBuilder(value);
+        }
 
-                return parseableString.ToString();
-            });
+        return parseableString.ToString();
+    });
 
-        ///<inheritdoc/>
-        public override string EscapedParseableString => _lazyParseableString.Value;
+    ///<inheritdoc/>
+    public override string EscapedParseableString => _lazyParseableString.Value;
 
-        ///<inheritdoc/>
-        public override string OriginalString => Value;
+    ///<inheritdoc/>
+    public override string OriginalString => Value;
 
-        ///<inheritdoc/>
-        public virtual bool Equals(StringValueExpression other) => Equals(Value, other?.Value);
+    ///<inheritdoc/>
+    public virtual bool Equals(StringValueExpression other) => Equals(Value, other?.Value);
 
-        ///<inheritdoc/>
-        public override bool Equals(object obj) =>
-            obj switch
-            {
-                NumericValueExpression numericValue => Value.Equals(numericValue.Value),
-                not null => ReferenceEquals(this, obj) || Equals(obj as StringValueExpression),
-                _ => false
-            };
+    ///<inheritdoc/>
+    public override bool Equals(object obj) =>
+        obj switch
+        {
+            NumericValueExpression numericValue => Value.Equals(numericValue.Value),
+            not null => ReferenceEquals(this, obj) || Equals(obj as StringValueExpression),
+            _ => false
+        };
 
-        /// <inheritdoc/>
-        public override bool IsEquivalentTo(FilterExpression other)
-            => other switch
-            {
-                StringValueExpression stringValue => Equals(stringValue),
-                ISimplifiable simplifiable => Equals(simplifiable.Simplify() as StringValueExpression),
-                _ => false
-            };
+    /// <inheritdoc/>
+    public override bool IsEquivalentTo(FilterExpression other)
+        => other switch
+        {
+            StringValueExpression stringValue => Equals(stringValue),
+            ISimplifiable simplifiable => Equals(simplifiable.Simplify() as StringValueExpression),
+            _ => false
+        };
 
-        ///<inheritdoc/>
-        public override int GetHashCode() => Value.GetHashCode();
+    ///<inheritdoc/>
+    public override int GetHashCode() => Value.GetHashCode();
 
-        ///<inheritdoc/>
-        public override double Complexity => 1;
+    ///<inheritdoc/>
+    public override double Complexity => 1;
 
-        ///<inheritdoc/>
-        public static bool operator ==(StringValueExpression left, StringValueExpression right)
-            => (left is null && right is null) || (left?.Equals(right) ?? false);
+    ///<inheritdoc/>
+    public static bool operator ==(StringValueExpression left, StringValueExpression right)
+        => (left is null && right is null) || (left?.Equals(right) ?? false);
 
-        ///<inheritdoc/>
-        public static bool operator !=(StringValueExpression left, StringValueExpression right)
-            => !(left == right);
-    }
+    ///<inheritdoc/>
+    public static bool operator !=(StringValueExpression left, StringValueExpression right)
+        => !(left == right);
 }

--- a/src/DataFilters/Grammar/Syntax/TextExpression.cs
+++ b/src/DataFilters/Grammar/Syntax/TextExpression.cs
@@ -1,130 +1,129 @@
-﻿namespace DataFilters.Grammar.Syntax
+﻿namespace DataFilters.Grammar.Syntax;
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+/// <summary>
+/// An expression that holds a string value "as is".
+/// </summary>
+public class TextExpression : StringValueExpression, IEquatable<TextExpression>
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Text;
+    private readonly Lazy<string> _lazyEscapedParseableString;
 
     /// <summary>
-    /// An expression that holds a string value "as is".
+    /// Builds a new <see cref="TextExpression"/> instance.
     /// </summary>
-    public class TextExpression : StringValueExpression, IEquatable<TextExpression>
+    /// <remarks>
+    /// <para>
+    /// <paramref name="value"/> should neither start nor end with &quot; unless these quotes are part of the raw text expression.
+    /// More specifically, all quotes inside <paramref name="value"/> will be escaped.
+    /// </para>
+    /// <list type="table">
+    /// <listheader>
+    ///     <term>Input</term>
+    ///     <term>Outputs</term>
+    /// </listheader>
+    /// <item>
+    ///     <term><c>foo</c></term>
+    ///     <description>
+    ///         <list type="bullet">
+    ///             <item>
+    ///                 <term><see cref="ConstantValueExpression.Value"/></term>
+    ///                 <description><c>foo</c></description>
+    ///             </item>
+    ///             <item>
+    ///                 <term><see cref="OriginalString"/></term>
+    ///                 <description><c>foo</c></description>
+    ///             </item>
+    ///             <item>
+    ///                 <term><see cref="EscapedParseableString"/></term>
+    ///                 <description><c>"foo"</c></description>
+    ///             </item>
+    ///         </list>
+    ///     </description>
+    /// </item>
+    /// <item>
+    ///     <term><c>"bar"</c></term>
+    ///     <description>
+    ///         <list type="bullet">
+    ///             <item>
+    ///                 <term><see cref="ConstantValueExpression.Value"/></term>
+    ///                 <description><c>"bar"</c></description>
+    ///             </item>
+    ///             <item>
+    ///                 <term><see cref="OriginalString"/></term>
+    ///                 <description><c>"bar"</c></description>
+    ///             </item>
+    ///             <item>
+    ///                 <term><see cref="EscapedParseableString"/></term>
+    ///                 <description><c>"\"bar\""</c></description>
+    ///             </item>
+    ///         </list>
+    ///     </description>
+    /// </item>
+    /// <item>
+    ///     <term><c>foo"bar</c></term>
+    ///     <description>
+    ///         <list type="bullet">
+    ///             <item>
+    ///                 <term><see cref="ConstantValueExpression.Value"/></term>
+    ///                 <description><c>foo"bar</c></description>
+    ///             </item>
+    ///             <item>
+    ///                 <term><see cref="OriginalString"/></term>
+    ///                 <description><c>foo"bar</c></description>
+    ///             </item>
+    ///             <item>
+    ///                 <term><see cref="EscapedParseableString"/></term>
+    ///                 <description><c>"foo\"bar"</c></description>
+    ///             </item>
+    ///         </list>
+    ///     </description> 
+    /// </item>
+    /// </list>
+    /// </remarks>
+    /// <param name="value">Value of the expression.</param>
+    public TextExpression(string value) : base(value)
     {
-        private readonly Lazy<string> _lazyEscapedParseableString;
-
-        /// <summary>
-        /// Builds a new <see cref="TextExpression"/> instance.
-        /// </summary>
-        /// <remarks>
-        /// <para>
-        /// <paramref name="value"/> should neither start nor end with &quot; unless these quotes are part of the raw text expression.
-        /// More specifically, all quotes inside <paramref name="value"/> will be escaped.
-        /// </para>
-        /// <list type="table">
-        /// <listheader>
-        ///     <term>Input</term>
-        ///     <term>Outputs</term>
-        /// </listheader>
-        /// <item>
-        ///     <term><c>foo</c></term>
-        ///     <description>
-        ///         <list type="bullet">
-        ///             <item>
-        ///                 <term><see cref="ConstantValueExpression.Value"/></term>
-        ///                 <description><c>foo</c></description>
-        ///             </item>
-        ///             <item>
-        ///                 <term><see cref="OriginalString"/></term>
-        ///                 <description><c>foo</c></description>
-        ///             </item>
-        ///             <item>
-        ///                 <term><see cref="EscapedParseableString"/></term>
-        ///                 <description><c>"foo"</c></description>
-        ///             </item>
-        ///         </list>
-        ///     </description>
-        /// </item>
-        /// <item>
-        ///     <term><c>"bar"</c></term>
-        ///     <description>
-        ///         <list type="bullet">
-        ///             <item>
-        ///                 <term><see cref="ConstantValueExpression.Value"/></term>
-        ///                 <description><c>"bar"</c></description>
-        ///             </item>
-        ///             <item>
-        ///                 <term><see cref="OriginalString"/></term>
-        ///                 <description><c>"bar"</c></description>
-        ///             </item>
-        ///             <item>
-        ///                 <term><see cref="EscapedParseableString"/></term>
-        ///                 <description><c>"\"bar\""</c></description>
-        ///             </item>
-        ///         </list>
-        ///     </description>
-        /// </item>
-        /// <item>
-        ///     <term><c>foo"bar</c></term>
-        ///     <description>
-        ///         <list type="bullet">
-        ///             <item>
-        ///                 <term><see cref="ConstantValueExpression.Value"/></term>
-        ///                 <description><c>foo"bar</c></description>
-        ///             </item>
-        ///             <item>
-        ///                 <term><see cref="OriginalString"/></term>
-        ///                 <description><c>foo"bar</c></description>
-        ///             </item>
-        ///             <item>
-        ///                 <term><see cref="EscapedParseableString"/></term>
-        ///                 <description><c>"foo\"bar"</c></description>
-        ///             </item>
-        ///         </list>
-        ///     </description> 
-        /// </item>
-        /// </list>
-        /// </remarks>
-        /// <param name="value">Value of the expression.</param>
-        public TextExpression(string value) : base(value)
+        _lazyEscapedParseableString = new Lazy<string>(() =>
         {
-            _lazyEscapedParseableString = new Lazy<string>(() =>
+            StringBuilder escapedParseableString;
+            if (value.AtLeastOnce(chr => chr == '"' || chr == '\\'))
             {
-                StringBuilder escapedParseableString;
-                if (value.AtLeastOnce(chr => chr == '"' || chr == '\\'))
-                {
-                    escapedParseableString = new StringBuilder(( value.Length * 2 ) + 2);
+                escapedParseableString = new StringBuilder(( value.Length * 2 ) + 2);
 
-                    foreach (char chr in value)
+                foreach (char chr in value)
+                {
+                    if (chr is '"' or '\\')
                     {
-                        if (chr is '"' or '\\')
-                        {
-                            escapedParseableString = escapedParseableString.Append('\\');
-                        }
-
-                        escapedParseableString = escapedParseableString.Append(chr);
+                        escapedParseableString = escapedParseableString.Append('\\');
                     }
+
+                    escapedParseableString = escapedParseableString.Append(chr);
                 }
-                else
-                {
-                    escapedParseableString = new StringBuilder(value);
-                }
+            }
+            else
+            {
+                escapedParseableString = new StringBuilder(value);
+            }
 
-                return escapedParseableString.Insert(0, '"').Append('"').ToString();
-            });
-        }
-
-        ///<inheritdoc/>
-        public override string EscapedParseableString => _lazyEscapedParseableString.Value;
-
-        ///<inheritdoc/>
-        public override string OriginalString => Value;
-
-        ///<inheritdoc/>
-        public virtual bool Equals(TextExpression other) => Value.Equals(other?.Value);
-
-        ///<inheritdoc/>
-        public override bool Equals(object obj) => Equals(obj as TextExpression);
-
-        ///<inheritdoc/>
-        public override int GetHashCode() => Value.GetHashCode();
+            return escapedParseableString.Insert(0, '"').Append('"').ToString();
+        });
     }
+
+    ///<inheritdoc/>
+    public override string EscapedParseableString => _lazyEscapedParseableString.Value;
+
+    ///<inheritdoc/>
+    public override string OriginalString => Value;
+
+    ///<inheritdoc/>
+    public virtual bool Equals(TextExpression other) => Value.Equals(other?.Value);
+
+    ///<inheritdoc/>
+    public override bool Equals(object obj) => Equals(obj as TextExpression);
+
+    ///<inheritdoc/>
+    public override int GetHashCode() => Value.GetHashCode();
 }

--- a/src/DataFilters/Grammar/Syntax/TimeExpression.cs
+++ b/src/DataFilters/Grammar/Syntax/TimeExpression.cs
@@ -1,109 +1,108 @@
-﻿namespace DataFilters.Grammar.Syntax
+﻿namespace DataFilters.Grammar.Syntax;
+
+using System;
+
+/// <summary>
+/// A <see cref="FilterExpression"/> that only consists of time part.
+/// </summary>
+public sealed class TimeExpression : FilterExpression, IEquatable<TimeExpression>, IBoundaryExpression, IFormattable
 {
-    using System;
+    /// <summary>
+    /// Hours part of the expression
+    /// </summary>
+    public int Hours { get; }
 
     /// <summary>
-    /// A <see cref="FilterExpression"/> that only consists of time part.
+    /// Minutes of the expression
     /// </summary>
-    public sealed class TimeExpression : FilterExpression, IEquatable<TimeExpression>, IBoundaryExpression, IFormattable
+    public int Minutes { get; }
+
+    /// <summary>
+    /// Seconds of the expression
+    /// </summary>
+    public int Seconds { get; }
+
+    /// <summary>
+    /// Milliseconds of the expression
+    /// </summary>
+    public int Milliseconds { get; }
+
+    /// <summary>
+    /// Builds a new <see cref="TimeExpression"/> instance.
+    /// </summary>
+    /// <param name="hours"></param>
+    /// <param name="minutes"></param>
+    /// <param name="seconds"></param>
+    /// <param name="milliseconds"></param>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// either <paramref name="hours"/>, <paramref name="minutes"/>, <paramref name="seconds"/>, <paramref name="milliseconds"/> is &lt; 0.
+    /// </exception>
+    public TimeExpression(int hours = 0, int minutes = 0, int seconds = 0, int milliseconds = 0)
     {
-        /// <summary>
-        /// Hours part of the expression
-        /// </summary>
-        public int Hours { get; }
-
-        /// <summary>
-        /// Minutes of the expression
-        /// </summary>
-        public int Minutes { get; }
-
-        /// <summary>
-        /// Seconds of the expression
-        /// </summary>
-        public int Seconds { get; }
-
-        /// <summary>
-        /// Milliseconds of the expression
-        /// </summary>
-        public int Milliseconds { get; }
-
-        /// <summary>
-        /// Builds a new <see cref="TimeExpression"/> instance.
-        /// </summary>
-        /// <param name="hours"></param>
-        /// <param name="minutes"></param>
-        /// <param name="seconds"></param>
-        /// <param name="milliseconds"></param>
-        /// <exception cref="ArgumentOutOfRangeException">
-        /// either <paramref name="hours"/>, <paramref name="minutes"/>, <paramref name="seconds"/>, <paramref name="milliseconds"/> is &lt; 0.
-        /// </exception>
-        public TimeExpression(int hours = 0, int minutes = 0, int seconds = 0, int milliseconds = 0)
+        if (hours < 0)
         {
-            if (hours < 0)
-            {
-                throw new ArgumentOutOfRangeException(nameof(hours), hours, $"{nameof(hours)} must be zero or positive");
-            }
-
-            if (minutes < 0)
-            {
-                throw new ArgumentOutOfRangeException(nameof(minutes), minutes, $"{nameof(minutes)} must be zero or positive");
-            }
-
-            if (seconds < 0)
-            {
-                throw new ArgumentOutOfRangeException(nameof(seconds), seconds, $"{nameof(seconds)} must be zero or positive");
-            }
-
-            if (milliseconds < 0)
-            {
-                throw new ArgumentOutOfRangeException(nameof(milliseconds), milliseconds, $"{nameof(milliseconds)} must be zero or positive");
-            }
-
-            Hours = hours;
-            Minutes = minutes;
-            Seconds = seconds;
-            Milliseconds = milliseconds;
+            throw new ArgumentOutOfRangeException(nameof(hours), hours, $"{nameof(hours)} must be zero or positive");
         }
 
-        ///<inheritdoc/>
-        public bool Equals(TimeExpression other) => other is not null
-            && (((Hours, Minutes, Seconds, Milliseconds) == (other.Hours, other.Minutes, other.Seconds, other.Milliseconds))
-              || new TimeSpan(0, Hours, Minutes, Seconds, Milliseconds).Equals(new TimeSpan(0, other.Hours, other.Minutes, other.Seconds, other.Milliseconds)));
-
-        ///<inheritdoc/>
-        public override bool Equals(object obj) => Equals(obj as TimeExpression);
-
-        ///<inheritdoc/>
-        public override bool IsEquivalentTo(FilterExpression other) => other switch
+        if (minutes < 0)
         {
-            TimeExpression time => Equals(time),
-            DateTimeExpression { Date: null, Time: var time, Offset: null } => Equals(time),
-            _ => Equals((other as ISimplifiable)?.Simplify() ?? other)
-        };
-
-        ///<inheritdoc/>
-        public override int GetHashCode() => (Hours, Minutes, Seconds, Milliseconds).GetHashCode();
-
-        ///<inheritdoc/>
-        public override string EscapedParseableString => $"{Hours:D2}:{Minutes:D2}:{Seconds:D2}{(Milliseconds > 0 ? $".{Milliseconds}" : string.Empty)}";
-
-        ///<inheritdoc/>
-        public void Deconstruct(out int hours, out int minutes, out int seconds, out int milliseconds)
-        {
-            hours = Hours;
-            minutes = Minutes;
-            seconds = Seconds;
-            milliseconds = Milliseconds;
+            throw new ArgumentOutOfRangeException(nameof(minutes), minutes, $"{nameof(minutes)} must be zero or positive");
         }
 
-        /// <inheritdoc />
-        public static bool operator ==(TimeExpression left, TimeExpression right) => left switch
+        if (seconds < 0)
         {
-            null => right is null,
-            _ => left.Equals(right)
-        };
+            throw new ArgumentOutOfRangeException(nameof(seconds), seconds, $"{nameof(seconds)} must be zero or positive");
+        }
 
-        /// <inheritdoc />
-        public static bool operator !=(TimeExpression left, TimeExpression right) => !(left == right);
+        if (milliseconds < 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(milliseconds), milliseconds, $"{nameof(milliseconds)} must be zero or positive");
+        }
+
+        Hours = hours;
+        Minutes = minutes;
+        Seconds = seconds;
+        Milliseconds = milliseconds;
     }
+
+    ///<inheritdoc/>
+    public bool Equals(TimeExpression other) => other is not null
+                                                && (((Hours, Minutes, Seconds, Milliseconds) == (other.Hours, other.Minutes, other.Seconds, other.Milliseconds))
+                                                    || new TimeSpan(0, Hours, Minutes, Seconds, Milliseconds).Equals(new TimeSpan(0, other.Hours, other.Minutes, other.Seconds, other.Milliseconds)));
+
+    ///<inheritdoc/>
+    public override bool Equals(object obj) => Equals(obj as TimeExpression);
+
+    ///<inheritdoc/>
+    public override bool IsEquivalentTo(FilterExpression other) => other switch
+    {
+        TimeExpression time => Equals(time),
+        DateTimeExpression { Date: null, Time: var time, Offset: null } => Equals(time),
+        _ => Equals((other as ISimplifiable)?.Simplify() ?? other)
+    };
+
+    ///<inheritdoc/>
+    public override int GetHashCode() => (Hours, Minutes, Seconds, Milliseconds).GetHashCode();
+
+    ///<inheritdoc/>
+    public override string EscapedParseableString => $"{Hours:D2}:{Minutes:D2}:{Seconds:D2}{(Milliseconds > 0 ? $".{Milliseconds}" : string.Empty)}";
+
+    ///<inheritdoc/>
+    public void Deconstruct(out int hours, out int minutes, out int seconds, out int milliseconds)
+    {
+        hours = Hours;
+        minutes = Minutes;
+        seconds = Seconds;
+        milliseconds = Milliseconds;
+    }
+
+    /// <inheritdoc />
+    public static bool operator ==(TimeExpression left, TimeExpression right) => left switch
+    {
+        null => right is null,
+        _ => left.Equals(right)
+    };
+
+    /// <inheritdoc />
+    public static bool operator !=(TimeExpression left, TimeExpression right) => !(left == right);
 }

--- a/src/DataFilters/IFilter.cs
+++ b/src/DataFilters/IFilter.cs
@@ -1,27 +1,26 @@
-﻿namespace DataFilters
+﻿namespace DataFilters;
+
+using System;
+
+/// <summary>
+/// Defines the basic shape of a filter
+/// </summary>
+public interface IFilter : IEquatable<IFilter>
 {
-    using System;
+    /// <summary>
+    /// Gets the JSON representation of the filter
+    /// </summary>
+    /// <returns>A json representation of the current instance.</returns>
+    string ToJson();
 
     /// <summary>
-    /// Defines the basic shape of a filter
+    /// Computes a new <see cref="IFilter"/> instance which is the exact opposite of the current instance.
     /// </summary>
-    public interface IFilter : IEquatable<IFilter>
-    {
-        /// <summary>
-        /// Gets the JSON representation of the filter
-        /// </summary>
-        /// <returns>A json representation of the current instance.</returns>
-        string ToJson();
-
-        /// <summary>
-        /// Computes a new <see cref="IFilter"/> instance which is the exact opposite of the current instance.
-        /// </summary>
-        /// <returns>The exact opposite of the current instance.</returns>
-        IFilter Negate();
+    /// <returns>The exact opposite of the current instance.</returns>
+    IFilter Negate();
 
 #if NETSTANDARD2_1 || NET5_0_OR_GREATER
-        ///<inheritdoc/>
-        public virtual void ToString() => ToJson();
+    ///<inheritdoc/>
+    public virtual void ToString() => ToJson();
 #endif
-    }
 }

--- a/src/DataFilters/IOrder.cs
+++ b/src/DataFilters/IOrder.cs
@@ -1,25 +1,24 @@
-﻿namespace DataFilters
-{
-    using System;
+﻿namespace DataFilters;
 
+using System;
+
+/// <summary>
+/// Marker interface
+/// </summary>
+/// <typeparam name="T">Type of the element the sort will be applied onto</typeparam>
+public interface IOrder<T> : IEquatable<IOrder<T>>
+{
     /// <summary>
-    /// Marker interface
+    /// Tests if the current instance is equivalent to <paramref name="other"/>.
     /// </summary>
-    /// <typeparam name="T">Type of the element the sort will be applied onto</typeparam>
-    public interface IOrder<T> : IEquatable<IOrder<T>>
-    {
-        /// <summary>
-        /// Tests if the current instance is equivalent to <paramref name="other"/>.
-        /// </summary>
-        /// <param name="other"></param>
-        /// <remarks>
-        /// Two <see cref="IOrder{T}"/> instances are equivalent when, given an expression, one can be swapped for the other without altering the meaning of the whole expression.
-        /// </remarks>
-        /// <returns><c>true</c> when current instance and <c>other</c> are equivalent and <c>false</c> otherwise.</returns>
+    /// <param name="other"></param>
+    /// <remarks>
+    /// Two <see cref="IOrder{T}"/> instances are equivalent when, given an expression, one can be swapped for the other without altering the meaning of the whole expression.
+    /// </remarks>
+    /// <returns><c>true</c> when current instance and <c>other</c> are equivalent and <c>false</c> otherwise.</returns>
 #if !(NETSTANDARD1_3 || NETSTANDARD2_0)
-        public virtual bool IsEquivalentTo(IOrder<T> other) => Equals(other);
+    public virtual bool IsEquivalentTo(IOrder<T> other) => Equals(other);
 #else
         bool IsEquivalentTo(IOrder<T> other);
 #endif
-    }
 }

--- a/src/DataFilters/InvalidOrderExpressionException.cs
+++ b/src/DataFilters/InvalidOrderExpressionException.cs
@@ -1,26 +1,25 @@
-﻿namespace DataFilters
+﻿namespace DataFilters;
+
+using System;
+
+/// <summary>
+/// Exception thrown for an invalid sort expression.
+/// </summary>
+[Serializable]
+public class InvalidOrderExpressionException : Exception
 {
-    using System;
-
-    /// <summary>
-    /// Exception thrown for an invalid sort expression.
-    /// </summary>
-    [Serializable]
-    public class InvalidOrderExpressionException : Exception
+    /// <inheritdoc/>
+    public InvalidOrderExpressionException(string expression) : base($"'{expression}' must matches '{OrderValidator.Pattern}' pattern")
     {
-        /// <inheritdoc/>
-        public InvalidOrderExpressionException(string expression) : base($"'{expression}' must matches '{OrderValidator.Pattern}' pattern")
-        {
-        }
+    }
 
-        /// <inheritdoc/>
-        public InvalidOrderExpressionException() : base()
-        {
-        }
+    /// <inheritdoc/>
+    public InvalidOrderExpressionException() : base()
+    {
+    }
 
-        /// <inheritdoc/>
-        public InvalidOrderExpressionException(string message, Exception innerException) : base(message, innerException)
-        {
-        }
+    /// <inheritdoc/>
+    public InvalidOrderExpressionException(string message, Exception innerException) : base(message, innerException)
+    {
     }
 }

--- a/src/DataFilters/MultiFilter.cs
+++ b/src/DataFilters/MultiFilter.cs
@@ -1,129 +1,128 @@
-﻿namespace DataFilters
-{
-    using DataFilters.Converters;
-    using Newtonsoft.Json;
-    using Newtonsoft.Json.Schema;
-    using System;
-    using System.Collections.Generic;
-    using System.Linq;
+﻿namespace DataFilters;
+
+using DataFilters.Converters;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Schema;
+using System;
+using System.Collections.Generic;
+using System.Linq;
 
 #if !NETSTANDARD1_3
-    using System.Text.Json.Serialization;
+using System.Text.Json.Serialization;
 #else
     using static Newtonsoft.Json.DefaultValueHandling;
     using static Newtonsoft.Json.Required;
 #endif
 
-    /// <summary>
-    /// An instance of this class holds combination of <see cref="IFilter"/>
-    /// </summary>
-    [JsonObject]
+/// <summary>
+/// An instance of this class holds combination of <see cref="IFilter"/>
+/// </summary>
+[JsonObject]
 #if NETSTANDARD1_3
     [JsonConverter(typeof(MultiFilterConverter))]
 #else
-    [System.Text.Json.Serialization.JsonConverter(typeof(MultiFilterConverter))]
+[System.Text.Json.Serialization.JsonConverter(typeof(MultiFilterConverter))]
 #endif
-    public sealed class MultiFilter : IFilter, IEquatable<MultiFilter>
+public sealed class MultiFilter : IFilter, IEquatable<MultiFilter>
+{
+    /// <summary>
+    /// Name of the json property that holds filter's filters collection.
+    /// </summary>
+    public const string FiltersJsonPropertyName = "filters";
+
+    /// <summary>
+    /// Name of the json property that holds the composite filter's logic
+    /// </summary>
+    public const string LogicJsonPropertyName = "logic";
+
+    /// <summary>
+    /// <see cref="MultiFilter"/> JSON schema
+    /// </summary>
+    public static JSchema Schema => new()
     {
-        /// <summary>
-        /// Name of the json property that holds filter's filters collection.
-        /// </summary>
-        public const string FiltersJsonPropertyName = "filters";
-
-        /// <summary>
-        /// Name of the json property that holds the composite filter's logic
-        /// </summary>
-        public const string LogicJsonPropertyName = "logic";
-
-        /// <summary>
-        /// <see cref="MultiFilter"/> JSON schema
-        /// </summary>
-        public static JSchema Schema => new()
+        Type = JSchemaType.Object,
+        Properties =
         {
-            Type = JSchemaType.Object,
-            Properties =
-            {
-                [FiltersJsonPropertyName] = new JSchema { Type = JSchemaType.Array, MinimumItems = 2 },
-                [LogicJsonPropertyName] = new JSchema { Type = JSchemaType.String, Default = "and"}
-            },
-            Required = { FiltersJsonPropertyName },
-            AllowAdditionalProperties = false
-        };
+            [FiltersJsonPropertyName] = new JSchema { Type = JSchemaType.Array, MinimumItems = 2 },
+            [LogicJsonPropertyName] = new JSchema { Type = JSchemaType.String, Default = "and"}
+        },
+        Required = { FiltersJsonPropertyName },
+        AllowAdditionalProperties = false
+    };
 
-        /// <summary>
-        /// Collections of filters
-        /// </summary>
+    /// <summary>
+    /// Collections of filters
+    /// </summary>
 #if NETSTANDARD1_3
         [JsonProperty(PropertyName = FiltersJsonPropertyName, Required = Always)]
 #else
-        [JsonPropertyName(FiltersJsonPropertyName)]
+    [JsonPropertyName(FiltersJsonPropertyName)]
 #endif
-        public IEnumerable<IFilter> Filters { get; set; } = [];
+    public IEnumerable<IFilter> Filters { get; set; } = [];
 
-        /// <summary>
-        /// Operator to apply between <see cref="Filters"/>
-        /// </summary>
+    /// <summary>
+    /// Operator to apply between <see cref="Filters"/>
+    /// </summary>
 #if NETSTANDARD1_3
         [JsonProperty(PropertyName = LogicJsonPropertyName, DefaultValueHandling = IgnoreAndPopulate)]
         [JsonConverter(typeof(CamelCaseEnumTypeConverter))]
 #else
-        [JsonPropertyName(LogicJsonPropertyName)]
+    [JsonPropertyName(LogicJsonPropertyName)]
 #endif
-        public FilterLogic Logic { get; set; }
+    public FilterLogic Logic { get; set; }
 
-        ///<inheritdoc/>
-        public string ToJson() => this.Jsonify();
+    ///<inheritdoc/>
+    public string ToJson() => this.Jsonify();
 
-        ///<inheritdoc/>
-        public IFilter Negate()
+    ///<inheritdoc/>
+    public IFilter Negate()
+    {
+        MultiFilter filter = new()
         {
-            MultiFilter filter = new()
+            Logic = Logic switch
             {
-                Logic = Logic switch
-                {
-                    FilterLogic.And => FilterLogic.Or,
-                    FilterLogic.Or => FilterLogic.And,
-                    _ => throw new ArgumentOutOfRangeException($"Unsupported {Logic}")
-                },
-                Filters = Filters.Select(f => f.Negate())
+                FilterLogic.And => FilterLogic.Or,
+                FilterLogic.Or => FilterLogic.And,
+                _ => throw new ArgumentOutOfRangeException($"Unsupported {Logic}")
+            },
+            Filters = Filters.Select(f => f.Negate())
 #if DEBUG
                 .ToArray()
 #endif
-            };
+        };
 
-            return filter;
-        }
+        return filter;
+    }
 
-        ///<inheritdoc/>
+    ///<inheritdoc/>
 #if NETSTANDARD1_3 || NETSTANDARD2_0
         public override int GetHashCode() => (Logic, Filters).GetHashCode();
 #else
-        public override int GetHashCode()
+    public override int GetHashCode()
+    {
+        HashCode hash = new();
+        hash.Add(Logic);
+        foreach (IFilter filter in Filters)
         {
-            HashCode hash = new();
-            hash.Add(Logic);
-            foreach (IFilter filter in Filters)
-            {
-                hash.Add(filter);
-            }
-            return hash.ToHashCode();
+            hash.Add(filter);
         }
+        return hash.ToHashCode();
+    }
 #endif
 
-        ///<inheritdoc/>
-        public bool Equals(IFilter other) => Equals(other as MultiFilter);
+    ///<inheritdoc/>
+    public bool Equals(IFilter other) => Equals(other as MultiFilter);
 
-        ///<inheritdoc/>
-        public override bool Equals(object obj) => Equals(obj as MultiFilter);
+    ///<inheritdoc/>
+    public override bool Equals(object obj) => Equals(obj as MultiFilter);
 
-        ///<inheritdoc/>
-        public bool Equals(MultiFilter other)
-            => Logic == other?.Logic
-            && Filters.Count() == other?.Filters?.Count()
-            && Filters.All(filter => other?.Filters?.Contains(filter) ?? false)
-            && (other?.Filters.All(filter => Filters.Contains(filter)) ?? false);
+    ///<inheritdoc/>
+    public bool Equals(MultiFilter other)
+        => Logic == other?.Logic
+           && Filters.Count() == other?.Filters?.Count()
+           && Filters.All(filter => other?.Filters?.Contains(filter) ?? false)
+           && (other?.Filters.All(filter => Filters.Contains(filter)) ?? false);
 
-        ///<inheritdoc/>
-        public override string ToString() => this.Jsonify();
-    }
+    ///<inheritdoc/>
+    public override string ToString() => this.Jsonify();
 }

--- a/src/DataFilters/MultiFilter.cs
+++ b/src/DataFilters/MultiFilter.cs
@@ -58,7 +58,7 @@
 #else
         [JsonPropertyName(FiltersJsonPropertyName)]
 #endif
-        public IEnumerable<IFilter> Filters { get; set; } = Enumerable.Empty<IFilter>();
+        public IEnumerable<IFilter> Filters { get; set; } = [];
 
         /// <summary>
         /// Operator to apply between <see cref="Filters"/>

--- a/src/DataFilters/MultiOrder.cs
+++ b/src/DataFilters/MultiOrder.cs
@@ -1,54 +1,53 @@
-﻿namespace DataFilters
+﻿namespace DataFilters;
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+using Utilities;
+
+/// <summary>
+/// Allow to sort by multiple <see cref="Order{T}"/> expression
+/// </summary>
+/// <typeparam name="T">Type onto which the sort will be applied</typeparam>
+/// <remarks>
+/// Builds a new <see cref="MultiOrder{T}"/> instance.
+/// </remarks>
+/// <param name="orders"></param>
+public class MultiOrder<T>(params Order<T>[] orders) : IOrder<T>, IEquatable<MultiOrder<T>>
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Linq;
-
-    using Utilities;
-
     /// <summary>
-    /// Allow to sort by multiple <see cref="Order{T}"/> expression
+    /// <see cref="Order{T}"/> items that the current instance carries.
     /// </summary>
-    /// <typeparam name="T">Type onto which the sort will be applied</typeparam>
-    /// <remarks>
-    /// Builds a new <see cref="MultiOrder{T}"/> instance.
-    /// </remarks>
-    /// <param name="orders"></param>
-    public class MultiOrder<T>(params Order<T>[] orders) : IOrder<T>, IEquatable<MultiOrder<T>>
-    {
-        /// <summary>
-        /// <see cref="Order{T}"/> items that the current instance carries.
-        /// </summary>
-        public IEnumerable<Order<T>> Orders => _orders;
+    public IEnumerable<Order<T>> Orders => _orders;
 
-        private readonly Order<T>[] _orders = orders.Where(s => s is not null)
-                                                                  .ToArray();
+    private readonly Order<T>[] _orders = orders.Where(s => s is not null)
+        .ToArray();
 
     private static readonly ArrayEqualityComparer<Order<T>> EqualityComparer = new();
 
-        /// <inheritdoc/>
-        public bool Equals(IOrder<T> other) => Equals(other as MultiOrder<T>);
+    /// <inheritdoc/>
+    public bool Equals(IOrder<T> other) => Equals(other as MultiOrder<T>);
 
     /// <inheritdoc/>
     public bool Equals(MultiOrder<T> other) => other is not null && EqualityComparer.Equals(_orders, other._orders);
 
-        /// <inheritdoc/>
-        public override bool Equals(object obj) => Equals(obj as MultiOrder<T>);
+    /// <inheritdoc/>
+    public override bool Equals(object obj) => Equals(obj as MultiOrder<T>);
 
-        /// <inheritdoc/>
-        public bool IsEquivalentTo(IOrder<T> other) => other is MultiOrder<T> otherMultisort
-                                                      && Orders.SequenceEqual(otherMultisort.Orders);
+    /// <inheritdoc/>
+    public bool IsEquivalentTo(IOrder<T> other) => other is MultiOrder<T> otherMultisort
+                                                   && Orders.SequenceEqual(otherMultisort.Orders);
 
     /// <inheritdoc/>
     public override int GetHashCode() => EqualityComparer.GetHashCode(_orders);
 
-        /// <inheritdoc/>
-        public override string ToString() => $"{nameof(Orders)}:[{string.Join(",", Orders.Select(x => x.ToString()))}]";
+    /// <inheritdoc/>
+    public override string ToString() => $"{nameof(Orders)}:[{string.Join(",", Orders.Select(x => x.ToString()))}]";
 
-        /// <inheritdoc/>
-        public static bool operator ==(MultiOrder<T> left, MultiOrder<T> right) => EqualityComparer<MultiOrder<T>>.Default.Equals(left, right);
+    /// <inheritdoc/>
+    public static bool operator ==(MultiOrder<T> left, MultiOrder<T> right) => EqualityComparer<MultiOrder<T>>.Default.Equals(left, right);
 
-        /// <inheritdoc/>
-        public static bool operator !=(MultiOrder<T> left, MultiOrder<T> right) => !(left == right);
-    }
+    /// <inheritdoc/>
+    public static bool operator !=(MultiOrder<T> left, MultiOrder<T> right) => !(left == right);
 }

--- a/src/DataFilters/Order.cs
+++ b/src/DataFilters/Order.cs
@@ -1,62 +1,50 @@
-﻿namespace DataFilters
-{
-#if STRING_SEGMENT
-    using Microsoft.Extensions.Primitives;
-#endif
-    using System;
+﻿using System;
+using static DataFilters.OrderDirection;
 
-    using static DataFilters.OrderDirection;
+namespace DataFilters;
+
+/// <summary>
+/// An expression to order <typeparamref name="T"/> elements.
+/// </summary>
+/// <typeparam name="T">Type of elements onto which the sort expression will applies</typeparam>
+public class Order<T> : IOrder<T>
+{
+    /// <summary>
+    /// The original expression used to create the current <see cref="Order{T}"/>.
+    /// </summary>
+    public string Expression { get; }
 
     /// <summary>
-    /// An expression to order <typeparamref name="T"/> elements.
+    /// The "direction" of the sort./>
     /// </summary>
-    /// <typeparam name="T">Type of elements onto which the sort expression will applies</typeparam>
-    public class Order<T> : IOrder<T>
+    public OrderDirection Direction { get; }
+
+    /// <summary>
+    /// Creates a new <see cref="Order{T}"/> using the specified <paramref name="expression"/> and <paramref name="direction"/>.
+    /// </summary>
+    /// <param name="expression">The expression</param>
+    /// <param name="direction">The direction (optional).</param>
+    /// <exception cref="ArgumentOutOfRangeException"> <paramref name="expression"/> is <see langword="null"/>, empty or contains only whitespaces. </exception>
+    public Order(string expression, OrderDirection direction = Ascending)
     {
-        /// <summary>
-        /// The original expression used to create the current <see cref="Order{T}"/>.
-        /// </summary>
-        public string Expression { get; }
-
-        /// <summary>
-        /// The "direction" of the sort./>
-        /// </summary>
-        public OrderDirection Direction { get; }
-
-        /// <summary>
-        /// Creates a new <see cref="Order{T}"/> using the specified <paramref name="expression"/> and <paramref name="direction"/>.
-        /// </summary>
-        /// <param name="expression">The expression</param>
-        /// <param name="direction">The direction (optional).</param>
-        /// <exception cref="ArgumentOutOfRangeException"> <paramref name="expression"/> is <c>null</c>, empty or contains only whitespaces. </exception>
-        public Order(string expression, OrderDirection direction = Ascending)
+        if (string.IsNullOrWhiteSpace(expression))
         {
-            if (string.IsNullOrWhiteSpace(expression))
-            {
-                throw new ArgumentOutOfRangeException(nameof(expression), "cannot be null or whitespace");
-            }
-            Expression = expression;
-            Direction = direction;
+            throw new ArgumentOutOfRangeException(nameof(expression), "cannot be null or whitespace");
         }
-
-        /// <inheritdoc/>
-        public bool Equals(IOrder<T> other)
-            => other is Order<T> sort && (Expression, Direction) == (sort.Expression, sort.Direction);
-
-        /// <inheritdoc/>
-        public override bool Equals(object obj) => Equals(obj as Order<T>);
-
-        /// <inheritdoc/>
-#if !(NETSTANDARD1_0 || NETSTANDARD1_3 || NETSTANDARD2_0)
-        public override int GetHashCode() => HashCode.Combine(Expression, Direction);
-#else
-        public override int GetHashCode() => (Expression, Direction).GetHashCode();
-
-        /// <inheritdoc/>
-        public bool IsEquivalentTo(IOrder<T> other) => Equals(other);
-#endif
-
-        /// <inheritdoc/>
-        public override string ToString() => this.Jsonify();
+        Expression = expression;
+        Direction = direction;
     }
+
+    /// <inheritdoc/>
+    public bool Equals(IOrder<T> other)
+        => other is Order<T> sort && (Expression, Direction) == (sort.Expression, sort.Direction);
+
+    /// <inheritdoc/>
+    public override bool Equals(object obj) => Equals(obj as Order<T>);
+
+    /// <inheritdoc/>
+    public override int GetHashCode() => HashCode.Combine(Expression, Direction);
+
+    /// <inheritdoc/>
+    public override string ToString() => this.Jsonify();
 }

--- a/src/DataFilters/OrderDirection.cs
+++ b/src/DataFilters/OrderDirection.cs
@@ -1,17 +1,16 @@
-﻿namespace DataFilters
+﻿namespace DataFilters;
+
+/// <summary>
+/// Enumeration of direction that can be associated to a <see cref="Order{T}"/> instance
+/// </summary>
+public enum OrderDirection : short
 {
     /// <summary>
-    /// Enumeration of direction that can be associated to a <see cref="Order{T}"/> instance
+    /// Order elements from the lowest to the highest.
     /// </summary>
-    public enum OrderDirection : short
-    {
-        /// <summary>
-        /// Order elements from the lowest to the highest.
-        /// </summary>
-        Ascending,
-        /// <summary>
-        /// Order eleemnts from the highest to the lowest.
-        /// </summary>
-        Descending
-    }
+    Ascending,
+    /// <summary>
+    /// Order elements from the highest to the lowest.
+    /// </summary>
+    Descending
 }

--- a/src/DataFilters/OrderValidator.cs
+++ b/src/DataFilters/OrderValidator.cs
@@ -1,37 +1,36 @@
-﻿namespace DataFilters
+﻿namespace DataFilters;
+
+using System;
+using System.Linq;
+using System.Text.RegularExpressions;
+using FluentValidation;
+
+/// <summary>
+/// Validates sort expression
+/// </summary>
+public class OrderValidator : AbstractValidator<string>
 {
-    using System;
-    using System.Linq;
-    using System.Text.RegularExpressions;
-    using FluentValidation;
+    private const string FieldPattern = Filter.ValidFieldNamePattern;
+    /// <summary>
+    /// Order expression pattern.
+    /// </summary>
+    public static readonly string Pattern = @$"^\s*(-|\+)?(({FieldPattern})\w*)+(\s*,\s*((-|\+)?(({FieldPattern})\w*)+)\s*)*$";
+    private readonly Regex _orderRegex = new(Pattern, RegexOptions.IgnoreCase, TimeSpan.FromSeconds(1));
+    private const char Separator = ',';
 
     /// <summary>
-    /// Validates sort expression
+    /// Builds a new <see cref="OrderValidator"/> instance.
     /// </summary>
-    public class OrderValidator : AbstractValidator<string>
-    {
-        private const string FieldPattern = Filter.ValidFieldNamePattern;
-        /// <summary>
-        /// Order expression pattern.
-        /// </summary>
-        public readonly static string Pattern = @$"^\s*(-|\+)?(({FieldPattern})\w*)+(\s*,\s*((-|\+)?(({FieldPattern})\w*)+)\s*)*$";
-        private readonly Regex _orderRegex = new(Pattern, RegexOptions.IgnoreCase, TimeSpan.FromSeconds(1));
-        private const char Separator = ',';
+    public OrderValidator() => RuleFor(x => x)
+        .Matches(Pattern)
+        .WithMessage(search =>
+        {
+            string[] incorrectExpressions = search.Split([Separator])
+                .Where(x => !_orderRegex.IsMatch(x))
+                .Select(x => $@"""{x}""")
+                .ToArray();
 
-        /// <summary>
-        /// Builds a new <see cref="OrderValidator"/> instance.
-        /// </summary>
-        public OrderValidator() => RuleFor(x => x)
-                .Matches(Pattern)
-                .WithMessage(search =>
-                {
-                    string[] incorrectExpresions = search.Split([Separator])
-                        .Where(x => !_orderRegex.IsMatch(x))
-                        .Select(x => $@"""{x}""")
-                        .ToArray();
-
-                    return $"Sort expression{(incorrectExpresions.Length == 1 ? string.Empty : "s")} {string.Join(", ", incorrectExpresions)} " +
-                $@"do{(incorrectExpresions.Length == 1 ? "es" : string.Empty)} not match ""{Pattern}"".";
-                });
-    }
+            return $"Sort expression{(incorrectExpressions.Length == 1 ? string.Empty : "s")} {string.Join(", ", incorrectExpressions)} " +
+                   $@"do{(incorrectExpressions.Length == 1 ? "es" : string.Empty)} not match ""{Pattern}"".";
+        });
 }

--- a/src/DataFilters/Serialization/CamelCaseEnumTypeConverter.cs
+++ b/src/DataFilters/Serialization/CamelCaseEnumTypeConverter.cs
@@ -1,16 +1,15 @@
-﻿namespace DataFilters.Converters
-{
-    using Newtonsoft.Json.Converters;
-    using Newtonsoft.Json.Serialization;
+﻿namespace DataFilters.Converters;
 
+using Newtonsoft.Json.Converters;
+using Newtonsoft.Json.Serialization;
+
+/// <summary>
+/// Converter that specifies that enum members should be converted using CamelCaseNamingStrategy
+/// </summary>
+public class CamelCaseEnumTypeConverter : StringEnumConverter
+{
     /// <summary>
-    /// Converter that specifies that enum members should be converted using CamelCaseNamingStrategy
+    /// Builds a new <see cref="CamelCaseEnumTypeConverter"/> instance
     /// </summary>
-    public class CamelCaseEnumTypeConverter : StringEnumConverter
-    {
-        /// <summary>
-        /// Builds a new <see cref="CamelCaseEnumTypeConverter"/> instance
-        /// </summary>
-        public CamelCaseEnumTypeConverter() => NamingStrategy = new CamelCaseNamingStrategy();
-    }
+    public CamelCaseEnumTypeConverter() => NamingStrategy = new CamelCaseNamingStrategy();
 }

--- a/src/DataFilters/Serialization/FilterOperatorConverter.cs
+++ b/src/DataFilters/Serialization/FilterOperatorConverter.cs
@@ -1,28 +1,28 @@
-﻿namespace DataFilters.Converters
-{
-    using System;
-    using System.Collections.Generic;
-    using System.Collections.Immutable;
-    using System.Linq;
+﻿namespace DataFilters.Converters;
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
 #if NETSTANDARD1_3
     using Newtonsoft.Json;
 #else
-    using System.Text.Json;
-    using System.Text.Json.Serialization;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 #endif
 
-    /// <summary>
-    /// <see cref="JsonConverter"/> implementation that can handle (de)serialization of <see cref="FilterOperator"/>
-    /// from/to JSon .
-    /// </summary>
+/// <summary>
+/// <see cref="JsonConverter"/> implementation that can handle (de)serialization of <see cref="FilterOperator"/>
+/// from/to JSon .
+/// </summary>
 #if NETSTANDARD1_3
     public class FilterOperatorConverter : JsonConverter
     {
 #else
-    public class FilterOperatorConverter : JsonConverter<FilterOperator>
-    {
+public class FilterOperatorConverter : JsonConverter<FilterOperator>
+{
 #endif
-    private readonly static IImmutableDictionary<string, FilterOperator> Operators = new Dictionary<string, FilterOperator>
+    private static readonly IImmutableDictionary<string, FilterOperator> Operators = new Dictionary<string, FilterOperator>
     {
         ["contains"] = FilterOperator.Contains,
         ["ncontains"] = FilterOperator.NotContains,
@@ -59,13 +59,13 @@
             return _operators[op.ToLower()];
         }
 #else
-        /// <inheritdoc/>
-        public override FilterOperator Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    /// <inheritdoc/>
+    public override FilterOperator Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        if (reader.TokenType != JsonTokenType.String)
         {
-            if (reader.TokenType != JsonTokenType.String)
-            {
-                throw new JsonException($"Expected {nameof(FilterOperator)} value");
-            }
+            throw new JsonException($"Expected {nameof(FilterOperator)} value");
+        }
 
         string op = reader.GetString();
         return Operators[op.ToLower()];
@@ -81,16 +81,15 @@
         }
 #else
 
-        /// <inheritdoc/>
-        public override void Write(Utf8JsonWriter writer, FilterOperator value, JsonSerializerOptions options)
-        {
+    /// <inheritdoc/>
+    public override void Write(Utf8JsonWriter writer, FilterOperator value, JsonSerializerOptions options)
+    {
 #if NETSTANDARD2_0
         string key = Operators.Single(op => op.Value == value).Key;
 #else
         (string key, _) = Operators.Single(op => op.Value == value);
 #endif
-            writer.WriteStringValue(key);
-        }
-#endif
+        writer.WriteStringValue(key);
     }
+#endif
 }

--- a/src/DataFilters/Serialization/MultiFilterConverter.cs
+++ b/src/DataFilters/Serialization/MultiFilterConverter.cs
@@ -1,7 +1,7 @@
-﻿namespace DataFilters.Converters
-{
-    using System;
-    using System.Collections.Generic;
+﻿namespace DataFilters.Converters;
+
+using System;
+using System.Collections.Generic;
 
 #if NETSTANDARD1_3
     using System.Collections.Immutable;
@@ -10,13 +10,13 @@
     using Newtonsoft.Json;
     using Newtonsoft.Json.Linq;
 #else
-    using System.Text.Json;
-    using System.Text.Json.Serialization;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 #endif
 
-    /// <summary>
-    /// <see cref="JsonConverter"/> implementation that allow to convert json string from/to <see cref="MultiFilter"/>
-    /// </summary>
+/// <summary>
+/// <see cref="JsonConverter"/> implementation that allow to convert json string from/to <see cref="MultiFilter"/>
+/// </summary>
 #if NETSTANDARD1_3
     public class MultiFilterConverter : JsonConverter
     {
@@ -70,139 +70,138 @@
             return multiFilter?.As(objectType);
         }
 #else
-    public class MultiFilterConverter : JsonConverter<MultiFilter>
+public class MultiFilterConverter : JsonConverter<MultiFilter>
+{
+    private readonly FilterConverter _filterConverter;
+
+    /// <summary>
+    /// Builds a new <see cref="MultiFilterConverter"/> isntance.
+    /// </summary>
+    public MultiFilterConverter()
     {
-        private readonly FilterConverter _filterConverter;
+        _filterConverter = new FilterConverter();
+    }
 
-        /// <summary>
-        /// Builds a new <see cref="MultiFilterConverter"/> isntance.
-        /// </summary>
-        public MultiFilterConverter()
+    ///<inheritdoc/>
+    public override MultiFilter Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        if (reader.TokenType != JsonTokenType.StartObject)
         {
-            _filterConverter = new FilterConverter();
+            throw new JsonException("Multifilter json must start with '{'.");
         }
 
-        ///<inheritdoc/>
-        public override MultiFilter Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        reader.Read();
+
+        if (reader.TokenType != JsonTokenType.PropertyName || MultiFilter.LogicJsonPropertyName != reader.GetString())
         {
-            if (reader.TokenType != JsonTokenType.StartObject)
+            throw new JsonException($@"Expected ""{MultiFilter.LogicJsonPropertyName}"" property.");
+        }
+
+        reader.Read();
+        FilterLogic logic = reader.GetString()?.ToLowerInvariant() switch
+        {
+            "and" => FilterLogic.And,
+            "or" => FilterLogic.Or,
+            object value => throw new JsonException(@$"Unexpected ""{value}"" value for ""{MultiFilter.LogicJsonPropertyName}"" property."),
+            null => throw new JsonException(@$"Unexpected ""null"" value for ""{MultiFilter.LogicJsonPropertyName}"" property.")
+
+        };
+
+        List<IFilter> filters = [];
+        if (reader.Read() && (reader.TokenType != JsonTokenType.PropertyName || MultiFilter.FiltersJsonPropertyName != reader.GetString()))
+        {
+            throw new JsonException($@"Expected ""{MultiFilter.FiltersJsonPropertyName}"" property.");
+        }
+
+        reader.Read();
+        if (reader.TokenType != JsonTokenType.StartArray)
+        {
+            throw new JsonException(@"Expected ""["".");
+        }
+
+        reader.Read();
+
+        // We are about to try parsing the JSON to get either a Filter or a MultiFilter.
+        // We store a copy of the original reader in case the parsing process fails.
+        Utf8JsonReader readerCopy = reader;
+        while (reader.TokenType != JsonTokenType.EndArray)
+        {
+            long position = reader.TokenStartIndex;
+            try
             {
-                throw new JsonException("Multifilter json must start with '{'.");
+                filters.Add(_filterConverter.Read(ref reader, typeof(Filter), options));
             }
-
-            reader.Read();
-
-            if (reader.TokenType != JsonTokenType.PropertyName || MultiFilter.LogicJsonPropertyName != reader.GetString())
+            catch
             {
-                throw new JsonException($@"Expected ""{MultiFilter.LogicJsonPropertyName}"" property.");
+                // The json is not a Filter so we need to go back to where the parsing was performed
+                // and try to get a MultFilter instead
+
+                // 1. The copyReader position is moved to where the original parser were before failing
+                while (readerCopy.TokenStartIndex < position)
+                {
+                    readerCopy.Read();
+                }
+
+                // 2. Try to parse the Json and get a MultiFilter.
+                filters.Add(Read(ref readerCopy, typeof(MultiFilter), options));
+                // The parsing was a success -> we move the reader to the continue the parsing process
+
+                while (reader.TokenStartIndex < readerCopy.TokenStartIndex)
+                {
+                    reader.Read();
+                }
+                reader.Read(); // Advances the reader until the next token
             }
+        }
 
-            reader.Read();
-            FilterLogic logic = reader.GetString()?.ToLowerInvariant() switch
+        reader.Read();
+        return reader.TokenType != JsonTokenType.EndObject
+            ? throw new JsonException(@"Expected ""}"".")
+            : new MultiFilter
             {
-                "and" => FilterLogic.And,
-                "or" => FilterLogic.Or,
-                object value => throw new JsonException(@$"Unexpected ""{value}"" value for ""{MultiFilter.LogicJsonPropertyName}"" property."),
-                null => throw new JsonException(@$"Unexpected ""null"" value for ""{MultiFilter.LogicJsonPropertyName}"" property.")
-
+                Logic = logic,
+                Filters = filters
             };
-
-            List<IFilter> filters = [];
-            if (reader.Read() && (reader.TokenType != JsonTokenType.PropertyName || MultiFilter.FiltersJsonPropertyName != reader.GetString()))
-            {
-                throw new JsonException($@"Expected ""{MultiFilter.FiltersJsonPropertyName}"" property.");
-            }
-
-            reader.Read();
-            if (reader.TokenType != JsonTokenType.StartArray)
-            {
-                throw new JsonException(@"Expected ""["".");
-            }
-
-            reader.Read();
-
-            // We are about to try parsing the JSON to get either a Filter or a MultiFilter.
-            // We store a copy of the original reader in case the parsing process fails.
-            Utf8JsonReader readerCopy = reader;
-            while (reader.TokenType != JsonTokenType.EndArray)
-            {
-                long position = reader.TokenStartIndex;
-                try
-                {
-                    filters.Add(_filterConverter.Read(ref reader, typeof(Filter), options));
-                }
-                catch
-                {
-                    // The json is not a Filter so we need to go back to where the parsing was performed
-                    // and try to get a MultFilter instead
-
-                    // 1. The copyReader position is moved to where the original parser were before failing
-                    while (readerCopy.TokenStartIndex < position)
-                    {
-                        readerCopy.Read();
-                    }
-
-                    // 2. Try to parse the Json and get a MultiFilter.
-                    filters.Add(Read(ref readerCopy, typeof(MultiFilter), options));
-                    // The parsing was a success -> we move the reader to the continue the parsing process
-
-                    while (reader.TokenStartIndex < readerCopy.TokenStartIndex)
-                    {
-                        reader.Read();
-                    }
-                    reader.Read(); // Advances the reader until the next token
-                }
-            }
-
-            reader.Read();
-            return reader.TokenType != JsonTokenType.EndObject
-                ? throw new JsonException(@"Expected ""}"".")
-                : new MultiFilter
-                {
-                    Logic = logic,
-                    Filters = filters
-                };
-        }
+    }
 #endif
-        ///<inheritdoc/>
+    ///<inheritdoc/>
 #if NETSTANDARD1_3
         public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
         {
             MultiFilter mf = (MultiFilter)value;
 #else
-        public override void Write(Utf8JsonWriter writer, MultiFilter value, JsonSerializerOptions options)
-        {
-            MultiFilter mf = value;
+    public override void Write(Utf8JsonWriter writer, MultiFilter value, JsonSerializerOptions options)
+    {
+        MultiFilter mf = value;
 #endif
-            writer.WriteStartObject();
+        writer.WriteStartObject();
 
-            writer.WritePropertyName(MultiFilter.LogicJsonPropertyName);
+        writer.WritePropertyName(MultiFilter.LogicJsonPropertyName);
 #if NETSTANDARD1_3
             writer.WriteValue(mf.Logic.ToString().ToLower());
 #else
-            writer.WriteStringValue(mf.Logic.ToString().ToLower());
+        writer.WriteStringValue(mf.Logic.ToString().ToLower());
 #endif
 
-            writer.WritePropertyName(MultiFilter.FiltersJsonPropertyName);
-            writer.WriteStartArray();
-            foreach (IFilter filter in mf.Filters)
-            {
+        writer.WritePropertyName(MultiFilter.FiltersJsonPropertyName);
+        writer.WriteStartArray();
+        foreach (IFilter filter in mf.Filters)
+        {
 #if NETSTANDARD1_3
                 serializer.Serialize(writer, filter);
 #else
-                if (filter is Filter f)
-                {
-                    _filterConverter.Write(writer, f, options);
-                }
-                else if (filter is MultiFilter multiFilter)
-                {
-                    Write(writer, multiFilter, options);
-                }
-#endif
+            if (filter is Filter f)
+            {
+                _filterConverter.Write(writer, f, options);
             }
-            writer.WriteEndArray();
-
-            writer.WriteEndObject();
+            else if (filter is MultiFilter multiFilter)
+            {
+                Write(writer, multiFilter, options);
+            }
+#endif
         }
+        writer.WriteEndArray();
+
+        writer.WriteEndObject();
     }
 }

--- a/src/DataFilters/StringExtensions.cs
+++ b/src/DataFilters/StringExtensions.cs
@@ -81,7 +81,7 @@
             }
 
 #if NETSTANDARD2_0 || NETSTANDARD2_1 || NET5_0_OR_GREATER
-            ReadOnlyMemory<string> sorts = sortString.Split(new[] { Separator }, StringSplitOptions.RemoveEmptyEntries)
+            ReadOnlyMemory<string> sorts = sortString.Split([Separator], StringSplitOptions.RemoveEmptyEntries)
                                                      .AsMemory();
 
 #else
@@ -281,15 +281,15 @@
                             filter = new MultiFilter
                             {
                                 Logic = FilterLogic.And,
-                                Filters = new IFilter[]
-                                {
+                                Filters =
+                                [
                                     new Filter(propInfo.Name,
                                                minOperator,
                                                tc.ConvertFrom(minValue)),
                                     new Filter(propInfo.Name,
                                                maxOperator,
                                                tc.ConvertFrom(maxValue))
-                                }
+                                ]
                             };
                         }
                         else if (min.constantExpression?.Value != default)

--- a/src/DataFilters/StringExtensions.cs
+++ b/src/DataFilters/StringExtensions.cs
@@ -1,384 +1,355 @@
-﻿namespace System
-{
-    using DataFilters;
+﻿using DataFilters;
+using FluentValidation.Results;
+using System.Linq;
+using DataFilters.Grammar.Parsing;
+using DataFilters.Grammar.Syntax;
+using Superpower;
+using Superpower.Model;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Reflection;
+using DataFilters.Casing;
+using Microsoft.Extensions.Primitives;
+using System.Runtime.InteropServices;
 
-    using FluentValidation.Results;
-
-    using System.Linq;
-
-    using DataFilters.Grammar.Parsing;
-    using DataFilters.Grammar.Syntax;
-
-    using Superpower;
-    using Superpower.Model;
-
-    using System.Collections.Generic;
-    using System.ComponentModel;
-    using System.Reflection;
-
-    using static DataFilters.FilterOperator;
-
-    using DataFilters.Casing;
-
-#if STRING_SEGMENT
-    using Microsoft.Extensions.Primitives;
-#endif
-
-    using static DataFilters.OrderDirection;
-
-#if NETSTANDARD2_0 || NETSTANDARD2_1 || NET5_0_OR_GREATER
-    using System.Runtime.InteropServices;
-
-#if NET6_0
-    using DateOnlyTimeOnly.AspNet.Converters;
-    using System.Collections.Concurrent;
-#endif
+using static DataFilters.FilterOperator;
+using static DataFilters.OrderDirection;
 
 #if NET7_0_OR_GREATER
     using System.Diagnostics;
 #endif
-#endif
+
+namespace System;
+
+/// <summary>
+/// String extensions methods
+/// </summary>
+public static class StringExtensions
+{
+    private static char Separator => ',';
+
     /// <summary>
-    /// String extensions methods
+    /// Converts <paramref name="sortString"/> to a <see cref="IOrder{T}"/> instance.
     /// </summary>
-    public static class StringExtensions
+    /// <typeparam name="T">Type of the element to which the <see cref="IOrder{T}"/> will be generated from</typeparam>
+    /// <param name="sortString"></param>
+    /// <exception cref="ArgumentOutOfRangeException">when <paramref name="sortString"/> is <see langword="null"/> or whitespace</exception>
+    /// <exception cref="InvalidOrderExpressionException">when <paramref name="sortString"/> is not a valid sort expression.</exception>
+    public static IOrder<T> ToSort<T>(this string sortString) => sortString.ToOrder<T>(PropertyNameResolutionStrategy.Default);
+
+    /// <summary>
+    /// Converts <paramref name="sortString"/> to a <see cref="IOrder{T}"/> instance.
+    /// </summary>
+    /// <typeparam name="T">Type of the element to which the <see cref="IOrder{T}"/> will be generated from</typeparam>
+    /// <param name="sortString"></param>
+    /// <param name="propertyNameResolutionStrategy">The transformation to apply to each property name.</param>
+    /// <exception cref="ArgumentOutOfRangeException">when <paramref name="sortString"/> is <see langword="null"/> or whitespace</exception>
+    /// <exception cref="InvalidOrderExpressionException">when <paramref name="sortString"/> is not a valid sort expression.</exception>
+    public static IOrder<T> ToOrder<T>(this string sortString, PropertyNameResolutionStrategy propertyNameResolutionStrategy)
     {
-        private static char Separator => ',';
-#if NET6_0
-        private readonly static ConcurrentDictionary<bool, byte> HackZone = new();
-#endif
-
-        /// <summary>
-        /// Converts <paramref name="sortString"/> to a <see cref="IOrder{T}"/> instance.
-        /// </summary>
-        /// <typeparam name="T">Type of the element to which the <see cref="IOrder{T}"/> will be generated from</typeparam>
-        /// <param name="sortString"></param>
-        /// <exception cref="ArgumentOutOfRangeException">when <paramref name="sortString"/> is <c>null</c> or whitespace</exception>
-        /// <exception cref="InvalidOrderExpressionException">when <paramref name="sortString"/> is not a valid sort expression.</exception>
-        public static IOrder<T> ToSort<T>(this string sortString) => sortString.ToOrder<T>(PropertyNameResolutionStrategy.Default);
-
-        /// <summary>
-        /// Converts <paramref name="sortString"/> to a <see cref="IOrder{T}"/> instance.
-        /// </summary>
-        /// <typeparam name="T">Type of the element to which the <see cref="IOrder{T}"/> will be generated from</typeparam>
-        /// <param name="sortString"></param>
-        /// <param name="propertyNameResolutionStrategy">The transformation to apply to each property name.</param>
-        /// <exception cref="ArgumentOutOfRangeException">when <paramref name="sortString"/> is <c>null</c> or whitespace</exception>
-        /// <exception cref="InvalidOrderExpressionException">when <paramref name="sortString"/> is not a valid sort expression.</exception>
-        public static IOrder<T> ToOrder<T>(this string sortString, PropertyNameResolutionStrategy propertyNameResolutionStrategy)
+        if (string.IsNullOrWhiteSpace(sortString) || sortString?.Length == 0)
         {
-            if (string.IsNullOrWhiteSpace(sortString) || sortString?.Length == 0)
-            {
-                throw new ArgumentOutOfRangeException(nameof(sortString), "cannot be be null or whitespace only");
-            }
-
-            OrderValidator validator = new();
-            ValidationResult validationResult = validator.Validate(sortString);
-
-            if (!validationResult.IsValid)
-            {
-                throw new InvalidOrderExpressionException(sortString);
-            }
-
-#if NETSTANDARD2_0 || NETSTANDARD2_1 || NET5_0_OR_GREATER
-            ReadOnlyMemory<string> sorts = sortString.Split([Separator], StringSplitOptions.RemoveEmptyEntries)
-                                                     .AsMemory();
-
-#else
-            string[] sorts = sortString.Split(new[] { Separator }, StringSplitOptions.RemoveEmptyEntries);
-
-#endif
-            IOrder<T> sort = null;
-
-            if (sorts.Length > 1)
-            {
-#if NETSTANDARD2_0 || NETSTANDARD2_1 || NET5_0_OR_GREATER
-                sort = new MultiOrder<T>(MemoryMarshal.ToEnumerable(sorts).Select(s => s.ToOrder<T>(propertyNameResolutionStrategy) as Order<T>).ToArray());
-#else
-                sort = new MultiOrder<T>(sorts.Select(s => s.ToOrder<T>(propertyNameResolutionStrategy) as Order<T>).ToArray());
-#endif
-            }
-            else if (sortString.StartsWith("+"))
-            {
-#if NETSTANDARD1_3 || NETSTANDARD2_0
-                sort = new Order<T>(propertyNameResolutionStrategy.Handle(sortString.Substring(1)));
-#else
-                sort = new Order<T>(propertyNameResolutionStrategy.Handle(sortString[1..]));
-#endif
-            }
-            else if (sortString.StartsWith("-"))
-            {
-#if NETSTANDARD1_3 || NETSTANDARD2_0
-                sort = new Order<T>(propertyNameResolutionStrategy.Handle(sortString.Substring(1)),
-                           direction: Descending);
-#else
-                sort = new Order<T>(propertyNameResolutionStrategy.Handle(sortString[1..]),
-                           direction: Descending);
-#endif
-            }
-            else
-            {
-                sort = new Order<T>(propertyNameResolutionStrategy.Handle(sortString));
-            }
-
-            return sort;
+            throw new ArgumentOutOfRangeException(nameof(sortString), "cannot be be null or whitespace only");
         }
 
-#if STRING_SEGMENT
-        /// <summary>
-        /// Builds a <see cref="IFilter"/> from <paramref name="queryString"/>
-        /// </summary>
-        /// <typeparam name="T">Type of element to filter</typeparam>
-        /// <param name="queryString">A query string (without any leading <c>?</c> character)</param>
-        /// <param name="propertyNameResolutionStrategy"></param>
-        /// <returns></returns>
-        /// <exception cref="ArgumentNullException"><paramref name="queryString"/> is <c>null</c>.</exception>
-        /// <exception cref="ArgumentOutOfRangeException"><paramref name="queryString"/> is not a valid query string.</exception>
-        public static IFilter ToFilter<T>(this string queryString, PropertyNameResolutionStrategy propertyNameResolutionStrategy)
-            => new StringSegment(queryString).ToFilter<T>(propertyNameResolutionStrategy);
+        OrderValidator validator = new();
+        ValidationResult validationResult = validator.Validate(sortString);
 
-        /// <summary>
-        /// Builds a <see cref="IFilter"/> from <paramref name="queryString"/> using <see cref="PropertyNameResolutionStrategy.Default"/>
-        /// </summary>
-        /// <typeparam name="T">Type of element to filter</typeparam>
-        /// <param name="queryString">A query string (without any leading <c>?</c> character)</param>
-        /// <returns>a <see cref="IFilter"/> that correspond to the <paramref name="queryString"/>.</returns>
-        /// <exception cref="ArgumentNullException"><paramref name="queryString"/> is <c>null</c>.</exception>
-        /// <exception cref="ArgumentOutOfRangeException"><paramref name="queryString"/> is not a valid query string.</exception>
-        public static IFilter ToFilter<T>(this string queryString) => ToFilter<T>(queryString, PropertyNameResolutionStrategy.Default);
-#endif
-
-        /// <summary>
-        /// Builds a <see cref="IFilter"/> from <paramref name="queryString"/> with the specified <paramref name="propertyNameResolutionStrategy"/>.
-        /// </summary>
-        /// <typeparam name="T">Type of element to filter</typeparam>
-        /// <param name="queryString">A query string (without any leading <c>?</c> character)</param>
-        /// <param name="propertyNameResolutionStrategy"></param>
-        /// <returns>The corresponding <see cref="IFilter"/></returns>
-        /// <exception cref="ArgumentNullException">either <paramref name="queryString"/> or <paramref name="propertyNameResolutionStrategy"/> is <c>null</c>.</exception>
-        /// <exception cref="ArgumentOutOfRangeException"><paramref name="queryString"/> is not a valid query string.</exception>
-#if STRING_SEGMENT
-        public static IFilter ToFilter<T>(this StringSegment queryString, PropertyNameResolutionStrategy propertyNameResolutionStrategy)
-            => ToFilter<T>(queryString.Value, new FilterOptions() { DefaultPropertyNameResolutionStrategy = propertyNameResolutionStrategy });
-#else
-        public static IFilter ToFilter<T>(this string queryString, PropertyNameResolutionStrategy propertyNameResolutionStrategy)
-           => ToFilter<T>(queryString, new FilterOptions() { DefaultPropertyNameResolutionStrategy = propertyNameResolutionStrategy });
-#endif
-
-        /// <summary>
-        /// Builds a <see cref="IFilter"/> from <paramref name="queryString"/> with the specified <paramref name="options"/>.
-        /// </summary>
-        /// <typeparam name="T">Type of element to filter</typeparam>
-        /// <param name="queryString">A query string (without any leading <c>?</c> character)</param>
-        /// <param name="options"></param>
-        /// <returns>The corresponding <see cref="IFilter"/></returns>
-        /// <exception cref="ArgumentNullException">either <paramref name="queryString"/> or <paramref name="options"/> is <c>null</c>.</exception>
-        /// <exception cref="ArgumentOutOfRangeException"><paramref name="queryString"/> is not a valid query string.</exception>
-        public static IFilter ToFilter<T>(this string queryString, FilterOptions options)
+        if (!validationResult.IsValid)
         {
-            string localQueryString = queryString;
+            throw new InvalidOrderExpressionException(sortString);
+        }
 
-            static IFilter ConvertExpressionToFilter(PropertyInfo propInfo, FilterExpression expression, TypeConverter tc)
+        ReadOnlyMemory<string> sorts = sortString.Split([Separator], StringSplitOptions.RemoveEmptyEntries)
+            .AsMemory();
+
+        IOrder<T> sort = null;
+
+        if (sorts.Length > 1)
+        {
+            sort = new MultiOrder<T>(MemoryMarshal.ToEnumerable(sorts)
+                .Select(s => s.ToOrder<T>(propertyNameResolutionStrategy) as Order<T>).ToArray());
+        }
+        else if (sortString.StartsWith("+"))
+        {
+            sort = new Order<T>(propertyNameResolutionStrategy.Handle(sortString[1..]));
+        }
+        else if (sortString.StartsWith("-"))
+        {
+            sort = new Order<T>(propertyNameResolutionStrategy.Handle(sortString[1..]),
+                direction: Descending);
+        }
+        else
+        {
+            sort = new Order<T>(propertyNameResolutionStrategy.Handle(sortString));
+        }
+
+        return sort;
+    }
+
+    /// <summary>
+    /// Builds a <see cref="IFilter"/> from <paramref name="queryString"/>
+    /// </summary>
+    /// <typeparam name="T">Type of element to filter</typeparam>
+    /// <param name="queryString">A query string (without any leading <c>?</c> character)</param>
+    /// <param name="propertyNameResolutionStrategy"></param>
+    /// <returns></returns>
+    /// <exception cref="ArgumentNullException"><paramref name="queryString"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentOutOfRangeException"><paramref name="queryString"/> is not a valid query string.</exception>
+    public static IFilter ToFilter<T>(this string queryString,
+        PropertyNameResolutionStrategy propertyNameResolutionStrategy)
+        => new StringSegment(queryString).ToFilter<T>(propertyNameResolutionStrategy);
+
+    /// <summary>
+    /// Builds a <see cref="IFilter"/> from <paramref name="queryString"/> using <see cref="PropertyNameResolutionStrategy.Default"/>
+    /// </summary>
+    /// <typeparam name="T">Type of element to filter</typeparam>
+    /// <param name="queryString">A query string (without any leading <c>?</c> character)</param>
+    /// <returns>a <see cref="IFilter"/> that correspond to the <paramref name="queryString"/>.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="queryString"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentOutOfRangeException"><paramref name="queryString"/> is not a valid query string.</exception>
+    public static IFilter ToFilter<T>(this string queryString) => ToFilter<T>(queryString, PropertyNameResolutionStrategy.Default);
+
+    /// <summary>
+    /// Builds a <see cref="IFilter"/> from <paramref name="queryString"/> with the specified <paramref name="propertyNameResolutionStrategy"/>.
+    /// </summary>
+    /// <typeparam name="T">Type of element to filter</typeparam>
+    /// <param name="queryString">A query string (without any leading <c>?</c> character)</param>
+    /// <param name="propertyNameResolutionStrategy"></param>
+    /// <returns>The corresponding <see cref="IFilter"/></returns>
+    /// <exception cref="ArgumentNullException">either <paramref name="queryString"/> or <paramref name="propertyNameResolutionStrategy"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentOutOfRangeException"><paramref name="queryString"/> is not a valid query string.</exception>
+    public static IFilter ToFilter<T>(this StringSegment queryString, PropertyNameResolutionStrategy propertyNameResolutionStrategy)
+        => ToFilter<T>(queryString.Value, new FilterOptions() { DefaultPropertyNameResolutionStrategy = propertyNameResolutionStrategy });
+
+    /// <summary>
+    /// Builds a <see cref="IFilter"/> from <paramref name="queryString"/> with the specified <paramref name="options"/>.
+    /// </summary>
+    /// <typeparam name="T">Type of element to filter</typeparam>
+    /// <param name="queryString">A query string (without any leading <c>?</c> character)</param>
+    /// <param name="options"></param>
+    /// <returns>The corresponding <see cref="IFilter"/></returns>
+    /// <exception cref="ArgumentNullException">either <paramref name="queryString"/> or <paramref name="options"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentOutOfRangeException"><paramref name="queryString"/> is not a valid query string.</exception>
+    /// <exception cref="NotSupportedException"><paramref name="queryString"/> contains an unsupported</exception>
+    public static IFilter ToFilter<T>(this string queryString, FilterOptions options)
+    {
+        string localQueryString = queryString;
+
+        static IFilter ConvertExpressionToFilter(PropertyInfo propInfo, FilterExpression expression, TypeConverter tc)
+        {
+            IFilter filter;
+            switch (expression)
             {
-                IFilter filter;
-                switch (expression)
-                {
-                    case ConstantValueExpression constant:
-                        string constantValue = constant.Value;
+                case ConstantValueExpression constant:
+                    string constantValue = constant.Value;
 
-                        filter = new Filter(propInfo.Name,
-                                            EqualTo,
-                                            tc.ConvertFromInvariantString(constantValue));
-                        break;
-                    case StartsWithExpression startsWith:
-                        filter = new Filter(propInfo.Name, StartsWith, startsWith.Value);
-                        break;
-                    case EndsWithExpression endsWith:
-                        filter = new Filter(propInfo.Name, EndsWith, endsWith.Value);
-                        break;
-                    case ContainsExpression endsWith:
-                        filter = new Filter(propInfo.Name, Contains, endsWith.Value);
-                        break;
-                    case NotExpression not:
-                        filter = ConvertExpressionToFilter(propInfo, not.Expression, tc).Negate();
-                        break;
-                    case OrExpression orExpression:
-                        filter = new MultiFilter
+                    filter = new Filter(propInfo.Name,
+                        EqualTo,
+                        tc.ConvertFromInvariantString(constantValue));
+                    break;
+                case StartsWithExpression startsWith:
+                    filter = new Filter(propInfo.Name, StartsWith, startsWith.Value);
+                    break;
+                case EndsWithExpression endsWith:
+                    filter = new Filter(propInfo.Name, EndsWith, endsWith.Value);
+                    break;
+                case ContainsExpression endsWith:
+                    filter = new Filter(propInfo.Name, Contains, endsWith.Value);
+                    break;
+                case NotExpression not:
+                    filter = ConvertExpressionToFilter(propInfo, not.Expression, tc).Negate();
+                    break;
+                case OrExpression orExpression:
+                    filter = new MultiFilter
+                    {
+                        Logic = FilterLogic.Or,
+                        Filters =
+                        [
+                            ConvertExpressionToFilter(propInfo, orExpression.Left, tc),
+                            ConvertExpressionToFilter(propInfo, orExpression.Right, tc)
+                        ]
+                    };
+                    break;
+                case AndExpression andExpression:
+                    filter = new MultiFilter
+                    {
+                        Logic = FilterLogic.And,
+                        Filters =
+                        [
+                            ConvertExpressionToFilter(propInfo, andExpression.Left, tc),
+                            ConvertExpressionToFilter(propInfo, andExpression.Right, tc)
+                        ]
+                    };
+                    break;
+                case BracketExpression regex:
+                    filter = new MultiFilter
+                    {
+                        Logic = FilterLogic.Or,
+                        //Filters = regex.Value.Select(c => ConvertExpressionToFilter(new ConstantExpression($"{regex.Before?.Value ?? string.Empty}{c}{regex.After?.Value ?? string.Empty}"), propertyName, tc))
+                    };
+                    break;
+                case GroupExpression group:
+                    filter = ConvertExpressionToFilter(propInfo, group.Expression, tc);
+                    break;
+                case OneOfExpression oneOf:
+                    FilterExpression[] possibleValues = [.. oneOf.Values];
+                    if (oneOf.Values.Exactly(1))
+                    {
+                        filter = ConvertExpressionToFilter(propInfo, possibleValues[0], tc);
+                    }
+                    else
+                    {
+                        List<IFilter> filters = new(possibleValues.Length);
+                        filters.AddRange(possibleValues.Select(item => ConvertExpressionToFilter(propInfo, item, tc)));
+
+                        filter = new MultiFilter { Logic = FilterLogic.Or, Filters = filters };
+                    }
+
+                    break;
+                case IntervalExpression range:
+
+                    static (ConstantValueExpression constantExpression, bool included)
+                        ConvertBoundaryExpressionToConstantExpression(BoundaryExpression input)
+                        => input?.Expression switch
                         {
-                            Logic = FilterLogic.Or,
-                            Filters =
-                            [
-                                ConvertExpressionToFilter(propInfo, orExpression.Left, tc),
-                                ConvertExpressionToFilter(propInfo, orExpression.Right, tc)
-                            ]
+                            NumericValueExpression numeric => ( new StringValueExpression(numeric.Value),
+                                input.Included ),
+                            DateTimeExpression { Date: not null, Time: null } dateTime => (
+                                new StringValueExpression(
+                                    $"{dateTime.Date.Year:D4}-{dateTime.Date.Month:D2}-{dateTime.Date.Day:D2}"),
+                                input.Included ),
+                            DateExpression date => (
+                                new StringValueExpression($"{date.Year:D4}-{date.Month:D2}-{date.Day:D2}"),
+                                input.Included ),
+                            DateTimeExpression { Date: null, Time: not null, Offset: null } dateTime => (
+                                new StringValueExpression(
+                                    $"0001-01-01T{dateTime.Time.Hours}:{dateTime.Time.Minutes}:{dateTime.Time.Seconds}"),
+                                input.Included ),
+                            TimeExpression time => (
+                                new StringValueExpression(
+                                    $"0001-01-01T{time.Hours:D2}:{time.Minutes:D2}:{time.Seconds:D2}"),
+                                input.Included ),
+                            DateTimeExpression { Date: not null, Time: not null, Offset: null } dateTime => (
+                                new StringValueExpression(
+                                    $"{dateTime.Date.Year:D4}-{dateTime.Date.Month:D2}-{dateTime.Date.Day:D2}T{dateTime.Time.Hours:D2}:{dateTime.Time.Minutes:D2}:{dateTime.Time.Seconds:D2}.{dateTime.Time.Milliseconds}"),
+                                input.Included ),
+                            DateTimeExpression { Date: not null, Time: not null, Offset: not null } dateTime => (
+                                new StringValueExpression(dateTime.EscapedParseableString), input.Included ),
+                            AsteriskExpression or null => default, // because this is equivalent to an unbounded range
+#if NET7_0_OR_GREATER
+                                _ => throw new UnreachableException($"Unsupported boundary type {input.Expression.GetType()}")
+#else
+                            _ => throw new NotSupportedException($"Unsupported boundary type {input.Expression.GetType()}")
+#endif
                         };
-                        break;
-                    case AndExpression andExpression:
+
+                    (ConstantValueExpression constantExpression, bool included) min =
+                        ConvertBoundaryExpressionToConstantExpression(range.Min);
+                    (ConstantValueExpression constantExpression, bool included) max =
+                        ConvertBoundaryExpressionToConstantExpression(range.Max);
+
+                    FilterOperator minOperator = min.included ? GreaterThanOrEqual : GreaterThan;
+                    FilterOperator maxOperator = max.included ? LessThanOrEqualTo : LessThan;
+
+                    if (min.constantExpression?.Value is not null && max.constantExpression?.Value is not null)
+                    {
+                        string minValue = min.constantExpression.Value;
+                        string maxValue = max.constantExpression.Value;
                         filter = new MultiFilter
                         {
                             Logic = FilterLogic.And,
                             Filters =
                             [
-                                ConvertExpressionToFilter(propInfo, andExpression.Left, tc),
-                                ConvertExpressionToFilter(propInfo, andExpression.Right, tc)
+                                new Filter(propInfo.Name,
+                                    minOperator,
+                                    tc.ConvertFrom(minValue)),
+                                new Filter(propInfo.Name,
+                                    maxOperator,
+                                    tc.ConvertFrom(maxValue))
                             ]
                         };
-                        break;
-                    case BracketExpression regex:
-                        filter = new MultiFilter
-                        {
-                            Logic = FilterLogic.Or,
-                            //Filters = regex.Value.Select(c => ConvertExpressionToFilter(new ConstantExpression($"{regex.Before?.Value ?? string.Empty}{c}{regex.After?.Value ?? string.Empty}"), propertyName, tc))
-                        };
-                        break;
-                    case GroupExpression group:
-                        filter = ConvertExpressionToFilter(propInfo, group.Expression, tc);
-                        break;
-                    case OneOfExpression oneOf:
-                        FilterExpression[] possibleValues = [.. oneOf.Values];
-                        if (oneOf.Values.Exactly(1))
-                        {
-                            filter = ConvertExpressionToFilter(propInfo, possibleValues[0], tc);
-                        }
-                        else
-                        {
-                            List<IFilter> filters = new(possibleValues.Length);
-                            filters.AddRange(possibleValues.Select(item => ConvertExpressionToFilter(propInfo, item, tc)));
-
-                            filter = new MultiFilter { Logic = FilterLogic.Or, Filters = filters };
-                        }
-                        break;
-                    case IntervalExpression range:
-
-                        static (ConstantValueExpression constantExpression, bool included) ConvertBoundaryExpressionToConstantExpression(BoundaryExpression input)
-                            => input?.Expression switch
-                            {
-                                NumericValueExpression numeric => (new StringValueExpression(numeric.Value), input.Included),
-                                DateTimeExpression { Date: not null, Time: null } dateTime => (new StringValueExpression($"{dateTime.Date.Year:D4}-{dateTime.Date.Month:D2}-{dateTime.Date.Day:D2}"), input.Included),
-                                DateExpression date => (new StringValueExpression($"{date.Year:D4}-{date.Month:D2}-{date.Day:D2}"), input.Included),
-                                DateTimeExpression { Date: null, Time: not null, Offset: null } dateTime => (new StringValueExpression($"0001-01-01T{dateTime.Time.Hours}:{dateTime.Time.Minutes}:{dateTime.Time.Seconds}"), input.Included),
-                                TimeExpression time => (new StringValueExpression($"0001-01-01T{time.Hours:D2}:{time.Minutes:D2}:{time.Seconds:D2}"), input.Included),
-                                DateTimeExpression { Date: not null, Time: not null, Offset: null } dateTime => (new StringValueExpression($"{dateTime.Date.Year:D4}-{dateTime.Date.Month:D2}-{dateTime.Date.Day:D2}T{dateTime.Time.Hours:D2}:{dateTime.Time.Minutes:D2}:{dateTime.Time.Seconds:D2}.{dateTime.Time.Milliseconds}"), input.Included),
-                                DateTimeExpression { Date: not null, Time: not null, Offset: not null } dateTime => (new StringValueExpression(dateTime.EscapedParseableString), input.Included),
-                                AsteriskExpression or null => default, // because this is equivalent to an unbounded range
-#if NET7_0_OR_GREATER
-                                _ => throw new UnreachableException($"Unsupported boundary type {input.Expression.GetType()}")
-#else
-                                _ => throw new NotSupportedException($"Unsupported boundary type {input.Expression.GetType()}")
-#endif
-                            };
-
-                        (ConstantValueExpression constantExpression, bool included) min = ConvertBoundaryExpressionToConstantExpression(range.Min);
-                        (ConstantValueExpression constantExpression, bool included) max = ConvertBoundaryExpressionToConstantExpression(range.Max);
-
-                        FilterOperator minOperator = min.included ? GreaterThanOrEqual : GreaterThan;
-                        FilterOperator maxOperator = max.included ? LessThanOrEqualTo : LessThan;
-
-                        if (min.constantExpression?.Value != default && max.constantExpression?.Value != default)
-                        {
-                            object minValue = min.constantExpression.Value;
-                            object maxValue = max.constantExpression.Value;
-                            filter = new MultiFilter
-                            {
-                                Logic = FilterLogic.And,
-                                Filters =
-                                [
-                                    new Filter(propInfo.Name,
-                                               minOperator,
-                                               tc.ConvertFrom(minValue)),
-                                    new Filter(propInfo.Name,
-                                               maxOperator,
-                                               tc.ConvertFrom(maxValue))
-                                ]
-                            };
-                        }
-                        else if (min.constantExpression?.Value != default)
-                        {
-                            object minValue = min.constantExpression.Value;
-                            filter = new Filter(propInfo.Name, minOperator, tc.ConvertFrom(minValue));
-                        }
-                        else
-                        {
-                            object maxValue = max.constantExpression.Value;
-                            filter = new Filter(propInfo.Name, maxOperator, tc.ConvertFrom(maxValue));
-                        }
-                        break;
-                    default:
-                        throw new NotSupportedException($"Unsupported '{expression.GetType()}'s expression type.");
-                }
-
-                return filter;
-            }
-
-            if (localQueryString == default)
-            {
-                throw new ArgumentNullException(nameof(queryString));
-            }
-
-            IFilter filter = Filter.True;
-            bool isEmptyQueryString = string.IsNullOrWhiteSpace(localQueryString);
-
-            if (!isEmptyQueryString)
-            {
-                FilterTokenizer tokenizer = new();
-                TokenList<FilterToken> tokens = tokenizer.Tokenize(localQueryString);
-
-                (PropertyName Property, FilterExpression Expression)[] expressions = FilterTokenParser.Criteria.Parse(tokens);
-#if NET6_0
-                if (HackZone.TryAdd(true, 1) && expressions.AtLeastOnce())
-                {
-                    TypeDescriptor.AddAttributes(typeof(DateOnly), new TypeConverterAttribute(typeof(DateOnlyTypeConverter)));
-                }
-#endif
-                if (expressions.Once())
-                {
-                    (PropertyName property, FilterExpression expression) = expressions[0];
-
-                    PropertyInfo pi = typeof(T).GetRuntimeProperties()
-                                               .SingleOrDefault(x => x.CanRead && x.Name == options.DefaultPropertyNameResolutionStrategy.Handle(property.Name));
-
-                    if (pi is not null)
-                    {
-                        TypeConverter tc = TypeDescriptor.GetConverter(pi.PropertyType);
-                        filter = ConvertExpressionToFilter(pi, expression, tc);
                     }
-                }
-                else
-                {
-                    IList<IFilter> filters = [];
-
-                    foreach ((PropertyName property, FilterExpression expression) in expressions)
+                    else if (min.constantExpression?.Value is not null)
                     {
-                        PropertyInfo pi = typeof(T).GetRuntimeProperties()
-                                                   .SingleOrDefault(x => x.CanRead && x.Name == options.DefaultPropertyNameResolutionStrategy.Handle(property.Name));
-
-                        if (pi is not null)
-                        {
-                            TypeConverter tc = TypeDescriptor.GetConverter(pi.PropertyType);
-                            filters.Add(ConvertExpressionToFilter(pi, expression, tc));
-                        }
+                        string minValue = min.constantExpression.Value;
+                        filter = new Filter(propInfo.Name, minOperator, tc.ConvertFrom(minValue));
+                    }
+                    else
+                    {
+                        string maxValue = max.constantExpression.Value;
+                        filter = new Filter(propInfo.Name, maxOperator, tc.ConvertFrom(maxValue));
                     }
 
-                    filter = new MultiFilter { Logic = options.Logic, Filters = filters };
-                }
+                    break;
+                default:
+                    throw new NotSupportedException($"Unsupported '{expression.GetType()}'s expression type.");
             }
 
             return filter;
         }
 
-        /// <summary>
-        /// Builds a <see cref="IFilter"/> from <paramref name="queryString"/> using <see cref="DefaultPropertyNameResolutionStrategy"/>.
-        /// </summary>
-        /// <typeparam name="T">Type of element to filter</typeparam>
-        /// <param name="queryString">A query string (without any leading <c>?</c> character)</param>
-        /// <returns>The corresponding <see cref="IFilter"/></returns>
-        /// <exception cref="ArgumentNullException"><paramref name="queryString"/> is <c>null</c>.</exception>
-        /// <exception cref="ArgumentOutOfRangeException"><paramref name="queryString"/> is not a valid query string.</exception>
-#if STRING_SEGMENT
-        public static IFilter ToFilter<T>(this StringSegment queryString) => ToFilter<T>(queryString.Value, PropertyNameResolutionStrategy.Default);
+        if (localQueryString is null)
+        {
+            throw new ArgumentNullException(nameof(queryString));
+        }
 
-#else
-        public static IFilter ToFilter<T>(this string queryString) => ToFilter<T>(queryString, PropertyNameResolutionStrategy.Default);
-#endif
+        IFilter filter = Filter.True;
+        bool isEmptyQueryString = string.IsNullOrWhiteSpace(localQueryString);
+
+        if (!isEmptyQueryString)
+        {
+            FilterTokenizer tokenizer = new();
+            TokenList<FilterToken> tokens = tokenizer.Tokenize(localQueryString);
+
+            (PropertyName Property, FilterExpression Expression)[] expressions = FilterTokenParser.Criteria.Parse(tokens);
+
+            if (expressions.Once())
+            {
+                ( PropertyName property, FilterExpression expression ) = expressions[0];
+
+                PropertyInfo pi = typeof(T).GetRuntimeProperties()
+                                           .SingleOrDefault(x => x.CanRead
+                                                                            && x.Name == options.DefaultPropertyNameResolutionStrategy.Handle(property.Name));
+
+                if (pi is not null)
+                {
+                    TypeConverter tc = TypeDescriptor.GetConverter(pi.PropertyType);
+                    filter = ConvertExpressionToFilter(pi, expression, tc);
+                }
+            }
+            else
+            {
+                IList<IFilter> filters = [];
+
+                foreach (( PropertyName property, FilterExpression expression ) in expressions)
+                {
+                    PropertyInfo pi = typeof(T).GetRuntimeProperties()
+                        .SingleOrDefault(x =>
+                            x.CanRead && x.Name == options.DefaultPropertyNameResolutionStrategy.Handle(property.Name));
+
+                    if (pi is not null)
+                    {
+                        TypeConverter tc = TypeDescriptor.GetConverter(pi.PropertyType);
+                        filters.Add(ConvertExpressionToFilter(pi, expression, tc));
+                    }
+                }
+
+                filter = new MultiFilter { Logic = options.Logic, Filters = filters };
+            }
+        }
+
+        return filter;
     }
+
+    /// <summary>
+    /// Builds a <see cref="IFilter"/> from <paramref name="queryString"/> using <see cref="DefaultPropertyNameResolutionStrategy"/>.
+    /// </summary>
+    /// <typeparam name="T">Type of element to filter</typeparam>
+    /// <param name="queryString">A query string (without any leading <c>?</c> character)</param>
+    /// <returns>The corresponding <see cref="IFilter"/></returns>
+    /// <exception cref="ArgumentNullException"><paramref name="queryString"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentOutOfRangeException"><paramref name="queryString"/> is not a valid query string.</exception>
+    public static IFilter ToFilter<T>(this StringSegment queryString) => ToFilter<T>(queryString.Value, PropertyNameResolutionStrategy.Default);
+
 }

--- a/src/Datafilters.Expressions/FilterExtensions.cs
+++ b/src/Datafilters.Expressions/FilterExtensions.cs
@@ -1,105 +1,105 @@
-﻿namespace DataFilters
-{
+﻿namespace DataFilters;
+
 #if NET6_0
     using DateOnlyTimeOnly.AspNet.Converters;
     using System.ComponentModel;
 #endif
 
-    using System;
-    using System.Collections.Generic;
-    using System.Linq;
-    using System.Linq.Expressions;
-    using System.Reflection;
-    using DataFilters.Expressions;
-    using static System.Linq.Expressions.Expression;
-    using static DataFilters.FilterOperator;
-    using static Expressions.NullableValueBehavior;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+using DataFilters.Expressions;
+using static System.Linq.Expressions.Expression;
+using static DataFilters.FilterOperator;
+using static Expressions.NullableValueBehavior;
 
-    /// <summary>
-    /// The `FilterExtensions` class provides extension methods for building expression trees from `IFilter` instances.
-    /// It allows for filtering data based on various conditions.
-    /// </summary>
-    /// <remarks>
-    /// Example Usage:
-    /// <code>
-    /// // Create a filter
-    /// IFilter filter = new Filter
-    /// {
-    ///     Field = "Name",
-    ///     Operator = FilterOperator.EqualTo,
-    ///     Value = "John"
-    /// };
-    ///
-    ///
-    /// // Build an expression tree
-    /// Expression&lt;Func&lt;Person, bool&gt;&gt; expression = filter.ToExpression&lt;Person&gt;();
-    ///
-    ///
-    /// // Use the expression to filter data
-    /// var filteredData = data.Where(expression.Compile());
-    /// </code>
-    /// </remarks>
-    public static class FilterExtensions
-    {
+/// <summary>
+/// The `FilterExtensions` class provides extension methods for building expression trees from `IFilter` instances.
+/// It allows for filtering data based on various conditions.
+/// </summary>
+/// <remarks>
+/// Example Usage:
+/// <code>
+/// // Create a filter
+/// IFilter filter = new Filter
+/// {
+///     Field = "Name",
+///     Operator = FilterOperator.EqualTo,
+///     Value = "John"
+/// };
+///
+///
+/// // Build an expression tree
+/// Expression&lt;Func&lt;Person, bool&gt;&gt; expression = filter.ToExpression&lt;Person&gt;();
+///
+///
+/// // Use the expression to filter data
+/// var filteredData = data.Where(expression.Compile());
+/// </code>
+/// </remarks>
+public static class FilterExtensions
+{
 #if NET6_0
         private readonly static ISet<bool> HackZone = new HashSet<bool>();
 #endif
 
-        /// <summary>
-        /// List of all primitives types
-        /// </summary>
-        /// <value></value>
-        private static readonly Type[] PrimitiveTypes = [
-            typeof(string),
-            typeof(Guid),
-            typeof(Guid?),
-            typeof(int),
-            typeof(int?),
-            typeof(long?),
-            typeof(long?),
-            typeof(short?),
-            typeof(short?),
-            typeof(decimal?),
-            typeof(decimal?),
-            typeof(double?),
-            typeof(double?),
-            typeof(ushort?),
-            typeof(ushort?),
-            typeof(uint?),
-            typeof(uint?),
-            typeof(ulong?),
-            typeof(ulong?),
-            typeof(DateTime),
-            typeof(DateTime?),
-            typeof(DateTimeOffset),
-            typeof(DateTimeOffset?),
+    /// <summary>
+    /// List of all primitives types
+    /// </summary>
+    /// <value></value>
+    private static readonly Type[] PrimitiveTypes = [
+        typeof(string),
+        typeof(Guid),
+        typeof(Guid?),
+        typeof(int),
+        typeof(int?),
+        typeof(long?),
+        typeof(long?),
+        typeof(short?),
+        typeof(short?),
+        typeof(decimal?),
+        typeof(decimal?),
+        typeof(double?),
+        typeof(double?),
+        typeof(ushort?),
+        typeof(ushort?),
+        typeof(uint?),
+        typeof(uint?),
+        typeof(ulong?),
+        typeof(ulong?),
+        typeof(DateTime),
+        typeof(DateTime?),
+        typeof(DateTimeOffset),
+        typeof(DateTimeOffset?),
 #if NET6_0_OR_GREATER
-            typeof(DateOnly), typeof(DateOnly?),
-            typeof(TimeOnly), typeof(TimeOnly?),
+        typeof(DateOnly), typeof(DateOnly?),
+        typeof(TimeOnly), typeof(TimeOnly?),
 #endif
-            typeof(bool),
-            typeof(bool?),
-            typeof(char),
-            typeof(char?)
-        ];
+        typeof(bool),
+        typeof(bool?),
+        typeof(char),
+        typeof(char?)
+    ];
 
-        /// <summary>
-        /// Builds an <see cref="Expression{TDelegate}"/> tree from a <see cref="IFilter"/> instance.
-        /// </summary>
-        /// <typeparam name="T">Type of the </typeparam>
-        /// <param name="filter"><see cref="IFilter"/> instance to build an <see cref="Expression{TDelegate}"/> tree from.</param>
-        /// <param name="nullableValueBehavior">Indicates if a "null check" should be added to avoid any potential <see cref="NullReferenceException"/> when accessing a property</param>
-        /// <returns><see cref="Expression{TDelegate}"/></returns>
-        /// <exception cref="ArgumentNullException">if <paramref name="filter"/> is <c>null</c>.</exception>
-        /// <remarks>
-        /// Setting <paramref name="nullableValueBehavior"/> to <see cref="AddNullCheck"/> can result in a little overhead
-        /// </remarks>
-        public static Expression<Func<T, bool>> ToExpression<T>(this IFilter filter, NullableValueBehavior nullableValueBehavior = NoAction)
+    /// <summary>
+    /// Builds an <see cref="Expression{TDelegate}"/> tree from a <see cref="IFilter"/> instance.
+    /// </summary>
+    /// <typeparam name="T">Type of the </typeparam>
+    /// <param name="filter"><see cref="IFilter"/> instance to build an <see cref="Expression{TDelegate}"/> tree from.</param>
+    /// <param name="nullableValueBehavior">Indicates if a "null check" should be added to avoid any potential <see cref="NullReferenceException"/> when accessing a property</param>
+    /// <returns><see cref="Expression{TDelegate}"/></returns>
+    /// <exception cref="ArgumentNullException">if <paramref name="filter"/> is <see langword="null"/>.</exception>
+    /// <remarks>
+    /// Setting <paramref name="nullableValueBehavior"/> to <see cref="AddNullCheck"/> can result in a little overhead
+    /// </remarks>
+    public static Expression<Func<T, bool>> ToExpression<T>(this IFilter filter, NullableValueBehavior nullableValueBehavior = NoAction)
+    {
+        if (filter == null)
         {
-            if (filter == null)
-            {
-                throw new ArgumentNullException(nameof(filter), $"{nameof(filter)} cannot be null");
-            }
+            throw new ArgumentNullException(nameof(filter), $"{nameof(filter)} cannot be null");
+        }
 
 #if NET6_0
             // HACK require to handle DateOnly and TimeOnly types.
@@ -110,553 +110,552 @@
             }
 #endif
 
-            Expression<Func<T, bool>> filterExpression = null;
+        Expression<Func<T, bool>> filterExpression = null;
 
-            switch (filter)
+        switch (filter)
+        {
+            case Filter df:
             {
-                case Filter df:
+                if (df.Field == null)
+                {
+                    filterExpression = _ => true;
+                }
+                else
+                {
+                    Type type = typeof(T);
+                    ParameterExpression pe = Parameter(type, "item");
+
+                    string[] fields =
+                    [
+                        .. df.Field.Replace(@"[""", ".")
+                            .Replace(@"""]", string.Empty)
+                            .Split(['.'])
+                    ];
+
+                    Expression body = nullableValueBehavior switch
                     {
-                        if (df.Field == null)
-                        {
-                            filterExpression = _ => true;
-                        }
-                        else
-                        {
-                            Type type = typeof(T);
-                            ParameterExpression pe = Parameter(type, "item");
+                        NoAction => ComputeExpression(pe, fields, type, df.Operator, df.Value),
+                        AddNullCheck => ComputeNullSafeExpression(pe, fields, type, df.Operator, df.Value),
+                        _ => throw new NotSupportedException($"Unsupported '{nullableValueBehavior}' behavior")
+                    };
 
-                            string[] fields =
-                            [
-                                .. df.Field.Replace(@"[""", ".")
-                                           .Replace(@"""]", string.Empty)
-                                           .Split(['.'])
-                            ];
+                    filterExpression = Lambda<Func<T, bool>>(body, pe);
+                }
 
-                            Expression body = nullableValueBehavior switch
-                            {
-                                NoAction => ComputeExpression(pe, fields, type, df.Operator, df.Value),
-                                AddNullCheck => ComputeNullSafeExpression(pe, fields, type, df.Operator, df.Value),
-                                _ => throw new NotSupportedException($"Unsupported '{nullableValueBehavior}' behavior")
-                            };
-
-                            filterExpression = Lambda<Func<T, bool>>(body, pe);
-                        }
-
-                        break;
-                    }
-
-                case MultiFilter dcf:
-                    {
-                        Expression<Func<T, bool>> expression = null;
-                        foreach (IFilter item in dcf.Filters)
-                        {
-                            expression = expression == null
-                                ? item.ToExpression<T>()
-                                : MergeExpressions(expression, dcf.Logic, item.ToExpression<T>());
-                        }
-
-                        filterExpression = expression;
-                        break;
-                    }
+                break;
             }
 
-            return filterExpression;
+            case MultiFilter dcf:
+            {
+                Expression<Func<T, bool>> expression = null;
+                foreach (IFilter item in dcf.Filters)
+                {
+                    expression = expression == null
+                        ? item.ToExpression<T>()
+                        : MergeExpressions(expression, dcf.Logic, item.ToExpression<T>());
+                }
+
+                filterExpression = expression;
+                break;
+            }
         }
 
-        private static object ConvertObjectToDateTime(object source, Type targetType)
-        {
-            object dateTime = null;
+        return filterExpression;
+    }
 
-            if (targetType == typeof(DateTime) || targetType == typeof(DateTime?))
+    private static object ConvertObjectToDateTime(object source, Type targetType)
+    {
+        object dateTime = null;
+
+        if (targetType == typeof(DateTime) || targetType == typeof(DateTime?))
+        {
+            if (DateTime.TryParse(source?.ToString(), out DateTime result))
             {
-                if (DateTime.TryParse(source?.ToString(), out DateTime result))
-                {
-                    dateTime = result;
-                }
+                dateTime = result;
             }
-            else if (targetType == typeof(DateTimeOffset) || targetType == typeof(DateTimeOffset?))
+        }
+        else if (targetType == typeof(DateTimeOffset) || targetType == typeof(DateTimeOffset?))
+        {
+            if (DateTimeOffset.TryParse(source?.ToString(), out DateTimeOffset result))
             {
-                if (DateTimeOffset.TryParse(source?.ToString(), out DateTimeOffset result))
-                {
-                    dateTime = result;
-                }
+                dateTime = result;
             }
+        }
 #if NET6_0_OR_GREATER
-            else if (targetType == typeof(DateOnly) || targetType == typeof(DateOnly?))
+        else if (targetType == typeof(DateOnly) || targetType == typeof(DateOnly?))
+        {
+            if (DateOnly.TryParse(source?.ToString(), out DateOnly result))
             {
-                if (DateOnly.TryParse(source?.ToString(), out DateOnly result))
-                {
-                    dateTime = result;
-                }
+                dateTime = result;
             }
+        }
 #endif
 
-            return dateTime;
-        }
+        return dateTime;
+    }
 
-        private static Expression ComputeBodyExpression(MemberExpression property, FilterOperator @operator, object value)
+    private static Expression ComputeBodyExpression(MemberExpression property, FilterOperator @operator, object value)
+    {
+        ConstantExpression constantExpression = ComputeConstantExpressionBasedOnPropertyExpressionTargetTypeAndValue(((PropertyInfo)property.Member).PropertyType, value);
+
+        return @operator switch
         {
-            ConstantExpression constantExpression = ComputeConstantExpressionBasedOnPropertyExpressionTargetTypeAndValue(((PropertyInfo)property.Member).PropertyType, value);
-
-            return @operator switch
-            {
-                NotEqualTo => NotEqual(property, constantExpression),
-                IsNull => Equal(property, Constant(null)),
-                IsNotNull => NotEqual(property, Constant(null)),
-                FilterOperator.LessThan => LessThan(property, constantExpression),
-                FilterOperator.GreaterThan => GreaterThan(property, constantExpression),
-                FilterOperator.GreaterThanOrEqual => GreaterThanOrEqual(property, constantExpression),
-                LessThanOrEqualTo => LessThanOrEqual(property, constantExpression),
+            NotEqualTo => NotEqual(property, constantExpression),
+            IsNull => Equal(property, Constant(null)),
+            IsNotNull => NotEqual(property, Constant(null)),
+            FilterOperator.LessThan => LessThan(property, constantExpression),
+            FilterOperator.GreaterThan => GreaterThan(property, constantExpression),
+            FilterOperator.GreaterThanOrEqual => GreaterThanOrEqual(property, constantExpression),
+            LessThanOrEqualTo => LessThanOrEqual(property, constantExpression),
 #if NET6_0_OR_GREATER
-                StartsWith => Call(property, typeof(string).GetRuntimeMethod(nameof(string.StartsWith), [constantExpression.Value?.GetType() ?? typeof(string)])!, constantExpression),
-                NotStartsWith => Not(Call(property, typeof(string).GetRuntimeMethod(nameof(string.StartsWith), [constantExpression.Value?.GetType() ?? typeof(string)])!, constantExpression)),
-                EndsWith => Call(property, typeof(string).GetRuntimeMethod(nameof(string.EndsWith), [value?.GetType() ?? typeof(string)])!, constantExpression),
-                NotEndsWith => Not(Call(property, typeof(string).GetRuntimeMethod(nameof(string.EndsWith), [value?.GetType() ?? typeof(string)])!, constantExpression)),
+            StartsWith => Call(property, typeof(string).GetRuntimeMethod(nameof(string.StartsWith), [constantExpression.Value?.GetType() ?? typeof(string)])!, constantExpression),
+            NotStartsWith => Not(Call(property, typeof(string).GetRuntimeMethod(nameof(string.StartsWith), [constantExpression.Value?.GetType() ?? typeof(string)])!, constantExpression)),
+            EndsWith => Call(property, typeof(string).GetRuntimeMethod(nameof(string.EndsWith), [value?.GetType() ?? typeof(string)])!, constantExpression),
+            NotEndsWith => Not(Call(property, typeof(string).GetRuntimeMethod(nameof(string.EndsWith), [value?.GetType() ?? typeof(string)])!, constantExpression)),
 #else
                 StartsWith => Call(property, typeof(string).GetRuntimeMethod(nameof(string.StartsWith), [typeof(string)])!, constantExpression),
                 NotStartsWith => Not(Call(property, typeof(string).GetRuntimeMethod(nameof(string.StartsWith), [value?.GetType() ?? typeof(string)])!, constantExpression)),
                 EndsWith => Call(property, typeof(string).GetRuntimeMethod(nameof(string.EndsWith), [value?.GetType() ?? typeof(string)])!, constantExpression),
                 NotEndsWith => Not(Call(property, typeof(string).GetRuntimeMethod(nameof(string.EndsWith), [value?.GetType() ?? typeof(string)])!, constantExpression)),
 #endif
-                Contains => ComputeContains(property, value),
-                NotContains => Not(Call(property, typeof(string).GetRuntimeMethod(nameof(string.Contains), [value?.GetType() ?? typeof(string)])!, constantExpression)),
-                IsEmpty => ComputeIsEmpty(property),
-                IsNotEmpty => ComputeIsNotEmpty(property),
-                EqualTo => ComputeEquals(property, value),
-                _ => throw new NotSupportedException($"Unsupported {@operator} operator when computing a body expression")
-            };
-        }
+            Contains => ComputeContains(property, value),
+            NotContains => Not(Call(property, typeof(string).GetRuntimeMethod(nameof(string.Contains), [value?.GetType() ?? typeof(string)])!, constantExpression)),
+            IsEmpty => ComputeIsEmpty(property),
+            IsNotEmpty => ComputeIsNotEmpty(property),
+            EqualTo => ComputeEquals(property, value),
+            _ => throw new NotSupportedException($"Unsupported {@operator} operator when computing a body expression")
+        };
+    }
 
-        private static Expression ComputeNullSafeBodyExpression(MemberExpression property, FilterOperator @operator, object value)
+    private static Expression ComputeNullSafeBodyExpression(MemberExpression property, FilterOperator @operator, object value)
+    {
+        ConstantExpression constantExpression = ComputeConstantExpressionBasedOnPropertyExpressionTargetTypeAndValue(((PropertyInfo)property.Member).PropertyType, value);
+
+        return @operator switch
         {
-            ConstantExpression constantExpression = ComputeConstantExpressionBasedOnPropertyExpressionTargetTypeAndValue(((PropertyInfo)property.Member).PropertyType, value);
-
-            return @operator switch
-            {
-                NotEqualTo => NotEqual(property, constantExpression),
-                IsNull => Equal(property, Constant(null)),
-                IsNotNull => NotEqual(property, Constant(null)),
-                FilterOperator.LessThan => LessThan(property, constantExpression),
-                FilterOperator.GreaterThan => GreaterThan(property, constantExpression),
-                FilterOperator.GreaterThanOrEqual => GreaterThanOrEqual(property, constantExpression),
-                LessThanOrEqualTo => LessThanOrEqual(property, constantExpression),
-                StartsWith => AndAlso(NotEqual(property, Constant(null)),
-                                      Call(property,
-                                           typeof(string).GetRuntimeMethod(nameof(string.StartsWith), [typeof(string)])!,
-                                           constantExpression)
-                                      ),
-                NotStartsWith => AndAlso(NotEqual(property, Constant(null)),
-                                         Not(
-                                             Call(property,
-                                                  typeof(string).GetRuntimeMethod(nameof(string.StartsWith), [value?.GetType() ?? typeof(string)])!,
-                                                  constantExpression)
-                                             )
-                                         ),
-                EndsWith => AndAlso(NotEqual(property, Constant(null)),
-                                    Call(property,
-                                         typeof(string).GetRuntimeMethod(nameof(string.EndsWith), [typeof(string)])!,
-                                         constantExpression)
-                                    ),
-                NotEndsWith => AndAlso(NotEqual(property, Constant(null)),
-                                       Not(
-                                           Call(property,
-                                                typeof(string).GetRuntimeMethod(nameof(string.EndsWith), [typeof(string)])!,
-                                                constantExpression)
-                                           )
-                                       ),
-                Contains => ComputeNullSafeContains(property, value),
-                NotContains => Not(ComputeNullSafeContains(property, value)),
-                IsEmpty => ComputeNullSafeIsEmpty(property),
-                IsNotEmpty => Not(ComputeNullSafeIsEmpty(property)),
-                EqualTo => ComputeNullSafeEquals(property, value),
-                _ => throw new NotSupportedException($"Unsupported {@operator} operator when computing a body expression")
-            };
-        }
+            NotEqualTo => NotEqual(property, constantExpression),
+            IsNull => Equal(property, Constant(null)),
+            IsNotNull => NotEqual(property, Constant(null)),
+            FilterOperator.LessThan => LessThan(property, constantExpression),
+            FilterOperator.GreaterThan => GreaterThan(property, constantExpression),
+            FilterOperator.GreaterThanOrEqual => GreaterThanOrEqual(property, constantExpression),
+            LessThanOrEqualTo => LessThanOrEqual(property, constantExpression),
+            StartsWith => AndAlso(NotEqual(property, Constant(null)),
+                Call(property,
+                    typeof(string).GetRuntimeMethod(nameof(string.StartsWith), [typeof(string)])!,
+                    constantExpression)
+            ),
+            NotStartsWith => AndAlso(NotEqual(property, Constant(null)),
+                Not(
+                    Call(property,
+                        typeof(string).GetRuntimeMethod(nameof(string.StartsWith), [value?.GetType() ?? typeof(string)])!,
+                        constantExpression)
+                )
+            ),
+            EndsWith => AndAlso(NotEqual(property, Constant(null)),
+                Call(property,
+                    typeof(string).GetRuntimeMethod(nameof(string.EndsWith), [typeof(string)])!,
+                    constantExpression)
+            ),
+            NotEndsWith => AndAlso(NotEqual(property, Constant(null)),
+                Not(
+                    Call(property,
+                        typeof(string).GetRuntimeMethod(nameof(string.EndsWith), [typeof(string)])!,
+                        constantExpression)
+                )
+            ),
+            Contains => ComputeNullSafeContains(property, value),
+            NotContains => Not(ComputeNullSafeContains(property, value)),
+            IsEmpty => ComputeNullSafeIsEmpty(property),
+            IsNotEmpty => Not(ComputeNullSafeIsEmpty(property)),
+            EqualTo => ComputeNullSafeEquals(property, value),
+            _ => throw new NotSupportedException($"Unsupported {@operator} operator when computing a body expression")
+        };
+    }
 
 #if NET6_0_OR_GREATER
-        /// <summary>
-        /// Computes and returns a <see cref="ConstantExpression"/> based on the property expression target type and value.
-        /// Handles different scenarios based on the member type, including <see cref="DateTime"/>,
-        /// <see cref="DateOnly"/> (for .NET 6.0 or greater),
-        /// enumerable types, and other types.
-        /// </summary>
+    /// <summary>
+    /// Computes and returns a <see cref="ConstantExpression"/> based on the property expression target type and value.
+    /// Handles different scenarios based on the member type, including <see cref="DateTime"/>,
+    /// <see cref="DateOnly"/> (for .NET 6.0 or greater),
+    /// enumerable types, and other types.
+    /// </summary>
 #else
         /// <summary>
         /// Computes and returns a <see cref="ConstantExpression"/> based on the property expression target type and value.
         /// Handles different scenarios based on the member type, including <see cref="DateTime"/>, enumerable and other types.
         /// </summary>
 #endif
-        private static ConstantExpression ComputeConstantExpressionBasedOnPropertyExpressionTargetTypeAndValue(Type memberType, object value)
-        {
-            ConstantExpression ce;
+    private static ConstantExpression ComputeConstantExpressionBasedOnPropertyExpressionTargetTypeAndValue(Type memberType, object value)
+    {
+        ConstantExpression ce;
 
-            if (IsDatetimeMember(memberType))
-            {
-                ce = Constant(ConvertObjectToDateTime(value, memberType), memberType);
-            }
+        if (IsDatetimeMember(memberType))
+        {
+            ce = Constant(ConvertObjectToDateTime(value, memberType), memberType);
+        }
 #if NET6_0_OR_GREATER
-            else if (IsDateOnly(memberType))
-            {
-                ce = Constant(ConvertObjectToDateTime(value, memberType), memberType);
-            }
+        else if (IsDateOnly(memberType))
+        {
+            ce = Constant(ConvertObjectToDateTime(value, memberType), memberType);
+        }
 #endif
-            else if (IsNotAStringAndIsEnumerable(memberType))
-            {
-                Type parameterType = memberType.GenericTypeArguments?.SingleOrDefault() ?? typeof(object);
-                ce = Constant(value, parameterType);
-            }
-            else
-            {
-                Type valueType = value switch
-                {
-                    null => memberType,
-                    _ => value.GetType()
-                };
-                ce = Constant(value, valueType);
-            }
-
-            return ce;
-        }
-
-        private static Expression ComputeIsEmpty(MemberExpression property) => IsNotAStringAndIsEnumerable(property.Type)
-                            ? Not(Call(typeof(Enumerable),
-                                  nameof(Enumerable.Any),
-                                  [property.Type.GenericTypeArguments[0]],
-                                  property))
-                            : Equal(property, Constant(string.Empty));
-
-        private static Expression ComputeNullSafeIsEmpty(MemberExpression property)
+        else if (IsNotAStringAndIsEnumerable(memberType))
         {
-            Expression isEmpty = null;
-            if (IsNotAStringAndIsEnumerable(property.Type))
-            {
-                Expression left = NotEqual(property, Constant(null));
-                Expression right = null;
-                Type genericType = null;
-#if !NETSTANDARD1_3
-                if (property.Type.IsGenericType)
-                {
-                    genericType = property.Type.GenericTypeArguments[0];
-                }
-#endif
-
-                right = Not(Call(typeof(Enumerable),
-                                nameof(Enumerable.Any),
-                                genericType is not null
-                                    ? [genericType]
-                                    : null,
-                                property));
-
-                isEmpty = AndAlso(left, right);
-            }
-            else
-            {
-                isEmpty = Not(Equal(property, Constant(string.Empty)));
-            }
-
-            return isEmpty;
+            Type parameterType = memberType.GenericTypeArguments?.SingleOrDefault() ?? typeof(object);
+            ce = Constant(value, parameterType);
         }
-
-        private static Expression ComputeContains(MemberExpression property, object value)
+        else
         {
-            Expression contains = null;
-            ConstantExpression constantExpression = ComputeConstantExpressionBasedOnPropertyExpressionTargetTypeAndValue(property.Type, value);
-
-            if (IsNotAStringAndIsEnumerable(property.Type))
+            Type valueType = value switch
             {
-                Type genericArgType = property.Type.GenericTypeArguments[0];
-                ParameterExpression pe = Parameter(genericArgType);
-
-                contains = typeof(string) == genericArgType
-                    ? Call(typeof(Enumerable),
-                                    nameof(Enumerable.Any),
-                                    [typeof(string)],
-                                    property,
-                                    Lambda(
-                                        Call(pe,
-                                            typeof(string).GetRuntimeMethod(nameof(string.Contains), [constantExpression.Value?.GetType() ?? typeof(string)])!,
-                                            constantExpression), [pe]))
-                    : Call(typeof(Enumerable),
-                                    nameof(Enumerable.Any),
-                                    [property.Type.GenericTypeArguments[0]],
-                                    property,
-                                    Lambda(Equal(pe, constantExpression), [pe]));
-            }
-            else
-            {
-                contains = Call(property,
-                                typeof(string).GetRuntimeMethod(nameof(string.Contains), [constantExpression.Value?.GetType() ?? typeof(string)])!,
-                                constantExpression);
-            }
-
-            return contains;
+                null => memberType,
+                _ => value.GetType()
+            };
+            ce = Constant(value, valueType);
         }
 
-        private static Expression ComputeNullSafeContains(MemberExpression property, object value)
-        {
-            Expression contains = null;
-            ConstantExpression constantExpression = ComputeConstantExpressionBasedOnPropertyExpressionTargetTypeAndValue(property.Type, value);
-
-            if (IsNotAStringAndIsEnumerable(property.Type))
-            {
-                Type genericArgType = property.Type.GenericTypeArguments[0];
-                ParameterExpression pe = Parameter(genericArgType);
-
-                contains = typeof(string) == genericArgType
-                    ? Call(typeof(Enumerable),
-                                    nameof(Enumerable.Any),
-                                    [typeof(string)],
-                                    property,
-                                    Lambda(
-                                        AndAlso(NotEqual(pe, Constant(null)),
-                                                Call(pe,
-                                                     typeof(string).GetRuntimeMethod(nameof(string.Contains), [typeof(string)])!,
-                                                     constantExpression)), [pe]))
-                    : Call(typeof(Enumerable),
-                           nameof(Enumerable.Any),
-                           [property.Type.GenericTypeArguments[0]],
-                           property,
-                           Lambda(Equal(pe, constantExpression), [pe]));
-            }
-            else
-            {
-                contains = Call(property,
-                              typeof(string).GetRuntimeMethod(nameof(string.Contains), [typeof(string)])!,
-                              constantExpression);
-            }
-
-            return contains;
-        }
-
-        private static Expression ComputeEquals(MemberExpression property, object value)
-        {
-            Expression equals = null;
-            ConstantExpression constantExpression = ComputeConstantExpressionBasedOnPropertyExpressionTargetTypeAndValue(property.Type, value);
-
-            if (IsNotAStringAndIsEnumerable(property.Type))
-            {
-                ParameterExpression pe = Parameter(property.Type.GenericTypeArguments[0]);
-                equals = Call(typeof(Enumerable),
-                              nameof(Enumerable.Any),
-                              [property.Type.GenericTypeArguments[0]],
-                              property,
-                              Lambda(Equal(pe, constantExpression), [pe]));
-            }
-            else
-            {
-                equals = Equal(property, constantExpression);
-            }
-
-            return equals;
-        }
-
-        private static Expression ComputeNullSafeEquals(MemberExpression property, object value)
-        {
-            Expression equals = null;
-            ConstantExpression constantExpression = ComputeConstantExpressionBasedOnPropertyExpressionTargetTypeAndValue(property.Type, value);
-
-            if (IsNotAStringAndIsEnumerable(property.Type))
-            {
-                ParameterExpression pe = Parameter(property.Type.GenericTypeArguments[0]);
-                equals = Call(typeof(Enumerable),
-                              nameof(Enumerable.Any),
-                              [property.Type.GenericTypeArguments[0]],
-                              property,
-                              Lambda(Equal(pe, constantExpression), [pe]));
-            }
-            else
-            {
-                equals = Equal(property, constantExpression);
-            }
-
-            return equals;
-        }
-
-        private static Expression ComputeIsNotEmpty(MemberExpression property) => IsNotAStringAndIsEnumerable(property.Type)
-                            ? Not(ComputeIsEmpty(property))
-                            : NotEqual(property, Constant(string.Empty));
-
-        private static bool IsNotAStringAndIsEnumerable(Type propertyType) => propertyType != typeof(string)
-                                                                              && propertyType.IsAssignableToGenericType(typeof(IEnumerable<>));
-
-        private static Expression ComputeExpression(ParameterExpression pe, IReadOnlyList<string> fields, Type targetType, FilterOperator @operator, object value, MemberExpression property = null)
-        {
-            Expression body = null;
-            int i = 0;
-
-            if (fields.Once())
-            {
-                if (IsNotAStringAndIsEnumerable(targetType))
-                {
-                    Type enumerableGenericType = targetType.GenericTypeArguments[0];
-                    TypeInfo typeInfo = enumerableGenericType.GetTypeInfo();
-                    ParameterExpression localParameter = Parameter(enumerableGenericType);
-                    Expression localBody;
-
-                    if (!(typeInfo.IsPrimitive || PrimitiveTypes.Contains(enumerableGenericType)))
-                    {
-                        MemberExpression localProperty = Property(localParameter, fields.Single());
-                        localBody = ComputeBodyExpression(localProperty, @operator, value);
-                        body = Call(typeof(Enumerable),
-                                     nameof(Enumerable.Any),
-                                     [enumerableGenericType],
-                                     property,
-                                     Lambda(localBody, [localParameter])
-                        );
-                    }
-                }
-                else
-                {
-                    body = ComputeBodyExpression(Property((Expression)property ?? pe, fields.Single()), @operator, value);
-                }
-            }
-            else
-            {
-                bool stopComputingExpression = false;
-                while (!stopComputingExpression && i < fields.Count)
-                {
-                    if (IsNotAStringAndIsEnumerable(targetType))
-                    {
-                        stopComputingExpression = true;
-                        Type enumerableGenericType = targetType.GenericTypeArguments[0];
-                        ParameterExpression localParameter = Parameter(enumerableGenericType);
-                        Expression localBody;
-
-                        fields = fields.Skip(i)
-                                       .ToArray();
-                        localBody = fields.Any()
-                            ? ComputeExpression(localParameter, fields, enumerableGenericType, @operator, value, property)
-                            : ComputeBodyExpression(property, @operator, value);
-
-                        body = Call(typeof(Enumerable),
-                                    nameof(Enumerable.Any),
-                                    [enumerableGenericType],
-                                    property,
-                                    Lambda(localBody, [localParameter])
-                                );
-                    }
-                    else
-                    {
-                        property = Property(body ?? property ?? (Expression)pe, fields.ElementAt(i));
-                        PropertyInfo pi = (PropertyInfo)property.Member;
-                        TypeInfo propertyTypeInfo = pi.PropertyType.GetTypeInfo();
-
-                        if (propertyTypeInfo.IsPrimitive || PrimitiveTypes.Contains(pi.PropertyType))
-                        {
-                            body = ComputeBodyExpression(property, @operator, value);
-                        }
-                        else
-                        {
-                            stopComputingExpression = true;
-                            body = ComputeExpression(pe, fields.Skip(i + 1).ToArray(), pi.PropertyType, @operator, value, property);
-                        }
-                    }
-
-                    i++;
-                }
-            }
-
-            return body;
-        }
-
-        private static Expression ComputeNullSafeExpression(ParameterExpression pe, IReadOnlyList<string> fields, Type targetType, FilterOperator @operator, object value, MemberExpression property = null)
-        {
-            Expression body = null;
-            int i = 0;
-
-            if (fields.Once())
-            {
-                if (IsNotAStringAndIsEnumerable(targetType))
-                {
-                    Type enumerableGenericType = targetType.GenericTypeArguments[0];
-                    TypeInfo typeInfo = enumerableGenericType.GetTypeInfo();
-                    ParameterExpression localParameter = Parameter(enumerableGenericType);
-                    Expression localBody;
-
-                    if (!(typeInfo.IsPrimitive || PrimitiveTypes.Contains(enumerableGenericType)))
-                    {
-                        MemberExpression localProperty = Property(localParameter, fields.Single());
-                        localBody = ComputeNullSafeBodyExpression(localProperty, @operator, value);
-                        body = AndAlso(NotEqual(property, Constant(null)),
-                                       Call(typeof(Enumerable),
-                                            nameof(Enumerable.Any),
-                                            [enumerableGenericType],
-                                            property,
-                                            Lambda(localBody, [localParameter]))
-                        );
-                    }
-                }
-                else
-                {
-                    body = ComputeNullSafeBodyExpression(Property((Expression)property ?? pe, fields.Single()), @operator, value);
-                }
-            }
-            else
-            {
-                bool stopComputingExpression = false;
-                while (!stopComputingExpression && i < fields.Count())
-                {
-                    if (IsNotAStringAndIsEnumerable(targetType))
-                    {
-                        stopComputingExpression = true;
-                        Type enumerableGenericType = targetType.GenericTypeArguments[0];
-                        ParameterExpression localParameter = Parameter(enumerableGenericType);
-                        Expression localBody;
-
-                        fields = fields.Skip(i)
-                                       .ToArray();
-                        localBody = fields.Any()
-                            ? ComputeNullSafeExpression(localParameter, fields.ToArray(), enumerableGenericType, @operator, value, property)
-                            : ComputeNullSafeBodyExpression(property, @operator, value);
-
-                        body = AndAlso(NotEqual(property, Constant(null)),
-                                       Call(typeof(Enumerable),
-                                            nameof(Enumerable.Any),
-                                            [enumerableGenericType],
-                                            property,
-                                            Lambda(localBody, [localParameter])));
-                    }
-                    else
-                    {
-                        property = Property(body ?? property ?? (Expression)pe, fields.ElementAt(i));
-                        PropertyInfo pi = (PropertyInfo)property.Member;
-                        TypeInfo propertyTypeInfo = pi.PropertyType.GetTypeInfo();
-
-                        if (propertyTypeInfo.IsPrimitive || PrimitiveTypes.Contains(pi.PropertyType))
-                        {
-                            body = ComputeNullSafeBodyExpression(property, @operator, value);
-                        }
-                        else
-                        {
-                            stopComputingExpression = true;
-                            body = ComputeNullSafeExpression(pe, fields.Skip(i + 1).ToArray(), pi.PropertyType, @operator, value, property);
-                        }
-                    }
-
-                    i++;
-                }
-            }
-
-            return body;
-        }
-
-        private static Expression<Func<T, bool>> MergeExpressions<T>(Expression<Func<T, bool>> left, FilterLogic logic, Expression<Func<T, bool>> right)
-                => logic switch
-                {
-                    FilterLogic.And => left.AndAlso(right),
-                    FilterLogic.Or => left.OrElse(right),
-                    _ => throw new NotSupportedException("Unsupported filter logic"),
-                };
-
-        // Tests if membertype is a "DateTime" type
-        private static bool IsDatetimeMember(Type memberType) => memberType == typeof(DateTime)
-                                                         || memberType == typeof(DateTime?)
-                                                         || memberType == typeof(DateTimeOffset)
-                                                         || memberType == typeof(DateTimeOffset?);
-
-#if NET6_0_OR_GREATER
-        private static bool IsDateOnly(Type memberType) => memberType == typeof(DateOnly)
-            || memberType == typeof(DateOnly?);
-#endif
+        return ce;
     }
+
+    private static Expression ComputeIsEmpty(MemberExpression property) => IsNotAStringAndIsEnumerable(property.Type)
+        ? Not(Call(typeof(Enumerable),
+            nameof(Enumerable.Any),
+            [property.Type.GenericTypeArguments[0]],
+            property))
+        : Equal(property, Constant(string.Empty));
+
+    private static Expression ComputeNullSafeIsEmpty(MemberExpression property)
+    {
+        Expression isEmpty = null;
+        if (IsNotAStringAndIsEnumerable(property.Type))
+        {
+            Expression left = NotEqual(property, Constant(null));
+            Expression right = null;
+            Type genericType = null;
+#if !NETSTANDARD1_3
+            if (property.Type.IsGenericType)
+            {
+                genericType = property.Type.GenericTypeArguments[0];
+            }
+#endif
+
+            right = Not(Call(typeof(Enumerable),
+                nameof(Enumerable.Any),
+                genericType is not null
+                    ? [genericType]
+                    : null,
+                property));
+
+            isEmpty = AndAlso(left, right);
+        }
+        else
+        {
+            isEmpty = Not(Equal(property, Constant(string.Empty)));
+        }
+
+        return isEmpty;
+    }
+
+    private static Expression ComputeContains(MemberExpression property, object value)
+    {
+        Expression contains = null;
+        ConstantExpression constantExpression = ComputeConstantExpressionBasedOnPropertyExpressionTargetTypeAndValue(property.Type, value);
+
+        if (IsNotAStringAndIsEnumerable(property.Type))
+        {
+            Type genericArgType = property.Type.GenericTypeArguments[0];
+            ParameterExpression pe = Parameter(genericArgType);
+
+            contains = typeof(string) == genericArgType
+                ? Call(typeof(Enumerable),
+                    nameof(Enumerable.Any),
+                    [typeof(string)],
+                    property,
+                    Lambda(
+                        Call(pe,
+                            typeof(string).GetRuntimeMethod(nameof(string.Contains), [constantExpression.Value?.GetType() ?? typeof(string)])!,
+                            constantExpression), [pe]))
+                : Call(typeof(Enumerable),
+                    nameof(Enumerable.Any),
+                    [property.Type.GenericTypeArguments[0]],
+                    property,
+                    Lambda(Equal(pe, constantExpression), [pe]));
+        }
+        else
+        {
+            contains = Call(property,
+                typeof(string).GetRuntimeMethod(nameof(string.Contains), [constantExpression.Value?.GetType() ?? typeof(string)])!,
+                constantExpression);
+        }
+
+        return contains;
+    }
+
+    private static Expression ComputeNullSafeContains(MemberExpression property, object value)
+    {
+        Expression contains = null;
+        ConstantExpression constantExpression = ComputeConstantExpressionBasedOnPropertyExpressionTargetTypeAndValue(property.Type, value);
+
+        if (IsNotAStringAndIsEnumerable(property.Type))
+        {
+            Type genericArgType = property.Type.GenericTypeArguments[0];
+            ParameterExpression pe = Parameter(genericArgType);
+
+            contains = typeof(string) == genericArgType
+                ? Call(typeof(Enumerable),
+                    nameof(Enumerable.Any),
+                    [typeof(string)],
+                    property,
+                    Lambda(
+                        AndAlso(NotEqual(pe, Constant(null)),
+                            Call(pe,
+                                typeof(string).GetRuntimeMethod(nameof(string.Contains), [typeof(string)])!,
+                                constantExpression)), [pe]))
+                : Call(typeof(Enumerable),
+                    nameof(Enumerable.Any),
+                    [property.Type.GenericTypeArguments[0]],
+                    property,
+                    Lambda(Equal(pe, constantExpression), [pe]));
+        }
+        else
+        {
+            contains = Call(property,
+                typeof(string).GetRuntimeMethod(nameof(string.Contains), [typeof(string)])!,
+                constantExpression);
+        }
+
+        return contains;
+    }
+
+    private static Expression ComputeEquals(MemberExpression property, object value)
+    {
+        Expression equals = null;
+        ConstantExpression constantExpression = ComputeConstantExpressionBasedOnPropertyExpressionTargetTypeAndValue(property.Type, value);
+
+        if (IsNotAStringAndIsEnumerable(property.Type))
+        {
+            ParameterExpression pe = Parameter(property.Type.GenericTypeArguments[0]);
+            equals = Call(typeof(Enumerable),
+                nameof(Enumerable.Any),
+                [property.Type.GenericTypeArguments[0]],
+                property,
+                Lambda(Equal(pe, constantExpression), [pe]));
+        }
+        else
+        {
+            equals = Equal(property, constantExpression);
+        }
+
+        return equals;
+    }
+
+    private static Expression ComputeNullSafeEquals(MemberExpression property, object value)
+    {
+        Expression equals = null;
+        ConstantExpression constantExpression = ComputeConstantExpressionBasedOnPropertyExpressionTargetTypeAndValue(property.Type, value);
+
+        if (IsNotAStringAndIsEnumerable(property.Type))
+        {
+            ParameterExpression pe = Parameter(property.Type.GenericTypeArguments[0]);
+            equals = Call(typeof(Enumerable),
+                nameof(Enumerable.Any),
+                [property.Type.GenericTypeArguments[0]],
+                property,
+                Lambda(Equal(pe, constantExpression), [pe]));
+        }
+        else
+        {
+            equals = Equal(property, constantExpression);
+        }
+
+        return equals;
+    }
+
+    private static Expression ComputeIsNotEmpty(MemberExpression property) => IsNotAStringAndIsEnumerable(property.Type)
+        ? Not(ComputeIsEmpty(property))
+        : NotEqual(property, Constant(string.Empty));
+
+    private static bool IsNotAStringAndIsEnumerable(Type propertyType) => propertyType != typeof(string)
+                                                                          && propertyType.IsAssignableToGenericType(typeof(IEnumerable<>));
+
+    private static Expression ComputeExpression(ParameterExpression pe, IReadOnlyList<string> fields, Type targetType, FilterOperator @operator, object value, MemberExpression property = null)
+    {
+        Expression body = null;
+        int i = 0;
+
+        if (fields.Once())
+        {
+            if (IsNotAStringAndIsEnumerable(targetType))
+            {
+                Type enumerableGenericType = targetType.GenericTypeArguments[0];
+                TypeInfo typeInfo = enumerableGenericType.GetTypeInfo();
+                ParameterExpression localParameter = Parameter(enumerableGenericType);
+                Expression localBody;
+
+                if (!(typeInfo.IsPrimitive || PrimitiveTypes.Contains(enumerableGenericType)))
+                {
+                    MemberExpression localProperty = Property(localParameter, fields.Single());
+                    localBody = ComputeBodyExpression(localProperty, @operator, value);
+                    body = Call(typeof(Enumerable),
+                        nameof(Enumerable.Any),
+                        [enumerableGenericType],
+                        property,
+                        Lambda(localBody, [localParameter])
+                    );
+                }
+            }
+            else
+            {
+                body = ComputeBodyExpression(Property((Expression)property ?? pe, fields.Single()), @operator, value);
+            }
+        }
+        else
+        {
+            bool stopComputingExpression = false;
+            while (!stopComputingExpression && i < fields.Count)
+            {
+                if (IsNotAStringAndIsEnumerable(targetType))
+                {
+                    stopComputingExpression = true;
+                    Type enumerableGenericType = targetType.GenericTypeArguments[0];
+                    ParameterExpression localParameter = Parameter(enumerableGenericType);
+                    Expression localBody;
+
+                    fields = fields.Skip(i)
+                        .ToArray();
+                    localBody = fields.Any()
+                        ? ComputeExpression(localParameter, fields, enumerableGenericType, @operator, value, property)
+                        : ComputeBodyExpression(property, @operator, value);
+
+                    body = Call(typeof(Enumerable),
+                        nameof(Enumerable.Any),
+                        [enumerableGenericType],
+                        property,
+                        Lambda(localBody, [localParameter])
+                    );
+                }
+                else
+                {
+                    property = Property(body ?? property ?? (Expression)pe, fields.ElementAt(i));
+                    PropertyInfo pi = (PropertyInfo)property.Member;
+                    TypeInfo propertyTypeInfo = pi.PropertyType.GetTypeInfo();
+
+                    if (propertyTypeInfo.IsPrimitive || PrimitiveTypes.Contains(pi.PropertyType))
+                    {
+                        body = ComputeBodyExpression(property, @operator, value);
+                    }
+                    else
+                    {
+                        stopComputingExpression = true;
+                        body = ComputeExpression(pe, fields.Skip(i + 1).ToArray(), pi.PropertyType, @operator, value, property);
+                    }
+                }
+
+                i++;
+            }
+        }
+
+        return body;
+    }
+
+    private static Expression ComputeNullSafeExpression(ParameterExpression pe, IReadOnlyList<string> fields, Type targetType, FilterOperator @operator, object value, MemberExpression property = null)
+    {
+        Expression body = null;
+        int i = 0;
+
+        if (fields.Once())
+        {
+            if (IsNotAStringAndIsEnumerable(targetType))
+            {
+                Type enumerableGenericType = targetType.GenericTypeArguments[0];
+                TypeInfo typeInfo = enumerableGenericType.GetTypeInfo();
+                ParameterExpression localParameter = Parameter(enumerableGenericType);
+                Expression localBody;
+
+                if (!(typeInfo.IsPrimitive || PrimitiveTypes.Contains(enumerableGenericType)))
+                {
+                    MemberExpression localProperty = Property(localParameter, fields.Single());
+                    localBody = ComputeNullSafeBodyExpression(localProperty, @operator, value);
+                    body = AndAlso(NotEqual(property, Constant(null)),
+                        Call(typeof(Enumerable),
+                            nameof(Enumerable.Any),
+                            [enumerableGenericType],
+                            property,
+                            Lambda(localBody, [localParameter]))
+                    );
+                }
+            }
+            else
+            {
+                body = ComputeNullSafeBodyExpression(Property((Expression)property ?? pe, fields.Single()), @operator, value);
+            }
+        }
+        else
+        {
+            bool stopComputingExpression = false;
+            while (!stopComputingExpression && i < fields.Count())
+            {
+                if (IsNotAStringAndIsEnumerable(targetType))
+                {
+                    stopComputingExpression = true;
+                    Type enumerableGenericType = targetType.GenericTypeArguments[0];
+                    ParameterExpression localParameter = Parameter(enumerableGenericType);
+                    Expression localBody;
+
+                    fields = fields.Skip(i)
+                        .ToArray();
+                    localBody = fields.Any()
+                        ? ComputeNullSafeExpression(localParameter, fields.ToArray(), enumerableGenericType, @operator, value, property)
+                        : ComputeNullSafeBodyExpression(property, @operator, value);
+
+                    body = AndAlso(NotEqual(property, Constant(null)),
+                        Call(typeof(Enumerable),
+                            nameof(Enumerable.Any),
+                            [enumerableGenericType],
+                            property,
+                            Lambda(localBody, [localParameter])));
+                }
+                else
+                {
+                    property = Property(body ?? property ?? (Expression)pe, fields.ElementAt(i));
+                    PropertyInfo pi = (PropertyInfo)property.Member;
+                    TypeInfo propertyTypeInfo = pi.PropertyType.GetTypeInfo();
+
+                    if (propertyTypeInfo.IsPrimitive || PrimitiveTypes.Contains(pi.PropertyType))
+                    {
+                        body = ComputeNullSafeBodyExpression(property, @operator, value);
+                    }
+                    else
+                    {
+                        stopComputingExpression = true;
+                        body = ComputeNullSafeExpression(pe, fields.Skip(i + 1).ToArray(), pi.PropertyType, @operator, value, property);
+                    }
+                }
+
+                i++;
+            }
+        }
+
+        return body;
+    }
+
+    private static Expression<Func<T, bool>> MergeExpressions<T>(Expression<Func<T, bool>> left, FilterLogic logic, Expression<Func<T, bool>> right)
+        => logic switch
+        {
+            FilterLogic.And => left.AndAlso(right),
+            FilterLogic.Or => left.OrElse(right),
+            _ => throw new NotSupportedException("Unsupported filter logic"),
+        };
+
+    // Tests if membertype is a "DateTime" type
+    private static bool IsDatetimeMember(Type memberType) => memberType == typeof(DateTime)
+                                                             || memberType == typeof(DateTime?)
+                                                             || memberType == typeof(DateTimeOffset)
+                                                             || memberType == typeof(DateTimeOffset?);
+
+#if NET6_0_OR_GREATER
+    private static bool IsDateOnly(Type memberType) => memberType == typeof(DateOnly)
+                                                       || memberType == typeof(DateOnly?);
+#endif
 }

--- a/src/Datafilters.Expressions/OrderExpression.cs
+++ b/src/Datafilters.Expressions/OrderExpression.cs
@@ -1,50 +1,49 @@
-﻿namespace DataFilters.Expressions
-{
-    using System;
-    using System.Linq.Expressions;
+﻿namespace DataFilters.Expressions;
 
-    using static DataFilters.OrderDirection;
+using System;
+using System.Linq.Expressions;
+
+using static DataFilters.OrderDirection;
+
+/// <summary>
+/// An instance of this class holds an <see cref="LambdaExpression"/> which defines a property and its related <see cref="OrderDirection"/> to use to order collections
+/// </summary>
+/// <typeparam name="T">Type of the object which the <see cref="OrderExpression{T}"/> c</typeparam>
+/// <remarks>
+/// An <see cref="OrderExpression{T}"/> only can be created by calling either
+/// <see cref="Create{TProperty}(Expression{Func{T, TProperty}}, OrderDirection)"/> or <see cref="Create(LambdaExpression, OrderDirection)"/>
+/// </remarks>
+/// <remarks>
+/// Builds a new <see cref="OrderExpression{T}"/> instance
+/// </remarks>
+/// <param name="keySelector">Lambda expression to the property onto which the sort will be performed. </param>
+/// <param name="direction">Direction of the sort.</param>
+public sealed class OrderExpression<T>(LambdaExpression keySelector, OrderDirection direction)
+{
+    /// <summary>
+    /// Creates a new instance of <see cref="OrderExpression{T}"/>
+    /// </summary>
+    /// <typeparam name="TProperty">Type of the property which will serve to order collections' items</typeparam>
+    /// <param name="keySelector">Expression used to select the property to used to order items in a collection</param>
+    /// <param name="direction">Order direction</param>
+    /// <returns>A fully built <see cref="OrderExpression{T}"/> instance.</returns>
+    public static OrderExpression<T> Create<TProperty>(Expression<Func<T, TProperty>> keySelector, OrderDirection direction = Ascending) => new(keySelector, direction);
 
     /// <summary>
-    /// An instance of this class holds an <see cref="LambdaExpression"/> which defines a property and its related <see cref="OrderDirection"/> to use to order collections
+    /// Creates a new instance of <see cref="OrderExpression{T}"/>
     /// </summary>
-    /// <typeparam name="T">Type of the object which the <see cref="OrderExpression{T}"/> c</typeparam>
-    /// <remarks>
-    /// An <see cref="OrderExpression{T}"/> only can be created by calling either
-    /// <see cref="Create{TProperty}(Expression{Func{T, TProperty}}, OrderDirection)"/> or <see cref="Create(LambdaExpression, OrderDirection)"/>
-    /// </remarks>
-    /// <remarks>
-    /// Builds a new <see cref="OrderExpression{T}"/> instance
-    /// </remarks>
-    /// <param name="keySelector">Lambda expression to the property onto which the sort will be performed. </param>
-    /// <param name="direction">Direction of the sort.</param>
-    public sealed class OrderExpression<T>(LambdaExpression keySelector, OrderDirection direction)
-    {
-        /// <summary>
-        /// Creates a new instance of <see cref="OrderExpression{T}"/>
-        /// </summary>
-        /// <typeparam name="TProperty">Type of the property which will serve to order collections' items</typeparam>
-        /// <param name="keySelector">Expression used to select the property to used to order items in a collection</param>
-        /// <param name="direction">Order direction</param>
-        /// <returns>A fully built <see cref="OrderExpression{T}"/> instance.</returns>
-        public static OrderExpression<T> Create<TProperty>(Expression<Func<T, TProperty>> keySelector, OrderDirection direction = Ascending) => new(keySelector, direction);
+    /// <param name="keySelector">Expression used to select the property to used to order items in a collection</param>
+    /// <param name="direction">Order direction</param>
+    /// <returns>A fully built OrderClause</returns>
+    public static OrderExpression<T> Create(LambdaExpression keySelector, OrderDirection direction = Ascending) => new(keySelector, direction);
 
-        /// <summary>
-        /// Creates a new instance of <see cref="OrderExpression{T}"/>
-        /// </summary>
-        /// <param name="keySelector">Expression used to select the property to used to order items in a collection</param>
-        /// <param name="direction">Order direction</param>
-        /// <returns>A fully built OrderClause</returns>
-        public static OrderExpression<T> Create(LambdaExpression keySelector, OrderDirection direction = Ascending) => new(keySelector, direction);
+    /// <summary>
+    /// The lambda expression to use when
+    /// </summary>
+    public LambdaExpression Expression { get; } = keySelector;
 
-        /// <summary>
-        /// The lambda expression to use when
-        /// </summary>
-        public LambdaExpression Expression { get; } = keySelector;
-
-        /// <summary>
-        /// Order direction (either <see cref="Ascending"/> or <see cref="Descending"/>
-        /// </summary>
-        public OrderDirection Direction { get; } = direction;
-    }
+    /// <summary>
+    /// Order direction (either <see cref="Ascending"/> or <see cref="Descending"/>
+    /// </summary>
+    public OrderDirection Direction { get; } = direction;
 }

--- a/src/Datafilters.Expressions/OrderExtensions.cs
+++ b/src/Datafilters.Expressions/OrderExtensions.cs
@@ -1,46 +1,45 @@
-﻿namespace DataFilters
+﻿namespace DataFilters;
+
+using System;
+using System.Collections.Generic;
+using DataFilters.Expressions;
+
+/// <summary>
+/// Extension methods for <see cref="IOrder{T}"/> instances.
+/// </summary>
+public static class OrderExtensions
 {
-    using System;
-    using System.Collections.Generic;
-    using DataFilters.Expressions;
-
     /// <summary>
-    /// Extension methods for <see cref="IOrder{T}"/> instances.
+    /// Converts <paramref name="sort"/> to a collection of <see cref="OrderExpression{T}"/>.
     /// </summary>
-    public static class OrderExtensions
+    /// <typeparam name="T">Type of element onto the sort expression will target.</typeparam>
+    /// <param name="sort"></param>
+    /// <returns>a collection of <see cref="OrderExpression{T}"/>s</returns>
+    public static IEnumerable<OrderExpression<T>> ToOrderClause<T>(this IOrder<T> sort)
     {
-        /// <summary>
-        /// Converts <paramref name="sort"/> to a collection of <see cref="OrderExpression{T}"/>.
-        /// </summary>
-        /// <typeparam name="T">Type of element onto the sort expression will target.</typeparam>
-        /// <param name="sort"></param>
-        /// <returns>a collection of <see cref="OrderExpression{T}"/>s</returns>
-        public static IEnumerable<OrderExpression<T>> ToOrderClause<T>(this IOrder<T> sort)
+        if (sort is not Order<T> and not MultiOrder<T>)
         {
-            if (sort is not Order<T> and not MultiOrder<T>)
-            {
-                throw new ArgumentOutOfRangeException(nameof(sort), "Unknown sort expression");
-            }
+            throw new ArgumentOutOfRangeException(nameof(sort), "Unknown sort expression");
+        }
 
-            return BuildOrderClauses(sort);
+        return BuildOrderClauses(sort);
 
-            static IEnumerable<OrderExpression<T>> BuildOrderClauses(IOrder<T> sort)
+        static IEnumerable<OrderExpression<T>> BuildOrderClauses(IOrder<T> sort)
+        {
+            switch (sort)
             {
-                switch (sort)
-                {
-                    case Order<T> singleSort:
-                        yield return OrderExpression<T>.Create(singleSort.Expression.ToLambda<T>(), singleSort.Direction);
-                        break;
-                    case MultiOrder<T> multiSort:
-                        foreach (Order<T> item in multiSort.Orders)
+                case Order<T> singleSort:
+                    yield return OrderExpression<T>.Create(singleSort.Expression.ToLambda<T>(), singleSort.Direction);
+                    break;
+                case MultiOrder<T> multiSort:
+                    foreach (Order<T> item in multiSort.Orders)
+                    {
+                        foreach (OrderExpression<T> order in item.ToOrderClause())
                         {
-                            foreach (OrderExpression<T> order in item.ToOrderClause())
-                            {
-                                yield return order;
-                            }
+                            yield return order;
                         }
-                        break;
-                }
+                    }
+                    break;
             }
         }
     }

--- a/src/Datafilters.Expressions/QueryableExtensions.cs
+++ b/src/Datafilters.Expressions/QueryableExtensions.cs
@@ -1,65 +1,64 @@
-﻿namespace System.Linq
+﻿namespace System.Linq;
+
+using System.Collections.Generic;
+using System.Linq.Expressions;
+using DataFilters;
+using DataFilters.Expressions;
+
+/// <summary>
+/// Provides extension methods for ordering a collection of entities.
+/// </summary>
+public static class QueryableExtensions
 {
-    using System.Collections.Generic;
-    using System.Linq.Expressions;
-    using DataFilters;
-    using DataFilters.Expressions;
-
     /// <summary>
-    /// Provides extension methods for ordering a collection of entities.
+    /// Orders the <paramref name="entries"/> based on the specified <paramref name="orderBy"/> object.
     /// </summary>
-    public static class QueryableExtensions
+    /// <typeparam name="T">The type of the entities in the collection.</typeparam>
+    /// <param name="entries">The collection of entities to be ordered.</param>
+    /// <param name="orderBy">The order expression object specifying the ordering criteria.</param>
+    /// <returns>An ordered queryable collection of entities.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when either <paramref name="entries"/> or <paramref name="orderBy"/> is <see langword="null"/>.</exception>
+    public static IOrderedQueryable<T> OrderBy<T>(this IQueryable<T> entries, in IOrder<T> orderBy)
     {
-        /// <summary>
-        /// Orders the <paramref name="entries"/> based on the specified <paramref name="orderBy"/> object.
-        /// </summary>
-        /// <typeparam name="T">The type of the entities in the collection.</typeparam>
-        /// <param name="entries">The collection of entities to be ordered.</param>
-        /// <param name="orderBy">The order expression object specifying the ordering criteria.</param>
-        /// <returns>An ordered queryable collection of entities.</returns>
-        /// <exception cref="ArgumentNullException">Thrown when either <paramref name="entries"/> or <paramref name="orderBy"/> is <see langword="null"/>.</exception>
-        public static IOrderedQueryable<T> OrderBy<T>(this IQueryable<T> entries, in IOrder<T> orderBy)
+        // Check for null parameters
+        if (entries is null)
         {
-            // Check for null parameters
-            if (entries is null)
-            {
-                throw new ArgumentNullException(nameof(entries));
-            }
-
-            if (orderBy is null)
-            {
-                throw new ArgumentNullException(nameof(orderBy));
-            }
-
-            // Get the list of order expressions
-            IEnumerable<OrderExpression<T>> orders = orderBy.ToOrderClause();
-            OrderExpression<T> first = orders.First();
-
-            // Build the initial sorting expression
-            Expression sortExpression = Expression.Call(typeof(Queryable),
-                                                        first.Direction switch
-                                                        {
-                                                            OrderDirection.Ascending => nameof(Queryable.OrderBy),
-                                                            _ => nameof(Queryable.OrderByDescending)
-                                                        },
-                                                        [entries.ElementType, first.Expression.ReturnType],
-                                                        entries.Expression, first.Expression);
-
-            // Build the subsequent sorting expressions
-            foreach (OrderExpression<T> order in orders.Skip(1))
-            {
-                sortExpression = Expression.Call(typeof(Queryable),
-                                                order.Direction switch
-                                                {
-                                                    OrderDirection.Ascending => nameof(Queryable.ThenBy),
-                                                    _ => nameof(Queryable.ThenByDescending)
-                                                },
-                                                [entries.ElementType, order.Expression.ReturnType],
-                                                sortExpression, order.Expression);
-            }
-
-            // Create the ordered queryable collection
-            return (IOrderedQueryable<T>)entries.Provider.CreateQuery(sortExpression);
+            throw new ArgumentNullException(nameof(entries));
         }
+
+        if (orderBy is null)
+        {
+            throw new ArgumentNullException(nameof(orderBy));
+        }
+
+        // Get the list of order expressions
+        IEnumerable<OrderExpression<T>> orders = orderBy.ToOrderClause();
+        OrderExpression<T> first = orders.First();
+
+        // Build the initial sorting expression
+        Expression sortExpression = Expression.Call(typeof(Queryable),
+            first.Direction switch
+            {
+                OrderDirection.Ascending => nameof(Queryable.OrderBy),
+                _ => nameof(Queryable.OrderByDescending)
+            },
+            [entries.ElementType, first.Expression.ReturnType],
+            entries.Expression, first.Expression);
+
+        // Build the subsequent sorting expressions
+        foreach (OrderExpression<T> order in orders.Skip(1))
+        {
+            sortExpression = Expression.Call(typeof(Queryable),
+                order.Direction switch
+                {
+                    OrderDirection.Ascending => nameof(Queryable.ThenBy),
+                    _ => nameof(Queryable.ThenByDescending)
+                },
+                [entries.ElementType, order.Expression.ReturnType],
+                sortExpression, order.Expression);
+        }
+
+        // Create the ordered queryable collection
+        return (IOrderedQueryable<T>)entries.Provider.CreateQuery(sortExpression);
     }
 }

--- a/test/DataFilters.Expressions.UnitTests/Hero.cs
+++ b/test/DataFilters.Expressions.UnitTests/Hero.cs
@@ -1,43 +1,42 @@
-﻿namespace DataFilters.Expressions.UnitTests
+﻿namespace DataFilters.Expressions.UnitTests;
+
+using System;
+using System.Collections.Generic;
+
+public class Hero : IEquatable<Hero>
 {
-    using System;
-    using System.Collections.Generic;
+    public string Name { get; set; }
 
-    public class Hero : IEquatable<Hero>
-    {
-        public string Name { get; set; }
+    public int Age { get; set; }
 
-        public int Age { get; set; }
-
-        public DateTimeOffset FirstAppearance { get; set; }
+    public DateTimeOffset FirstAppearance { get; set; }
 
 #if NET6_0_OR_GREATER
-        public DateOnly LastAppearance { get; set; }
+    public DateOnly LastAppearance { get; set; }
 #endif
 
-        public Hero Acolyte { get; set; }
+    public Hero Acolyte { get; set; }
 
-        ///<inheritdoc/>
-        public override bool Equals(object obj) => Equals(obj as Hero);
+    ///<inheritdoc/>
+    public override bool Equals(object obj) => Equals(obj as Hero);
 
-        ///<inheritdoc/>
-        public bool Equals(Hero other) => other != null && Name == other.Name && Age == other.Age;
+    ///<inheritdoc/>
+    public bool Equals(Hero other) => other != null && Name == other.Name && Age == other.Age;
 
-        ///<inheritdoc/>
+    ///<inheritdoc/>
 #if NETCOREAPP1_0 || NETCOREAPP2_0
         public override int GetHashCode() => (Name, Age).GetHashCode();
 #else
-        public override int GetHashCode() => HashCode.Combine(Name, Age);
+    public override int GetHashCode() => HashCode.Combine(Name, Age);
 #endif
 
-        public static bool operator ==(Hero hero1, Hero hero2)
-        {
-            return EqualityComparer<Hero>.Default.Equals(hero1, hero2);
-        }
+    public static bool operator ==(Hero hero1, Hero hero2)
+    {
+        return EqualityComparer<Hero>.Default.Equals(hero1, hero2);
+    }
 
-        public static bool operator !=(Hero hero1, Hero hero2)
-        {
-            return !(hero1 == hero2);
-        }
+    public static bool operator !=(Hero hero1, Hero hero2)
+    {
+        return !(hero1 == hero2);
     }
 }

--- a/test/DataFilters.Expressions.UnitTests/QueryableExtensionsTests.cs
+++ b/test/DataFilters.Expressions.UnitTests/QueryableExtensionsTests.cs
@@ -1,53 +1,52 @@
-﻿namespace DataFilters.Expressions.UnitTests
+﻿namespace DataFilters.Expressions.UnitTests;
+
+using System;
+using System.Linq;
+using FluentAssertions;
+using Xunit;
+using Xunit.Abstractions;
+using Xunit.Categories;
+
+[UnitTest]
+public class QueryableExtensionsTests(ITestOutputHelper outputHelper)
 {
-    using System;
-    using System.Linq;
-    using FluentAssertions;
-    using Xunit;
-    using Xunit.Abstractions;
-    using Xunit.Categories;
-
-    [UnitTest]
-    public class QueryableExtensionsTests(ITestOutputHelper outputHelper)
-    {
-        public static TheoryData<IQueryable<Hero>, IOrder<Hero>> ThrowsArgumentNullExceptionCases
-            => new()
+    public static TheoryData<IQueryable<Hero>, IOrder<Hero>> ThrowsArgumentNullExceptionCases
+        => new()
+        {
             {
-                {
-                    null,
-                    new Order<Hero>(nameof(Hero.Name))
-                },
-                {
-                    Enumerable.Empty<Hero>().AsQueryable(),
-                    null
-                }
-            };
+                null,
+                new Order<Hero>(nameof(Hero.Name))
+            },
+            {
+                Enumerable.Empty<Hero>().AsQueryable(),
+                null
+            }
+        };
 
-        [Theory]
-        [MemberData(nameof(ThrowsArgumentNullExceptionCases))]
-        public void Should_Throws_ArgumentNullException_When_Parameter_IsNull(IQueryable<Hero> heroes, IOrder<Hero> orderBy)
-        {
-            outputHelper.WriteLine($"{nameof(heroes)} is null : {heroes == null}");
-            outputHelper.WriteLine($"{nameof(orderBy)} is null : {orderBy == null}");
+    [Theory]
+    [MemberData(nameof(ThrowsArgumentNullExceptionCases))]
+    public void Should_Throws_ArgumentNullException_When_Parameter_IsNull(IQueryable<Hero> heroes, IOrder<Hero> orderBy)
+    {
+        outputHelper.WriteLine($"{nameof(heroes)} is null : {heroes == null}");
+        outputHelper.WriteLine($"{nameof(orderBy)} is null : {orderBy == null}");
 
-            // Act
-            Action action = () => heroes.OrderBy(orderBy);
+        // Act
+        Action action = () => heroes.OrderBy(orderBy);
 
-            // Assert
-            action.Should()
-                .ThrowExactly<ArgumentNullException>()
-                .Where(ex => !string.IsNullOrWhiteSpace(ex.ParamName));
-        }
+        // Assert
+        action.Should()
+            .ThrowExactly<ArgumentNullException>()
+            .Where(ex => !string.IsNullOrWhiteSpace(ex.ParamName));
+    }
 
-        [Fact]
-        public void Should_Throws_ArgumentNullException_WhenOrderBy_Null()
-        {
-            // Act
-            Action action = () => Enumerable.Empty<Hero>().AsQueryable().OrderBy(null);
+    [Fact]
+    public void Should_Throws_ArgumentNullException_WhenOrderBy_Null()
+    {
+        // Act
+        Action action = () => Enumerable.Empty<Hero>().AsQueryable().OrderBy(null);
 
-            // Assert
-            action.Should()
-                .ThrowExactly<ArgumentNullException>();
-        }
+        // Assert
+        action.Should()
+            .ThrowExactly<ArgumentNullException>();
     }
 }

--- a/test/DataFilters.Expressions.UnitTests/ToOrderClauseTests.cs
+++ b/test/DataFilters.Expressions.UnitTests/ToOrderClauseTests.cs
@@ -1,164 +1,163 @@
-﻿namespace DataFilters.Expressions.UnitTests
+﻿namespace DataFilters.Expressions.UnitTests;
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using FluentAssertions;
+using FluentAssertions.Extensions;
+using Xunit;
+using Xunit.Categories;
+using static DataFilters.OrderDirection;
+
+[UnitTest]
+[Feature("Expressions")]
+public class ToOrderClauseTests
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Linq;
-    using System.Linq.Expressions;
-    using FluentAssertions;
-    using FluentAssertions.Extensions;
-    using Xunit;
-    using Xunit.Categories;
-    using static DataFilters.OrderDirection;
-
-    [UnitTest]
-    [Feature("Expressions")]
-    public class ToOrderClauseTests
-    {
-        public static TheoryData<IReadOnlyList<Hero>, IOrder<Hero>, Expression<Func<IEnumerable<Hero>, bool>>> ToOrderClauseCases
-            => new()
-            {
-                {
-                    [
-                        new Hero { Name = "Batman"},
-                        new Hero { Name = "Flash"}
-                    ],
-                    new Order<Hero>(nameof(Hero.Name)),
-                    heroes => heroes.Exactly(2)
-                        && heroes.First().Name == "Batman"
-                        && heroes.Last().Name == "Flash"
-
-                },
-                {
-                    [
-                        new Hero { Name = "Batman"},
-                        new Hero { Name = "Flash"}
-                    ],
-                    new Order<Hero>("name"),
-                    heroes => heroes.Exactly(2)
-                        && heroes.First().Name == "Batman"
-                        && heroes.Last().Name == "Flash"
-
-                },
-
-                {
-                    new[]
-                    {
-                        new Hero { Name = "Batman"},
-                        new Hero { Name = "Flash"}
-                    },
-                    new Order<Hero>(" name"),
-                    heroes => heroes.Exactly(2)
-                        && heroes.First().Name == "Batman"
-                        && heroes.Last().Name == "Flash"
-
-                },
-
-                {
-                    new[]
-                    {
-                        new Hero { Name = "Batman"},
-                        new Hero { Name = "Flash"}
-                    },
-                    new Order<Hero>(nameof(Hero.Name), Descending),
-
-                    heroes => heroes.Exactly(2)
-                        && heroes.First().Name == "Flash"
-                        && heroes.Last().Name == "Batman"
-
-                },
-
-                {
-                    new[]
-                    {
-                        new Hero { Name = "Batman", Age = 27},
-                        new Hero { Name = "Wonder Woman", Age = 30},
-                        new Hero { Name = "Flash", Age = 37}
-                    },
-                    new MultiOrder<Hero>
-                    (
-                        new Order<Hero>(nameof(Hero.Age), Ascending),
-                        new Order<Hero>(nameof(Hero.Name), Descending)
-                    ),
-                    heroes => heroes.Exactly(3)
-                                                                          && heroes.First().Name == "Batman"
-                                                                          && heroes.Last().Name == "Flash"
-
-                },
-
-                {
-                    new[]
-                    {
-                        new Hero { Name = "Batman", Age = 27},
-                        new Hero { Name = "Wonder Woman", Age = 30},
-                        new Hero { Name = "Flash", Age = 37}
-                    },
-                    new MultiOrder<Hero>
-                    (
-                        new Order<Hero>(nameof(Hero.Name), Descending),
-                        new Order<Hero>(nameof(Hero.Age), Ascending)
-                    ),
-                    heroes => heroes.Exactly(3)
-                                                                          && heroes.First().Name == "Wonder Woman"
-                                                                          && heroes.Last().Name == "Batman"
-
-                },
-
-                {
-                    new[]
-                    {
-                        new Hero { Name = "Batman", FirstAppearance = 1.May(1939)},
-                        new Hero { Name = "Flash" , FirstAppearance = 1.May(1940)}
-                    },
-                    new Order<Hero>(nameof(Hero.FirstAppearance), Descending),
-
-                    heroes => heroes.Exactly(2)
-                                                                          && heroes.First().Name == "Flash"
-                                                                          && heroes.Last().Name == "Batman"
-
-                },
-
-                {
-                    new[]
-                    {
-                        new Hero
-                        {
-                            Name = "Batman",
-                            FirstAppearance = 1.May(1938),
-                            Acolyte = new Hero { Name = "Robin", Age = 13 }
-                        },
-                        new Hero
-                        {
-                            Name = "Flash",
-                            FirstAppearance = 1.May(1940),
-                            Acolyte = new Hero { Name = "Kid Flash", Age = 15 }
-                        },
-                        new Hero
-                        {
-                            Name = "Green Arrow",
-                            FirstAppearance = 1.May(1940),
-                            Acolyte = new Hero { Name = "Red Arrow", Age = 14 }
-                        }
-                    },
-                    new MultiOrder<Hero>(
-                        new Order<Hero>(nameof(Hero.FirstAppearance), Descending),
-                        new Order<Hero>($"{nameof(Hero.Acolyte)}.{nameof(Hero.Age)}", Ascending)
-                    ),
-
-                    heroes => heroes.Select(x => x.Name).SequenceEqual(new []{ "Green Arrow", "Flash", "Batman"})
-                },
-            };
-
-        [Theory]
-        [MemberData(nameof(ToOrderClauseCases))]
-        public void ToOrderTests(IEnumerable<Hero> heroes, IOrder<Hero> order, Expression<Func<IEnumerable<Hero>, bool>> expectation)
+    public static TheoryData<IReadOnlyList<Hero>, IOrder<Hero>, Expression<Func<IEnumerable<Hero>, bool>>> ToOrderClauseCases
+        => new()
         {
-            // Act
-            IEnumerable<Hero> actual = heroes.AsQueryable()
-                                             .OrderBy(order);
+            {
+                [
+                    new Hero { Name = "Batman"},
+                    new Hero { Name = "Flash"}
+                ],
+                new Order<Hero>(nameof(Hero.Name)),
+                heroes => heroes.Exactly(2)
+                          && heroes.First().Name == "Batman"
+                          && heroes.Last().Name == "Flash"
 
-            // Assert
-            actual.Should()
-                  .Match(expectation);
-        }
+            },
+            {
+                [
+                    new Hero { Name = "Batman"},
+                    new Hero { Name = "Flash"}
+                ],
+                new Order<Hero>("name"),
+                heroes => heroes.Exactly(2)
+                          && heroes.First().Name == "Batman"
+                          && heroes.Last().Name == "Flash"
+
+            },
+
+            {
+                new[]
+                {
+                    new Hero { Name = "Batman"},
+                    new Hero { Name = "Flash"}
+                },
+                new Order<Hero>(" name"),
+                heroes => heroes.Exactly(2)
+                          && heroes.First().Name == "Batman"
+                          && heroes.Last().Name == "Flash"
+
+            },
+
+            {
+                new[]
+                {
+                    new Hero { Name = "Batman"},
+                    new Hero { Name = "Flash"}
+                },
+                new Order<Hero>(nameof(Hero.Name), Descending),
+
+                heroes => heroes.Exactly(2)
+                          && heroes.First().Name == "Flash"
+                          && heroes.Last().Name == "Batman"
+
+            },
+
+            {
+                new[]
+                {
+                    new Hero { Name = "Batman", Age = 27},
+                    new Hero { Name = "Wonder Woman", Age = 30},
+                    new Hero { Name = "Flash", Age = 37}
+                },
+                new MultiOrder<Hero>
+                (
+                    new Order<Hero>(nameof(Hero.Age), Ascending),
+                    new Order<Hero>(nameof(Hero.Name), Descending)
+                ),
+                heroes => heroes.Exactly(3)
+                          && heroes.First().Name == "Batman"
+                          && heroes.Last().Name == "Flash"
+
+            },
+
+            {
+                new[]
+                {
+                    new Hero { Name = "Batman", Age = 27},
+                    new Hero { Name = "Wonder Woman", Age = 30},
+                    new Hero { Name = "Flash", Age = 37}
+                },
+                new MultiOrder<Hero>
+                (
+                    new Order<Hero>(nameof(Hero.Name), Descending),
+                    new Order<Hero>(nameof(Hero.Age), Ascending)
+                ),
+                heroes => heroes.Exactly(3)
+                          && heroes.First().Name == "Wonder Woman"
+                          && heroes.Last().Name == "Batman"
+
+            },
+
+            {
+                new[]
+                {
+                    new Hero { Name = "Batman", FirstAppearance = 1.May(1939)},
+                    new Hero { Name = "Flash" , FirstAppearance = 1.May(1940)}
+                },
+                new Order<Hero>(nameof(Hero.FirstAppearance), Descending),
+
+                heroes => heroes.Exactly(2)
+                          && heroes.First().Name == "Flash"
+                          && heroes.Last().Name == "Batman"
+
+            },
+
+            {
+                new[]
+                {
+                    new Hero
+                    {
+                        Name = "Batman",
+                        FirstAppearance = 1.May(1938),
+                        Acolyte = new Hero { Name = "Robin", Age = 13 }
+                    },
+                    new Hero
+                    {
+                        Name = "Flash",
+                        FirstAppearance = 1.May(1940),
+                        Acolyte = new Hero { Name = "Kid Flash", Age = 15 }
+                    },
+                    new Hero
+                    {
+                        Name = "Green Arrow",
+                        FirstAppearance = 1.May(1940),
+                        Acolyte = new Hero { Name = "Red Arrow", Age = 14 }
+                    }
+                },
+                new MultiOrder<Hero>(
+                    new Order<Hero>(nameof(Hero.FirstAppearance), Descending),
+                    new Order<Hero>($"{nameof(Hero.Acolyte)}.{nameof(Hero.Age)}", Ascending)
+                ),
+
+                heroes => heroes.Select(x => x.Name).SequenceEqual(new []{ "Green Arrow", "Flash", "Batman"})
+            },
+        };
+
+    [Theory]
+    [MemberData(nameof(ToOrderClauseCases))]
+    public void ToOrderTests(IEnumerable<Hero> heroes, IOrder<Hero> order, Expression<Func<IEnumerable<Hero>, bool>> expectation)
+    {
+        // Act
+        IEnumerable<Hero> actual = heroes.AsQueryable()
+            .OrderBy(order);
+
+        // Assert
+        actual.Should()
+            .Match(expectation);
     }
 }

--- a/test/DataFilters.PerformanceTests/BracketVsOr.cs
+++ b/test/DataFilters.PerformanceTests/BracketVsOr.cs
@@ -1,25 +1,26 @@
 ﻿using DataFilters.PerfomanceTests;
 
-namespace DataFilters.PerformanceTests
+namespace DataFilters.PerformanceTests;
+
+using System;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Jobs;
+
+[MemoryDiagnoser]
+[SimpleJob(RuntimeMoniker.Net80)]
+[SimpleJob(RuntimeMoniker.Net90)]
+[System.Diagnostics.CodeAnalysis.SuppressMessage("Performance", "CA1822:Marquer les membres comme étant static")]
+public class BracketVsOr
 {
-    using System;
-    using BenchmarkDotNet.Attributes;
-    using BenchmarkDotNet.Jobs;
+    [Benchmark]
+    [Arguments("Nickname=Br[a-f]")]
+    public IFilter Bracket(string input) => input.ToFilter<SuperHero>();
 
-    [MemoryDiagnoser]
-    [System.Diagnostics.CodeAnalysis.SuppressMessage("Performance", "CA1822:Marquer les membres comme étant static")]
-    public class BracketVsOr
-    {
-        [Benchmark]
-        [Arguments("Nickname=Br[a-f]")]
-        public IFilter Bracket(string input) => input.ToFilter<SuperHero>();
+    [Benchmark]
+    [Arguments("Nickname=(Bra|Brb)|(Brc|Brd)|(Bre|Brf)")]
+    public IFilter Or(string input) => input.ToFilter<SuperHero>();
 
-        [Benchmark]
-        [Arguments("Nickname=(Bra|Brb)|(Brc|Brd)|(Bre|Brf)")]
-        public IFilter Or(string input) => input.ToFilter<SuperHero>();
-
-        [Benchmark]
-        [Arguments("Nickname={Bra|Brb|Brc|Brd|Bre|Brf}")]
-        public IFilter OneOf(string input) => input.ToFilter<SuperHero>();
-    }
+    [Benchmark]
+    [Arguments("Nickname={Bra|Brb|Brc|Brd|Bre|Brf}")]
+    public IFilter OneOf(string input) => input.ToFilter<SuperHero>();
 }

--- a/test/DataFilters.PerformanceTests/GroupParserPerformanceTests.cs
+++ b/test/DataFilters.PerformanceTests/GroupParserPerformanceTests.cs
@@ -6,50 +6,49 @@ using DataFilters.Grammar.Parsing;
 using Superpower;
 using Superpower.Model;
 
-namespace DataFilters.PerformanceTests
+namespace DataFilters.PerformanceTests;
+
+[MemoryDiagnoser]
+[SimpleJob(RuntimeMoniker.Net80)]
+[SimpleJob(RuntimeMoniker.Net90)]
+[SuppressMessage("Performance", "CA1822:Marquer les membres comme étant static")]
+public class GroupParserPerformanceTests
 {
-    [MemoryDiagnoser]
-    [SimpleJob(RuntimeMoniker.Net80)]
-    [SimpleJob(RuntimeMoniker.Net90)]
-    [SuppressMessage("Performance", "CA1822:Marquer les membres comme étant static")]
-    public class GroupParserPerformanceTests
+    [Params(1, 2, 3, 5)] // Paramètres pour le nombre de parenthèses
+    public int ParenthesesCount;
+
+    private string _constructedString;
+    private const string FixedText = "12:34:56.789";
+    private FilterTokenizer _tokenizer;
+    private TokenList<FilterToken> _tokens;
+
+    [GlobalSetup]
+    public void Setup()
     {
-        [Params(1, 2, 3, 5)] // Paramètres pour le nombre de parenthèses
-        public int ParenthesesCount;
-
-        private string _constructedString;
-        private const string FixedText = "12:34:56.789";
-        private FilterTokenizer _tokenizer;
-        private TokenList<FilterToken> _tokens;
-
-        [GlobalSetup]
-        public void Setup()
+        _tokenizer = new FilterTokenizer();
+        StringBuilder sb = new StringBuilder();
+            
+        // Ajout des parenthèses ouvrantes
+        for (int i = 0; i < ParenthesesCount; i++)
         {
-            _tokenizer = new FilterTokenizer();
-            StringBuilder sb = new StringBuilder();
-            
-            // Ajout des parenthèses ouvrantes
-            for (int i = 0; i < ParenthesesCount; i++)
-            {
-                sb.Append('(');
-            }
-
-            // Ajout du texte fixe
-            sb.Append(FixedText);
-
-            // Ajout des parenthèses fermantes
-            for (int i = 0; i < ParenthesesCount; i++)
-            {
-                sb.Append(')');
-            }
-
-            _constructedString = sb.ToString();
-            
-            _tokens = _tokenizer.Tokenize(_constructedString);
+            sb.Append('(');
         }
-        
-        [Benchmark]
-        public void Parse() => FilterTokenParser.Group.Parse(_tokens);
-    
+
+        // Ajout du texte fixe
+        sb.Append(FixedText);
+
+        // Ajout des parenthèses fermantes
+        for (int i = 0; i < ParenthesesCount; i++)
+        {
+            sb.Append(')');
+        }
+
+        _constructedString = sb.ToString();
+            
+        _tokens = _tokenizer.Tokenize(_constructedString);
     }
+        
+    [Benchmark]
+    public void Parse() => FilterTokenParser.Group.Parse(_tokens);
+    
 }

--- a/test/DataFilters.PerformanceTests/GroupParserPerformanceTests.cs
+++ b/test/DataFilters.PerformanceTests/GroupParserPerformanceTests.cs
@@ -9,8 +9,8 @@ using Superpower.Model;
 namespace DataFilters.PerformanceTests
 {
     [MemoryDiagnoser]
-    [SimpleJob(RuntimeMoniker.Net60)]
     [SimpleJob(RuntimeMoniker.Net80)]
+    [SimpleJob(RuntimeMoniker.Net90)]
     [SuppressMessage("Performance", "CA1822:Marquer les membres comme étant static")]
     public class GroupParserPerformanceTests
     {

--- a/test/DataFilters.PerformanceTests/Program.cs
+++ b/test/DataFilters.PerformanceTests/Program.cs
@@ -1,11 +1,9 @@
 ﻿using BenchmarkDotNet.Running;
 
-namespace DataFilters.PerformanceTests
-{
+namespace DataFilters.PerformanceTests;
 
-    public class Program
-    {
-        static void Main(string[] args) => BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly)
-                                                            .Run(args);
-    }
+public class Program
+{
+    static void Main(string[] args) => BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly)
+        .Run(args);
 }

--- a/test/DataFilters.PerformanceTests/SuperHero.cs
+++ b/test/DataFilters.PerformanceTests/SuperHero.cs
@@ -1,14 +1,13 @@
-﻿namespace DataFilters.PerfomanceTests
+﻿namespace DataFilters.PerfomanceTests;
+
+using System.Collections.Generic;
+
+public class SuperHero
 {
-    using System.Collections.Generic;
+    public string Nickname { get; set; }
 
-    public class SuperHero
-    {
-        public string Nickname { get; set; }
+    public string[] Powers { get; set; }
 
-        public string[] Powers { get; set; }
+    public IEnumerable<SuperHero> Acolytes { get; set; }
 
-        public IEnumerable<SuperHero> Acolytes { get; set; }
-
-    }
 }

--- a/test/DataFilters.Queries.UnitTests/FilterToQueriesTests.cs
+++ b/test/DataFilters.Queries.UnitTests/FilterToQueriesTests.cs
@@ -1,143 +1,142 @@
-namespace DataFilters.Queries.UnitTests
+namespace DataFilters.Queries.UnitTests;
+
+using System;
+using FluentAssertions;
+using FluentAssertions.Extensions;
+using global::Queries.Core.Parts.Clauses;
+using Xunit;
+using Xunit.Abstractions;
+using static DataFilters.FilterOperator;
+
+public class FilterToQueriesTests(ITestOutputHelper outputHelper)
 {
-    using System;
-    using FluentAssertions;
-    using FluentAssertions.Extensions;
-    using global::Queries.Core.Parts.Clauses;
-    using Xunit;
-    using Xunit.Abstractions;
-    using static DataFilters.FilterOperator;
-
-    public class FilterToQueriesTests(ITestOutputHelper outputHelper)
-    {
-        public static TheoryData<IFilter, IWhereClause> FilterToWhereCases
-            => new()
+    public static TheoryData<IFilter, IWhereClause> FilterToWhereCases
+        => new()
+        {
             {
-                {
-                    new Filter(field: "Name",@operator: EqualTo, value: "Wayne"),
-                    new WhereClause(column: "Name".Field(), @operator: ClauseOperator.EqualTo, constraint: "Wayne")
-                },
-                {
-                    new Filter(field: "Name",@operator: NotEqualTo, value: "Wayne"),
-                    new WhereClause(column: "Name".Field(), @operator: ClauseOperator.NotEqualTo, constraint: "Wayne")
-                },
+                new Filter(field: "Name",@operator: EqualTo, value: "Wayne"),
+                new WhereClause(column: "Name".Field(), @operator: ClauseOperator.EqualTo, constraint: "Wayne")
+            },
+            {
+                new Filter(field: "Name",@operator: NotEqualTo, value: "Wayne"),
+                new WhereClause(column: "Name".Field(), @operator: ClauseOperator.NotEqualTo, constraint: "Wayne")
+            },
 
-                {
-                    new Filter(field: "Name",@operator: Contains, value: "W"),
-                    new WhereClause(column: "Name".Field(), @operator: ClauseOperator.Like, constraint: "%W%")
-                },
+            {
+                new Filter(field: "Name",@operator: Contains, value: "W"),
+                new WhereClause(column: "Name".Field(), @operator: ClauseOperator.Like, constraint: "%W%")
+            },
 
-                {
-                    new Filter(field: "Name",@operator: EndsWith, value: "W"),
-                    new WhereClause(column: "Name".Field(), @operator: ClauseOperator.Like, constraint: "%W")
-                },
+            {
+                new Filter(field: "Name",@operator: EndsWith, value: "W"),
+                new WhereClause(column: "Name".Field(), @operator: ClauseOperator.Like, constraint: "%W")
+            },
 
-                {
-                    new Filter(field: "Name",@operator: NotEndsWith, value: "W"),
-                    new WhereClause(column: "Name".Field(), @operator: ClauseOperator.NotLike, constraint: "%W")
-                },
+            {
+                new Filter(field: "Name",@operator: NotEndsWith, value: "W"),
+                new WhereClause(column: "Name".Field(), @operator: ClauseOperator.NotLike, constraint: "%W")
+            },
 
+            {
+                new MultiFilter
                 {
-                    new MultiFilter
-                    {
-                        Logic = FilterLogic.Or,
-                        Filters = new []{
-                            new Filter(field: "Name",@operator: EndsWith, value: "man"),
-                            new Filter(field: "Name",@operator: StartsWith, value: "Bat")
-                        }
-                    },
-                    new CompositeWhereClause
-                    {
-                        Logic = ClauseLogic.Or,
-                        Clauses = new []{
-                            new WhereClause("Name".Field(),@operator: ClauseOperator.Like, constraint: "%man"),
-                            new WhereClause("Name".Field(),@operator: ClauseOperator.Like, constraint: "Bat%")
-                        }
+                    Logic = FilterLogic.Or,
+                    Filters = new []{
+                        new Filter(field: "Name",@operator: EndsWith, value: "man"),
+                        new Filter(field: "Name",@operator: StartsWith, value: "Bat")
                     }
                 },
-
+                new CompositeWhereClause
                 {
-                    new Filter(field: "Name", @operator: EndsWith, "*"),
-                    new WhereClause(column: "Name".Field(), @operator: ClauseOperator.Like, "%*")
-                },
+                    Logic = ClauseLogic.Or,
+                    Clauses = new []{
+                        new WhereClause("Name".Field(),@operator: ClauseOperator.Like, constraint: "%man"),
+                        new WhereClause("Name".Field(),@operator: ClauseOperator.Like, constraint: "Bat%")
+                    }
+                }
+            },
 
-                {
-                    new Filter(field: "Superpower", IsNull),
-                    new WhereClause(column: "Superpower".Field(), @operator: ClauseOperator.IsNull)
-                },
+            {
+                new Filter(field: "Name", @operator: EndsWith, "*"),
+                new WhereClause(column: "Name".Field(), @operator: ClauseOperator.Like, "%*")
+            },
 
-                {
-                    new Filter(field: "Superpower", IsNotNull),
-                    new WhereClause(column: "Superpower".Field(), @operator: ClauseOperator.IsNotNull)
-                },
+            {
+                new Filter(field: "Superpower", IsNull),
+                new WhereClause(column: "Superpower".Field(), @operator: ClauseOperator.IsNull)
+            },
 
-                {
-                    new Filter(field: "Nickname", NotStartsWith, "Bat"),
-                    new WhereClause(column: "Nickname".Field(), ClauseOperator.NotLike, "Bat%")
-                },
+            {
+                new Filter(field: "Superpower", IsNotNull),
+                new WhereClause(column: "Superpower".Field(), @operator: ClauseOperator.IsNotNull)
+            },
 
-                {
-                    new Filter(field: "Nickname", NotContains, "man"),
-                    new WhereClause(column: "Nickname".Field(), ClauseOperator.NotLike, "%man%")
-                },
+            {
+                new Filter(field: "Nickname", NotStartsWith, "Bat"),
+                new WhereClause(column: "Nickname".Field(), ClauseOperator.NotLike, "Bat%")
+            },
 
-                {
-                    new Filter(field: "XP", FilterOperator.LessThan, 10),
-                    new WhereClause("XP".Field(), ClauseOperator.LessThan, 10)
-                },
+            {
+                new Filter(field: "Nickname", NotContains, "man"),
+                new WhereClause(column: "Nickname".Field(), ClauseOperator.NotLike, "%man%")
+            },
 
-                {
-                    new Filter(field: "XP", LessThanOrEqualTo, 10),
-                    new WhereClause("XP".Field(), ClauseOperator.LessThanOrEqualTo, 10)
-                },
+            {
+                new Filter(field: "XP", FilterOperator.LessThan, 10),
+                new WhereClause("XP".Field(), ClauseOperator.LessThan, 10)
+            },
 
-                {
-                    new Filter(field : "Height", GreaterThan, 6.4),
-                    new WhereClause("Height".Field(), ClauseOperator.GreaterThan, 6.4.Literal())
-                },
+            {
+                new Filter(field: "XP", LessThanOrEqualTo, 10),
+                new WhereClause("XP".Field(), ClauseOperator.LessThanOrEqualTo, 10)
+            },
 
-                {
-                    new Filter(field : "Height", GreaterThan, 6m),
-                    new WhereClause("Height".Field(), ClauseOperator.GreaterThan, 6m)
-                },
+            {
+                new Filter(field : "Height", GreaterThan, 6.4),
+                new WhereClause("Height".Field(), ClauseOperator.GreaterThan, 6.4.Literal())
+            },
 
-                {
-                    new Filter(field : "Height", GreaterThanOrEqual, 6),
-                    new WhereClause("Height".Field(), ClauseOperator.GreaterThanOrEqualTo, 6)
-                },
+            {
+                new Filter(field : "Height", GreaterThan, 6m),
+                new WhereClause("Height".Field(), ClauseOperator.GreaterThan, 6m)
+            },
 
-                {
-                    new Filter("BirthDate", GreaterThan, 18.January(1983)),
-                    new WhereClause("BirthDate".Field(), ClauseOperator.GreaterThan, 18.January(1983))
-                },
+            {
+                new Filter(field : "Height", GreaterThanOrEqual, 6),
+                new WhereClause("Height".Field(), ClauseOperator.GreaterThanOrEqualTo, 6)
+            },
+
+            {
+                new Filter("BirthDate", GreaterThan, 18.January(1983)),
+                new WhereClause("BirthDate".Field(), ClauseOperator.GreaterThan, 18.January(1983))
+            },
 
 #if NET6_0_OR_GREATER
-                {
-                    new Filter("BirthDate", GreaterThan, DateOnly.FromDateTime(18.January(1983))),
-                    new WhereClause("BirthDate".Field(), ClauseOperator.GreaterThan, DateOnly.FromDateTime(18.January(1983)))
-                },
+            {
+                new Filter("BirthDate", GreaterThan, DateOnly.FromDateTime(18.January(1983))),
+                new WhereClause("BirthDate".Field(), ClauseOperator.GreaterThan, DateOnly.FromDateTime(18.January(1983)))
+            },
 
-                {
-                    new Filter("Time", GreaterThan, TimeOnly.FromDateTime(18.January(1983).Add(15.Hours().And(47.Minutes())))),
-                    new WhereClause("Time".Field(), ClauseOperator.GreaterThan, TimeOnly.FromDateTime(18.January(1983).Add(15.Hours().And(47.Minutes()))))
-                }
+            {
+                new Filter("Time", GreaterThan, TimeOnly.FromDateTime(18.January(1983).Add(15.Hours().And(47.Minutes())))),
+                new WhereClause("Time".Field(), ClauseOperator.GreaterThan, TimeOnly.FromDateTime(18.January(1983).Add(15.Hours().And(47.Minutes()))))
+            }
 #endif
-            };
+        };
 
-        [Theory]
-        [MemberData(nameof(FilterToWhereCases))]
-        public void FilterToWhere(IFilter filter, IWhereClause expected)
-        {
-            outputHelper.WriteLine($"Filter : {filter.Jsonify()}");
-            outputHelper.WriteLine($"Expected : {expected.Jsonify()}");
+    [Theory]
+    [MemberData(nameof(FilterToWhereCases))]
+    public void FilterToWhere(IFilter filter, IWhereClause expected)
+    {
+        outputHelper.WriteLine($"Filter : {filter.Jsonify()}");
+        outputHelper.WriteLine($"Expected : {expected.Jsonify()}");
 
-            // Act
-            IWhereClause actualWhere = filter.ToWhere();
-            outputHelper.WriteLine($"actualQuery : {actualWhere.Jsonify()}");
+        // Act
+        IWhereClause actualWhere = filter.ToWhere();
+        outputHelper.WriteLine($"actualQuery : {actualWhere.Jsonify()}");
 
-            // Assert
-            actualWhere.Should()
-                .Be(expected);
-        }
+        // Assert
+        actualWhere.Should()
+            .Be(expected);
     }
 }

--- a/test/DataFilters.Queries.UnitTests/OrderToQueriesTests.cs
+++ b/test/DataFilters.Queries.UnitTests/OrderToQueriesTests.cs
@@ -1,58 +1,57 @@
-﻿namespace DataFilters.Queries.UnitTests
+﻿namespace DataFilters.Queries.UnitTests;
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using FluentAssertions;
+using global::Queries.Core.Parts.Sorting;
+using Xunit;
+using Xunit.Abstractions;
+using static global::Queries.Core.Parts.Sorting.OrderDirection;
+
+public class OrderToQueriesTests(ITestOutputHelper outputHelper)
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Linq;
-    using System.Linq.Expressions;
-    using FluentAssertions;
-    using global::Queries.Core.Parts.Sorting;
-    using Xunit;
-    using Xunit.Abstractions;
-    using static global::Queries.Core.Parts.Sorting.OrderDirection;
-
-    public class OrderToQueriesTests(ITestOutputHelper outputHelper)
+    public class Person
     {
-        public class Person
+        public string Firstname { get; set; }
+
+        public string Lastname { get; set; }
+    }
+
+    public static TheoryData<IOrder<Person>, Expression<Func<IEnumerable<IOrder>, bool>>> OrderToOrderCases
+        => new()
         {
-            public string Firstname { get; set; }
-
-            public string Lastname { get; set; }
-        }
-
-        public static TheoryData<IOrder<Person>, Expression<Func<IEnumerable<IOrder>, bool>>> OrderToOrderCases
-            => new()
             {
-                {
-                    new Order<Person>("Name"),
-                     sorts => sorts.Once()
-                        && sorts.First().Equals(new OrderExpression("Name".Field(), Ascending))
-                },
+                new Order<Person>("Name"),
+                sorts => sorts.Once()
+                         && sorts.First().Equals(new OrderExpression("Name".Field(), Ascending))
+            },
 
-                {
-                    new MultiOrder<Person>
-                    (
-                        new Order<Person>(nameof(Person.Firstname)),
-                        new Order<Person>(nameof(Person.Lastname))
-                    ),
-                         sorts => sorts.Exactly(2)
-                            && sorts.First().Equals(new OrderExpression(nameof(Person.Firstname), Ascending))
-                            && sorts.Last().Equals(new OrderExpression(nameof(Person.Lastname), Ascending))
-                }
-            };
+            {
+                new MultiOrder<Person>
+                (
+                    new Order<Person>(nameof(Person.Firstname)),
+                    new Order<Person>(nameof(Person.Lastname))
+                ),
+                sorts => sorts.Exactly(2)
+                         && sorts.First().Equals(new OrderExpression(nameof(Person.Firstname), Ascending))
+                         && sorts.Last().Equals(new OrderExpression(nameof(Person.Lastname), Ascending))
+            }
+        };
 
-        [Theory]
-        [MemberData(nameof(OrderToOrderCases))]
-        public void FilterToOrder(IOrder<Person> sort, Expression<Func<IEnumerable<IOrder>, bool>> expected)
-        {
-            outputHelper.WriteLine($"Sort : {sort.Jsonify()}");
+    [Theory]
+    [MemberData(nameof(OrderToOrderCases))]
+    public void FilterToOrder(IOrder<Person> sort, Expression<Func<IEnumerable<IOrder>, bool>> expected)
+    {
+        outputHelper.WriteLine($"Sort : {sort.Jsonify()}");
 
-            // Act
-            IEnumerable<IOrder> actual = sort.ToOrder();
-            outputHelper.WriteLine($"actual result : {actual.Jsonify()}");
+        // Act
+        IEnumerable<IOrder> actual = sort.ToOrder();
+        outputHelper.WriteLine($"actual result : {actual.Jsonify()}");
 
-            // Assert
-            actual.Should()
-                .Match(expected);
-        }
+        // Assert
+        actual.Should()
+            .Match(expected);
     }
 }

--- a/test/DataFilters.UnitTests/Converters/DataFilterConvertersTests.cs
+++ b/test/DataFilters.UnitTests/Converters/DataFilterConvertersTests.cs
@@ -1,266 +1,265 @@
 ﻿#if NETCOREAPP2_1
 using static Newtonsoft.Json.JsonConvert;
 #endif
-namespace DataFilters.UnitTests.Converters
+namespace DataFilters.UnitTests.Converters;
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Linq.Expressions;
+using FluentAssertions;
+using Newtonsoft.Json.Linq;
+using Newtonsoft.Json.Schema;
+using Xunit;
+using Xunit.Abstractions;
+using Xunit.Categories;
+using static DataFilters.FilterLogic;
+using static DataFilters.FilterOperator;
+
+[UnitTest]
+[Feature("Converters")]
+public class DataFilterConverterTests(ITestOutputHelper outputHelper)
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Collections.Immutable;
-    using System.Linq;
-    using System.Linq.Expressions;
-    using FluentAssertions;
-    using Newtonsoft.Json.Linq;
-    using Newtonsoft.Json.Schema;
-    using Xunit;
-    using Xunit.Abstractions;
-    using Xunit.Categories;
-    using static DataFilters.FilterLogic;
-    using static DataFilters.FilterOperator;
-
-    [UnitTest]
-    [Feature("Converters")]
-    public class DataFilterConverterTests(ITestOutputHelper outputHelper)
+    private static IImmutableDictionary<string, FilterOperator> Operators => new Dictionary<string, FilterOperator>
     {
-        private static IImmutableDictionary<string, FilterOperator> Operators => new Dictionary<string, FilterOperator>
-        {
-            ["eq"] = EqualTo,
-            ["neq"] = NotEqualTo,
-            ["lt"] = FilterOperator.LessThan,
-            ["gt"] = GreaterThan,
-            ["lte"] = LessThanOrEqualTo,
-            ["gte"] = GreaterThanOrEqual,
-            ["contains"] = Contains,
-            ["isnull"] = IsNull,
-            ["isnotnull"] = IsNotNull,
-            ["isnotempty"] = IsNotEmpty,
-            ["isempty"] = IsEmpty
-        }.ToImmutableDictionary();
+        ["eq"] = EqualTo,
+        ["neq"] = NotEqualTo,
+        ["lt"] = FilterOperator.LessThan,
+        ["gt"] = GreaterThan,
+        ["lte"] = LessThanOrEqualTo,
+        ["gte"] = GreaterThanOrEqual,
+        ["contains"] = Contains,
+        ["isnull"] = IsNull,
+        ["isnotnull"] = IsNotNull,
+        ["isnotempty"] = IsNotEmpty,
+        ["isempty"] = IsEmpty
+    }.ToImmutableDictionary();
 
-        /// <summary>
-        /// Deserialize tests cases
-        /// </summary>
-        public static TheoryData<Filter, Expression<Func<string, bool>>> SerializeCases
+    /// <summary>
+    /// Deserialize tests cases
+    /// </summary>
+    public static TheoryData<Filter, Expression<Func<string, bool>>> SerializeCases
+    {
+        get
         {
-            get
+            TheoryData<Filter, Expression<Func<string, bool>>> cases = [];
+            foreach (KeyValuePair<string, FilterOperator> item in Operators.Where(kv => !Filter.UnaryOperators.Any(op => op == kv.Value)))
             {
-                TheoryData<Filter, Expression<Func<string, bool>>> cases = [];
-                foreach (KeyValuePair<string, FilterOperator> item in Operators.Where(kv => !Filter.UnaryOperators.Any(op => op == kv.Value)))
-                {
-                    cases.Add
-                    (
-                        new Filter(field: "Firstname", @operator: item.Value, value: "Bruce"),
-                         (json) => json != null
-                            && JToken.Parse(json).Type == JTokenType.Object
-                            && JToken.Parse(json).IsValid(Filter.Schema(item.Value))
-                            && "Firstname".Equals(JToken.Parse(json)[Filter.FieldJsonPropertyName].Value<string>())
-                            && item.Key.Equals(JToken.Parse(json)[Filter.OperatorJsonPropertyName].Value<string>())
-                            && "Bruce".Equals(JToken.Parse(json)[Filter.ValueJsonPropertyName].Value<string>())
-                    );
-                }
-
-                foreach (KeyValuePair<string, FilterOperator> item in Operators.Where(kv => Filter.UnaryOperators.Any(op => op == kv.Value)))
-                {
-                    cases.Add
-                    (
-                        new Filter(field: "Firstname", @operator: item.Value),
-                         (json) => json != null
-                            && JToken.Parse(json).Type == JTokenType.Object
-                            && JObject.Parse(json).Properties().Exactly(2)
-                            && "Firstname".Equals(JObject.Parse(json)[Filter.FieldJsonPropertyName].Value<string>())
-                            && item.Key.Equals(JObject.Parse(json)[Filter.OperatorJsonPropertyName].Value<string>())
-                    );
-                }
-
-                return cases;
+                cases.Add
+                (
+                    new Filter(field: "Firstname", @operator: item.Value, value: "Bruce"),
+                    (json) => json != null
+                              && JToken.Parse(json).Type == JTokenType.Object
+                              && JToken.Parse(json).IsValid(Filter.Schema(item.Value))
+                              && "Firstname".Equals(JToken.Parse(json)[Filter.FieldJsonPropertyName].Value<string>())
+                              && item.Key.Equals(JToken.Parse(json)[Filter.OperatorJsonPropertyName].Value<string>())
+                              && "Bruce".Equals(JToken.Parse(json)[Filter.ValueJsonPropertyName].Value<string>())
+                );
             }
-        }
 
-        /// <summary>
-        /// Deserialize tests cases
-        /// </summary>
-        public static TheoryData<string, Type, Expression<Func<object, bool>>> DeserializeCases
-        {
-            get
+            foreach (KeyValuePair<string, FilterOperator> item in Operators.Where(kv => Filter.UnaryOperators.Any(op => op == kv.Value)))
             {
-                TheoryData<string, Type, Expression<Func<object, bool>>> cases = [];
-                foreach ((string key, FilterOperator value) in Operators.Where(op => op.Value != IsNull
-                                                                                     && op.Value != IsNotNull
-                                                                                     && op.Value != IsEmpty
-                                                                                     && op.Value != IsNotEmpty))
-                {
-                    cases.Add
-                    (
-                        $@"{{""field"" :""Firstname"", ""op"":""{key}"", ""value"" : ""Bruce""}}",
-                        typeof(Filter),
-                        result => new Filter("Firstname", value, "Bruce").Equals(result)
-                    );
-                }
-
                 cases.Add
                 (
-                    @"{""field"" :""Firstname"", ""op"":""isnull""}",
+                    new Filter(field: "Firstname", @operator: item.Value),
+                    (json) => json != null
+                              && JToken.Parse(json).Type == JTokenType.Object
+                              && JObject.Parse(json).Properties().Exactly(2)
+                              && "Firstname".Equals(JObject.Parse(json)[Filter.FieldJsonPropertyName].Value<string>())
+                              && item.Key.Equals(JObject.Parse(json)[Filter.OperatorJsonPropertyName].Value<string>())
+                );
+            }
+
+            return cases;
+        }
+    }
+
+    /// <summary>
+    /// Deserialize tests cases
+    /// </summary>
+    public static TheoryData<string, Type, Expression<Func<object, bool>>> DeserializeCases
+    {
+        get
+        {
+            TheoryData<string, Type, Expression<Func<object, bool>>> cases = [];
+            foreach ((string key, FilterOperator value) in Operators.Where(op => op.Value != IsNull
+                         && op.Value != IsNotNull
+                         && op.Value != IsEmpty
+                         && op.Value != IsNotEmpty))
+            {
+                cases.Add
+                (
+                    $@"{{""field"" :""Firstname"", ""op"":""{key}"", ""value"" : ""Bruce""}}",
                     typeof(Filter),
-                     (result) => new Filter("Firstname", IsNull, null).Equals(result)
+                    result => new Filter("Firstname", value, "Bruce").Equals(result)
                 );
+            }
 
+            cases.Add
+            (
+                @"{""field"" :""Firstname"", ""op"":""isnull""}",
+                typeof(Filter),
+                (result) => new Filter("Firstname", IsNull, null).Equals(result)
+            );
+
+            cases.Add
+            (
+                @"{""field"" :""Firstname"", ""op"":""isnull"", ""value"" : 6}",
+                typeof(Filter),
+                (result) => new Filter("Firstname", IsNull, null).Equals(result)
+            );
+
+            cases.Add
+            (
+                @"{""field"" :""Firstname"", ""op"":""isnotnull"", ""value"" : 6}",
+                typeof(Filter),
+                (result) => new Filter("Firstname", IsNotNull, null).Equals(result)
+            );
+
+            cases.Add
+            (
+                @$"{{""field"" :""integer"", ""op"":""eq"", ""value"" : {long.MaxValue}}}",
+                typeof(Filter),
+                (result) => new Filter("integer", EqualTo, long.MaxValue).Equals(result)
+            );
+
+            cases.Add
+            (
+                @"{""field"" :""bool"", ""op"":""eq"", ""value"" : true }",
+                typeof(Filter),
+                (result) => new Filter("bool", EqualTo, true).Equals(result)
+            );
+
+            cases.Add
+            (
+                @"{""field"" :""EqualNull"", ""op"":""eq"", ""value"" : null }",
+                typeof(Filter),
+                (result) => new Filter("EqualNull", IsNull, null).Equals(result)
+            );
+
+            cases.Add
+            (
+                @"{""field"" :""NotEqualNull"", ""op"":""neq"", ""value"" : null }",
+                typeof(Filter),
+                (result) => new Filter("NotEqualNull", IsNotNull, null).Equals(result)
+            );
+
+            {
+                Guid uuid = Guid.NewGuid();
                 cases.Add
                 (
-                       @"{""field"" :""Firstname"", ""op"":""isnull"", ""value"" : 6}",
-                       typeof(Filter),
-                        (result) => new Filter("Firstname", IsNull, null).Equals(result)
-                );
-
-                cases.Add
-                (
-                       @"{""field"" :""Firstname"", ""op"":""isnotnull"", ""value"" : 6}",
-                       typeof(Filter),
-                        (result) => new Filter("Firstname", IsNotNull, null).Equals(result)
-                );
-
-                cases.Add
-                (
-                    @$"{{""field"" :""integer"", ""op"":""eq"", ""value"" : {long.MaxValue}}}",
+                    $@"{{""field"" :""guid"", ""op"":""eq"", ""value"" : ""{uuid}"" }}",
                     typeof(Filter),
-                     (result) => new Filter("integer", EqualTo, long.MaxValue).Equals(result)
+                    (result) => new Filter("guid", EqualTo, uuid.ToString()).Equals(result)
                 );
+            }
 
-                cases.Add
-                (
-                    @"{""field"" :""bool"", ""op"":""eq"", ""value"" : true }",
-                    typeof(Filter),
-                     (result) => new Filter("bool", EqualTo, true).Equals(result)
-                );
+            cases.Add
+            (
+                @"{""field"" :""date"", ""op"":""eq"", ""value"" : ""2019-8-23T00:00"" }",
+                typeof(Filter),
+                (result) => new Filter("date", EqualTo, "2019-8-23T00:00").Equals(result)
+            );
 
-                cases.Add
-                (
-                    @"{""field"" :""EqualNull"", ""op"":""eq"", ""value"" : null }",
-                    typeof(Filter),
-                     (result) => new Filter("EqualNull", IsNull, null).Equals(result)
-                );
-
-                cases.Add
-                (
-                    @"{""field"" :""NotEqualNull"", ""op"":""neq"", ""value"" : null }",
-                    typeof(Filter),
-                     (result) => new Filter("NotEqualNull", IsNotNull, null).Equals(result)
-                );
-
-                {
-                    Guid uuid = Guid.NewGuid();
-                    cases.Add
-                    (
-                        $@"{{""field"" :""guid"", ""op"":""eq"", ""value"" : ""{uuid}"" }}",
-                        typeof(Filter),
-                         (result) => new Filter("guid", EqualTo, uuid.ToString()).Equals(result)
-                    );
-                }
-
-                cases.Add
-                (
-                    @"{""field"" :""date"", ""op"":""eq"", ""value"" : ""2019-8-23T00:00"" }",
-                    typeof(Filter),
-                     (result) => new Filter("date", EqualTo, "2019-8-23T00:00").Equals(result)
-                );
-
-                cases.Add
-                (
-                    "{" +
-                        @"""logic"": ""or""," +
-                        @"""filters"": [" +
-                            @"{ ""field"" :""Firstname"", ""op"":""eq"", ""value"":""Bruce""}," +
-                            @"{ ""field"" :""Firstname"", ""op"":""eq"", ""value"":""Clark""}" +
-                        "]" +
-                    "}",
-                    typeof(MultiFilter),
-                     (result) =>
-                        new MultiFilter
+            cases.Add
+            (
+                "{" +
+                @"""logic"": ""or""," +
+                @"""filters"": [" +
+                @"{ ""field"" :""Firstname"", ""op"":""eq"", ""value"":""Bruce""}," +
+                @"{ ""field"" :""Firstname"", ""op"":""eq"", ""value"":""Clark""}" +
+                "]" +
+                "}",
+                typeof(MultiFilter),
+                (result) =>
+                    new MultiFilter
+                    {
+                        Logic = Or,
+                        Filters = new IFilter[]
                         {
-                            Logic = Or,
-                            Filters = new IFilter[]
-                            {
-                                new Filter("Firstname", EqualTo, "Bruce"),
-                                new Filter("Firstname", EqualTo, "Clark")
-                            }
-                        }.Equals(result)
+                            new Filter("Firstname", EqualTo, "Bruce"),
+                            new Filter("Firstname", EqualTo, "Clark")
+                        }
+                    }.Equals(result)
 
-                );
+            );
 
-                cases.Add
-                (
-                    "{" +
-                        @"""logic"": ""and""," +
-                        @"""filters"": [" +
-                            @"{ ""field"" :""HasSuperpower"", ""op"":""eq"", ""value"": false}," +
-                            "{" +
-                                @"""logic"": ""or""," +
-                                @"""filters"": [" +
-                                    @"{ ""field"" :""Lastname"", ""op"":""eq"", ""value"":""Wayne""}," +
-                                    @"{ ""field"" :""Lastname"", ""op"":""eq"", ""value"":""Kent""}" +
-                                "]" +
-                            "}" +
-                        "]" +
-                    "}",
-                    typeof(MultiFilter),
-                     (result) =>
-                        new MultiFilter
+            cases.Add
+            (
+                "{" +
+                @"""logic"": ""and""," +
+                @"""filters"": [" +
+                @"{ ""field"" :""HasSuperpower"", ""op"":""eq"", ""value"": false}," +
+                "{" +
+                @"""logic"": ""or""," +
+                @"""filters"": [" +
+                @"{ ""field"" :""Lastname"", ""op"":""eq"", ""value"":""Wayne""}," +
+                @"{ ""field"" :""Lastname"", ""op"":""eq"", ""value"":""Kent""}" +
+                "]" +
+                "}" +
+                "]" +
+                "}",
+                typeof(MultiFilter),
+                (result) =>
+                    new MultiFilter
+                    {
+                        Logic = And,
+                        Filters = new IFilter[]
                         {
-                            Logic = And,
-                            Filters = new IFilter[]
+                            new Filter("HasSuperpower", EqualTo, false),
+                            new MultiFilter
                             {
-                                new Filter("HasSuperpower", EqualTo, false),
-                                new MultiFilter
+                                Logic = Or,
+                                Filters = new IFilter[]
                                 {
-                                    Logic = Or,
-                                    Filters = new IFilter[]
-                                    {
-                                        new Filter("Lastname", EqualTo, "Wayne"),
-                                        new Filter("Lastname", EqualTo, "Kent")
-                                    }
+                                    new Filter("Lastname", EqualTo, "Wayne"),
+                                    new Filter("Lastname", EqualTo, "Kent")
                                 }
                             }
-                        }.Equals(result)
+                        }
+                    }.Equals(result)
 
-                );
+            );
 
-                return cases;
-            }
+            return cases;
         }
+    }
 
-        /// <summary>
-        /// Tests the deserialization of the <paramref name="json"/> to an instance of the specified <paramref name="targetType"/> <br/>
-        /// The deserialization is done using <c>JsonConvert.DeserializeObject</c>
-        /// </summary>
-        /// <param name="json">json to deserialize</param>
-        /// <param name="targetType">type the json string will be deserialize into</param>
-        /// <param name="expectation">Expectation that result of the deserialization should match</param>
-        [Theory]
-        [MemberData(nameof(DeserializeCases))]
-        public void Deserialize(string json, Type targetType, Expression<Func<object, bool>> expectation)
-        {
-            outputHelper.WriteLine($"{nameof(json)} : {json}");
+    /// <summary>
+    /// Tests the deserialization of the <paramref name="json"/> to an instance of the specified <paramref name="targetType"/> <br/>
+    /// The deserialization is done using <c>JsonConvert.DeserializeObject</c>
+    /// </summary>
+    /// <param name="json">json to deserialize</param>
+    /// <param name="targetType">type the json string will be deserialize into</param>
+    /// <param name="expectation">Expectation that result of the deserialization should match</param>
+    [Theory]
+    [MemberData(nameof(DeserializeCases))]
+    public void Deserialize(string json, Type targetType, Expression<Func<object, bool>> expectation)
+    {
+        outputHelper.WriteLine($"{nameof(json)} : {json}");
 
-            object result = System.Text.Json.JsonSerializer.Deserialize(json, targetType);
+        object result = System.Text.Json.JsonSerializer.Deserialize(json, targetType);
 
-            result.Should()
-                  .Match(expectation);
-        }
+        result.Should()
+            .Match(expectation);
+    }
 
-        /// <summary>
-        /// Tests the serialization of the <paramref name="obj"/> to its string representation
-        /// The deserialization is done using <c>JsonConvert.DeserializeObject</c>
-        /// </summary>
-        /// <param name="filter">json to deserialize</param>
-        /// <param name="expectation">Expectation that result of the deserialization should match</param>
-        [Theory]
-        [MemberData(nameof(SerializeCases))]
-        public void Serialize(IFilter filter, Expression<Func<string, bool>> expectation)
-        {
-            outputHelper.WriteLine($"Serializing {filter}");
+    /// <summary>
+    /// Tests the serialization of the <paramref name="obj"/> to its string representation
+    /// The deserialization is done using <c>JsonConvert.DeserializeObject</c>
+    /// </summary>
+    /// <param name="filter">json to deserialize</param>
+    /// <param name="expectation">Expectation that result of the deserialization should match</param>
+    [Theory]
+    [MemberData(nameof(SerializeCases))]
+    public void Serialize(IFilter filter, Expression<Func<string, bool>> expectation)
+    {
+        outputHelper.WriteLine($"Serializing {filter}");
 
-            string result = System.Text.Json.JsonSerializer.Serialize(filter, filter.GetType());
+        string result = System.Text.Json.JsonSerializer.Serialize(filter, filter.GetType());
 
-            result.Should()
-                .Match(expectation);
-        }
+        result.Should()
+            .Match(expectation);
     }
 }

--- a/test/DataFilters.UnitTests/FilterExtensionsTests.cs
+++ b/test/DataFilters.UnitTests/FilterExtensionsTests.cs
@@ -1,518 +1,517 @@
-﻿namespace DataFilters.UnitTests
+﻿namespace DataFilters.UnitTests;
+
+using System;
+using DataFilters;
+using DataFilters.Casing;
+using DataFilters.TestObjects;
+using FluentAssertions;
+using FluentAssertions.Common;
+using FluentAssertions.Extensions;
+using Xunit;
+using Xunit.Abstractions;
+using Xunit.Categories;
+using static DataFilters.FilterLogic;
+using static DataFilters.FilterOperator;
+
+[UnitTest]
+public class FilterExtensionsTests(ITestOutputHelper outputHelper)
 {
-    using System;
-    using DataFilters;
-    using DataFilters.Casing;
-    using DataFilters.TestObjects;
-    using FluentAssertions;
-    using FluentAssertions.Common;
-    using FluentAssertions.Extensions;
-    using Xunit;
-    using Xunit.Abstractions;
-    using Xunit.Categories;
-    using static DataFilters.FilterLogic;
-    using static DataFilters.FilterOperator;
-
-    [UnitTest]
-    public class FilterExtensionsTests(ITestOutputHelper outputHelper)
-    {
-        public static TheoryData<string, IFilter> ToFilterCases
+    public static TheoryData<string, IFilter> ToFilterCases
         => new()
+        {
+            {
+                $"{nameof(Person.Firstname)}=Hal&{nameof(Person.Lastname)}=Jordan",
+                new MultiFilter
                 {
+                    Logic = And,
+                    Filters = new IFilter[]
                     {
-                        $"{nameof(Person.Firstname)}=Hal&{nameof(Person.Lastname)}=Jordan",
-                        new MultiFilter
-                        {
-                            Logic = And,
-                            Filters = new IFilter[]
-                        {
-                            new Filter(nameof(Person.Firstname), EqualTo, "Hal"),
-                            new Filter(nameof(Person.Lastname), EqualTo, "Jordan")
-                        }
-                        }
-                    },
+                        new Filter(nameof(Person.Firstname), EqualTo, "Hal"),
+                        new Filter(nameof(Person.Lastname), EqualTo, "Jordan")
+                    }
+                }
+            },
 
+            {
+                string.Empty,
+                new Filter(field: null, @operator: EqualTo)
+            },
+            {
+                string.Empty,
+                Filter.True
+            },
+            {
+                $"{nameof(Person.Firstname)}=!*wayne",
+                new Filter(field: nameof(Person.Firstname), @operator: NotEndsWith, value: "wayne")
+            },
+            {
+                $"{nameof(Person.Firstname)}=Vandal|Genghis",
+                new MultiFilter
+                {
+                    Logic = Or,
+                    Filters = new IFilter[]
                     {
-                        string.Empty,
-                        new Filter(field: null, @operator: EqualTo)
-                    },
+                        new Filter(field: nameof(Person.Firstname), @operator: EqualTo, value: "Vandal"),
+                        new Filter(field: nameof(Person.Firstname), @operator: EqualTo, value: "Genghis")
+                    }
+                }
+            },
+            {
+                $"{nameof(Person.Firstname)}=(V*|G*),(*l|*s)",
+                new MultiFilter
+                {
+                    Logic = And,
+                    Filters = new IFilter[]
                     {
-                        string.Empty,
-                        Filter.True
-                    },
-                    {
-                        $"{nameof(Person.Firstname)}=!*wayne",
-                        new Filter(field: nameof(Person.Firstname), @operator: NotEndsWith, value: "wayne")
-                    },
-                    {
-                        $"{nameof(Person.Firstname)}=Vandal|Genghis",
                         new MultiFilter
                         {
                             Logic = Or,
                             Filters = new IFilter[]
-                        {
-                            new Filter(field: nameof(Person.Firstname), @operator: EqualTo, value: "Vandal"),
-                            new Filter(field: nameof(Person.Firstname), @operator: EqualTo, value: "Genghis")
-                        }
-                        }
-                    },
-                    {
-                        $"{nameof(Person.Firstname)}=(V*|G*),(*l|*s)",
+                            {
+                                new Filter(field: nameof(Person.Firstname), @operator: StartsWith, value: "V"),
+                                new Filter(field: nameof(Person.Firstname), @operator: StartsWith, value: "G")
+                            }
+                        },
                         new MultiFilter
                         {
-                            Logic = And,
+                            Logic = Or,
                             Filters = new IFilter[]
-                        {
-                            new MultiFilter
                             {
-                                Logic = Or,
-                                Filters = new IFilter[]
-                                {
-                                    new Filter(field: nameof(Person.Firstname), @operator: StartsWith, value: "V"),
-                                    new Filter(field: nameof(Person.Firstname), @operator: StartsWith, value: "G")
-                                }
-                            },
-                            new MultiFilter
-                            {
-                                Logic = Or,
-                                Filters = new IFilter[]
-                                {
-                                    new Filter(field: nameof(Person.Firstname), @operator: EndsWith, value: "l"),
-                                    new Filter(field: nameof(Person.Firstname), @operator: EndsWith, value: "s")
-                                }
+                                new Filter(field: nameof(Person.Firstname), @operator: EndsWith, value: "l"),
+                                new Filter(field: nameof(Person.Firstname), @operator: EndsWith, value: "s")
                             }
                         }
-                        }
-                    },
+                    }
+                }
+            },
 
-                    {
-                        string.Empty,
-                        Filter.True
-                    },
+            {
+                string.Empty,
+                Filter.True
+            },
 
-                    {
-                        "Firstname=Bruce",
-                        new Filter("Firstname", EqualTo, "Bruce")
-                    },
+            {
+                "Firstname=Bruce",
+                new Filter("Firstname", EqualTo, "Bruce")
+            },
 
-                    {
-                        "Firstname=!Bruce",
-                        new Filter("Firstname", NotEqualTo, "Bruce")
-                    },
+            {
+                "Firstname=!Bruce",
+                new Filter("Firstname", NotEqualTo, "Bruce")
+            },
 
-                    {
-                        "Firstname=!!Bruce",
-                        new Filter("Firstname", EqualTo, "Bruce")
-                    },
+            {
+                "Firstname=!!Bruce",
+                new Filter("Firstname", EqualTo, "Bruce")
+            },
 
+            {
+                "Firstname=Bruce|Dick",
+                new MultiFilter
+                {
+                    Logic = Or,
+                    Filters = new IFilter[]
                     {
-                        "Firstname=Bruce|Dick",
-                        new MultiFilter
-                        {
-                            Logic = Or,
-                            Filters = new IFilter[]
-                        {
-                            new Filter("Firstname", EqualTo, "Bruce"),
-                            new Filter("Firstname", EqualTo, "Dick")
-                        }
-                        }
-                    },
+                        new Filter("Firstname", EqualTo, "Bruce"),
+                        new Filter("Firstname", EqualTo, "Dick")
+                    }
+                }
+            },
 
-                    {
-                        "Firstname=Bru*",
-                        new Filter("Firstname", StartsWith, "Bru")
-                    },
+            {
+                "Firstname=Bru*",
+                new Filter("Firstname", StartsWith, "Bru")
+            },
 
-                    {
-                        "Firstname=*Bru",
-                        new Filter("Firstname", EndsWith, "Bru")
-                    },
+            {
+                "Firstname=*Bru",
+                new Filter("Firstname", EndsWith, "Bru")
+            },
 
-                    {
-                        "Height=[100 TO *[",
-                        new Filter("Height", GreaterThanOrEqual, 100)
-                    },
+            {
+                "Height=[100 TO *[",
+                new Filter("Height", GreaterThanOrEqual, 100)
+            },
 
+            {
+                "Height=[100 TO 200]",
+                new MultiFilter
+                {
+                    Logic = And,
+                    Filters = new IFilter[]
                     {
-                        "Height=[100 TO 200]",
-                        new MultiFilter
-                        {
-                            Logic = And,
-                            Filters = new IFilter[]
-                        {
-                            new Filter("Height", GreaterThanOrEqual, 100),
-                            new Filter("Height", LessThanOrEqualTo, 200)
-                        }
-                        }
-                    },
-
-                    {
-                        "Height=]100 TO 200[",
-                        new MultiFilter
-                        {
-                            Logic = And,
-                            Filters = new IFilter[]
-                        {
-                            new Filter("Height", GreaterThan, 100),
-                            new Filter("Height", FilterOperator.LessThan, 200)
-                        }
-                        }
-                    },
-
-                    {
-                        "Height=]* TO 200]",
+                        new Filter("Height", GreaterThanOrEqual, 100),
                         new Filter("Height", LessThanOrEqualTo, 200)
-                    },
+                    }
+                }
+            },
 
+            {
+                "Height=]100 TO 200[",
+                new MultiFilter
+                {
+                    Logic = And,
+                    Filters = new IFilter[]
                     {
-                        "Nickname=Bat*,*man",
-                        new MultiFilter
-                        {
-                            Logic = And,
-                            Filters = new IFilter[]
-                        {
-                            new Filter("Nickname", StartsWith, "Bat"),
-                            new Filter("Nickname", EndsWith, "man"),
-                        }
-                        }
-                    },
+                        new Filter("Height", GreaterThan, 100),
+                        new Filter("Height", FilterOperator.LessThan, 200)
+                    }
+                }
+            },
 
-                    {
-                        "Nickname=Bat*man",
-                        new MultiFilter
-                        {
-                            Logic = And,
-                            Filters = new IFilter[]
-                        {
-                            new Filter("Nickname", StartsWith, "Bat"),
-                            new Filter("Nickname", EndsWith, "man"),
-                        }
-                        }
-                    },
+            {
+                "Height=]* TO 200]",
+                new Filter("Height", LessThanOrEqualTo, 200)
+            },
 
+            {
+                "Nickname=Bat*,*man",
+                new MultiFilter
+                {
+                    Logic = And,
+                    Filters = new IFilter[]
                     {
-                        "Nickname=Bat*,*man*",
-                        new MultiFilter
-                        {
-                            Logic = And,
-                            Filters = new IFilter[]
-                        {
-                            new Filter("Nickname", StartsWith, "Bat"),
-                            new Filter("Nickname", Contains, "man"),
-                        }
-                        }
-                    },
+                        new Filter("Nickname", StartsWith, "Bat"),
+                        new Filter("Nickname", EndsWith, "man"),
+                    }
+                }
+            },
 
+            {
+                "Nickname=Bat*man",
+                new MultiFilter
+                {
+                    Logic = And,
+                    Filters = new IFilter[]
                     {
-                        "Firstname=!Bru*",
-                        new Filter("Firstname", NotStartsWith, "Bru")
-                    },
+                        new Filter("Nickname", StartsWith, "Bat"),
+                        new Filter("Nickname", EndsWith, "man"),
+                    }
+                }
+            },
 
+            {
+                "Nickname=Bat*,*man*",
+                new MultiFilter
+                {
+                    Logic = And,
+                    Filters = new IFilter[]
                     {
-                        "Nickname=!(Bat*man)",
+                        new Filter("Nickname", StartsWith, "Bat"),
+                        new Filter("Nickname", Contains, "man"),
+                    }
+                }
+            },
+
+            {
+                "Firstname=!Bru*",
+                new Filter("Firstname", NotStartsWith, "Bru")
+            },
+
+            {
+                "Nickname=!(Bat*man)",
+                new MultiFilter
+                {
+                    Logic = Or,
+                    Filters = new IFilter[]
+                    {
+                        new Filter("Nickname", NotStartsWith, "Bat"),
+                        new Filter("Nickname", NotEndsWith, "man"),
+                    }
+                }
+            },
+
+            {
+                "Firstname=Bru*&Lastname=Wayne",
+                new MultiFilter
+                {
+                    Logic = And,
+                    Filters = new IFilter[]
+                    {
+                        new Filter("Firstname", StartsWith, "Bru"),
+                        new Filter("Lastname", EqualTo, "Wayne"),
+                    }
+                }
+            },
+
+            {
+                "Firstname=Br[uU]ce",
+                new MultiFilter
+                {
+                    Logic = Or,
+                    Filters = new IFilter[]
+                    {
+                        new Filter("Firstname", EqualTo, "Bruce"),
+                        new Filter("Firstname", EqualTo, "BrUce"),
+                    }
+                }
+            },
+
+            {
+                "Firstname=*Br[uU]",
+                new MultiFilter
+                {
+                    Logic = Or,
+                    Filters =
+                    [
+                        new Filter("Firstname", EndsWith, "Bru"),
+                        new Filter("Firstname", EndsWith, "BrU"),
+                    ]
+                }
+            },
+
+            {
+                "Firstname=!(Bruce|Wayne)",
+                new MultiFilter
+                {
+                    Logic = And,
+                    Filters = new IFilter[]
+                    {
+                        new Filter("Firstname", NotEqualTo, "Bruce"),
+                        new Filter("Firstname", NotEqualTo, "Wayne")
+                    }
+                }
+            },
+
+            {
+                "Firstname=(Bruce|Wayne)",
+                new MultiFilter
+                {
+                    Logic = Or,
+                    Filters = new IFilter[]
+                    {
+                        new Filter("Firstname", EqualTo, "Bruce"),
+                        new Filter("Firstname", EqualTo, "Wayne")
+                    }
+                }
+            },
+
+            {
+                "Firstname=(Bat*|Sup*)|(*man|*er)",
+                new MultiFilter
+                {
+                    Logic = Or,
+                    Filters = new IFilter[]
+                    {
                         new MultiFilter
                         {
                             Logic = Or,
                             Filters = new IFilter[]
-                        {
-                            new Filter("Nickname", NotStartsWith, "Bat"),
-                            new Filter("Nickname", NotEndsWith, "man"),
-                        }
-                        }
-                    },
-
-                    {
-                        "Firstname=Bru*&Lastname=Wayne",
-                        new MultiFilter
-                        {
-                            Logic = And,
-                            Filters = new IFilter[]
-                        {
-                            new Filter("Firstname", StartsWith, "Bru"),
-                            new Filter("Lastname", EqualTo, "Wayne"),
-                        }
-                        }
-                    },
-
-                    {
-                        "Firstname=Br[uU]ce",
-                        new MultiFilter
-                        {
-                            Logic = Or,
-                            Filters = new IFilter[]
-                        {
-                            new Filter("Firstname", EqualTo, "Bruce"),
-                            new Filter("Firstname", EqualTo, "BrUce"),
-                        }
-                        }
-                    },
-
-                    {
-                        "Firstname=*Br[uU]",
-                        new MultiFilter
-                        {
-                            Logic = Or,
-                            Filters =
-                            [
-                                new Filter("Firstname", EndsWith, "Bru"),
-                                new Filter("Firstname", EndsWith, "BrU"),
-                            ]
-                        }
-                    },
-
-                    {
-                        "Firstname=!(Bruce|Wayne)",
-                        new MultiFilter
-                        {
-                            Logic = And,
-                            Filters = new IFilter[]
-                        {
-                            new Filter("Firstname", NotEqualTo, "Bruce"),
-                            new Filter("Firstname", NotEqualTo, "Wayne")
-                        }
-                        }
-                    },
-
-                    {
-                        "Firstname=(Bruce|Wayne)",
-                        new MultiFilter
-                        {
-                            Logic = Or,
-                            Filters = new IFilter[]
-                        {
-                            new Filter("Firstname", EqualTo, "Bruce"),
-                            new Filter("Firstname", EqualTo, "Wayne")
-                        }
-                        }
-                    },
-
-                    {
-                        "Firstname=(Bat*|Sup*)|(*man|*er)",
-                        new MultiFilter
-                        {
-                            Logic = Or,
-                            Filters = new IFilter[]
-                        {
-                            new MultiFilter
                             {
-                                Logic = Or,
-                                Filters = new IFilter[]
-                                {
-                                    new Filter("Firstname", StartsWith, "Bat"),
-                                    new Filter("Firstname", StartsWith, "Sup"),
-                                }
-                            },
-                            new MultiFilter
-                            {
-                                Logic = Or,
-                                Filters = new IFilter[]
-                                {
-                                    new Filter("Firstname", EndsWith, "man"),
-                                    new Filter("Firstname", EndsWith, "er"),
-                                }
-                            },
-                        }
-                        }
-                    },
-
-                    {
-                        @"BattleCry=*\!",
-                        new Filter(field: "BattleCry", @operator: EndsWith, "!")
-                    },
-
-                    {
-                        @"BattleCry=\**",
-                        new Filter(field: "BattleCry", @operator: StartsWith, "*")
-                    },
-
-                    {
-                        "BirthDate=]2016-10-18 TO 2016-10-25[",
+                                new Filter("Firstname", StartsWith, "Bat"),
+                                new Filter("Firstname", StartsWith, "Sup"),
+                            }
+                        },
                         new MultiFilter
                         {
-                            Logic = And,
+                            Logic = Or,
                             Filters = new IFilter[]
-                        {
+                            {
+                                new Filter("Firstname", EndsWith, "man"),
+                                new Filter("Firstname", EndsWith, "er"),
+                            }
+                        },
+                    }
+                }
+            },
+
+            {
+                @"BattleCry=*\!",
+                new Filter(field: "BattleCry", @operator: EndsWith, "!")
+            },
+
+            {
+                @"BattleCry=\**",
+                new Filter(field: "BattleCry", @operator: StartsWith, "*")
+            },
+
+            {
+                "BirthDate=]2016-10-18 TO 2016-10-25[",
+                new MultiFilter
+                {
+                    Logic = And,
+                    Filters = new IFilter[]
+                    {
 #if NET6_0_OR_GREATER
-                            new Filter(nameof(SuperHero.BirthDate), GreaterThan, DateOnly.FromDateTime(18.October(2016))),
-                            new Filter(nameof(SuperHero.BirthDate), FilterOperator.LessThan, DateOnly.FromDateTime(25.October(2016)))
+                        new Filter(nameof(SuperHero.BirthDate), GreaterThan, DateOnly.FromDateTime(18.October(2016))),
+                        new Filter(nameof(SuperHero.BirthDate), FilterOperator.LessThan, DateOnly.FromDateTime(25.October(2016)))
 #else
                             new Filter(nameof(SuperHero.BirthDate), GreaterThan, 18.October(2016)),
                             new Filter(nameof(SuperHero.BirthDate), FilterOperator.LessThan, 25.October(2016))
 #endif
-                        }
-                        }
-                    },
+                    }
+                }
+            },
 
+            {
+                "BirthDate=]2016-10-18T18:00:00 TO 2016-10-25T19:00:00[",
+                new MultiFilter
+                {
+                    Logic = And,
+                    Filters = new IFilter[]
                     {
-                        "BirthDate=]2016-10-18T18:00:00 TO 2016-10-25T19:00:00[",
-                        new MultiFilter
-                        {
-                            Logic = And,
-                            Filters = new IFilter[]
-                        {
 #if NET6_0_OR_GREATER
-                            new Filter(nameof(SuperHero.BirthDate), GreaterThan, DateOnly.FromDateTime(18.October(2016))),
-                            new Filter(nameof(SuperHero.BirthDate), FilterOperator.LessThan, DateOnly.FromDateTime(25.October(2016)))
+                        new Filter(nameof(SuperHero.BirthDate), GreaterThan, DateOnly.FromDateTime(18.October(2016))),
+                        new Filter(nameof(SuperHero.BirthDate), FilterOperator.LessThan, DateOnly.FromDateTime(25.October(2016)))
 #else
                             new Filter(nameof(SuperHero.BirthDate), GreaterThan, 18.October(2016).Add(18.Hours())),
                             new Filter(nameof(SuperHero.BirthDate), FilterOperator.LessThan, 25.October(2016).Add(19.Hours()))
 #endif
-                        }
-                        }
-                    },
-
-                    {
-                        "DateTimeWithOffset=]2016-10-18T18:00:00Z TO 2016-10-18T23:00:00-02:00[",
-                        new MultiFilter
-                        {
-                            Logic = And,
-                            Filters = new IFilter[]
-                        {
-                            new Filter("DateTimeWithOffset", GreaterThan, 18.October(2016).Add(18.Hours()).ToDateTimeOffset()),
-                            new Filter("DateTimeWithOffset", FilterOperator.LessThan, 18.October(2016).Add(23.Hours()).ToDateTimeOffset(-2.Hours()))
-                        }
-                        }
-                    },
-
-                    {
-                        "Nickname={Bat|Sup|Wonder}*,*m[ae]n",
-                        new MultiFilter
-                        {
-                            Logic = And,
-                            Filters = new[]
-                        {
-                                new MultiFilter
-                                {
-                                    Logic = Or,
-                                    Filters = new[]
-                                {
-                                        new Filter(nameof(SuperHero.Nickname), StartsWith, "Bat"),
-                                        new Filter(nameof(SuperHero.Nickname), StartsWith, "Sup"),
-                                        new Filter(nameof(SuperHero.Nickname), StartsWith, "Wonder")
-                                    }
-                                },
-                                new MultiFilter
-                                {
-                                    Logic = Or,
-                                    Filters = new[]
-                                {
-                                        new Filter(nameof(SuperHero.Nickname), EndsWith, "man"),
-                                        new Filter(nameof(SuperHero.Nickname), EndsWith, "men")
-                                    }
-                                }
-                            }
-                        }
-                    },
-                };
-
-        [Theory]
-        [MemberData(nameof(ToFilterCases))]
-        public void ToFilter(string filter, IFilter expected)
-        {
-            outputHelper.WriteLine($"{nameof(filter)} : '{filter}'");
-
-            // Act
-            IFilter actual = filter.ToFilter<SuperHero>();
-
-            // Assert
-            actual.Should()
-                  .NotBeSameAs(expected).And
-                  .Be(expected);
-        }
-
-        [Fact]
-        public void Given_null_ToFilter_should_throw_ArgumentNullException()
-        {
-            // Act
-            Action action = () => ((string)null).ToFilter<Person>();
-
-            // Assert
-            action.Should()
-                .Throw<ArgumentNullException>().Which
-                .ParamName.Should()
-                .NotBeNullOrWhiteSpace();
-        }
-
-        public static TheoryData<string, PropertyNameResolutionStrategy, Filter> ToFilterWithPropertyNameResolutionStrategyCases
-            => new()
-                {
-                    {
-                        "SnakeCaseProperty=10",
-                        PropertyNameResolutionStrategy.SnakeCase,
-                        new Filter("snake_case_property", EqualTo, "10")
-                    },
-                    {
-                        "pascal_case_property=10",
-                        PropertyNameResolutionStrategy.PascalCase,
-                        new Filter("PascalCaseProperty", EqualTo, "10")
                     }
-                };
-
-        [Theory]
-        [MemberData(nameof(ToFilterWithPropertyNameResolutionStrategyCases))]
-        public void Given_input_and_casing_resolution_strategy_ToFilter_should_create_corresponding_filter(string filter, PropertyNameResolutionStrategy propertyNameResolutionStrategy, IFilter expected)
-        {
-            // Act
-            IFilter actual = filter.ToFilter<Model>(propertyNameResolutionStrategy);
-
-            // Assert
-            actual.Should()
-                  .Be(expected);
-        }
-
-        public static TheoryData<string, FilterOptions, MultiFilter> ToFilterWithFilterOptionsCases
-        {
-            get
-            {
-                FilterLogic[] logics = [And, Or];
-                TheoryData<string, FilterOptions, MultiFilter> cases = [];
-                foreach (FilterLogic logic in logics)
-                {
-                    cases.Add
-                    (
-                        "snake_case_property=10&PascalCaseProperty=value",
-                        new FilterOptions { Logic = logic },
-                        new MultiFilter
-                        {
-                            Logic = logic,
-                            Filters = new IFilter[]
-                            {
-                                new Filter("snake_case_property", EqualTo, "10"),
-                                new Filter("PascalCaseProperty", EqualTo, "value"),
-                            }
-                        }
-                    );
-
-                    cases.Add
-                    (
-                        "snake_case_property=10&PascalCaseProperty=value",
-                        new FilterOptions { Logic = logic },
-                        new MultiFilter
-                        {
-                            Logic = logic,
-                            Filters = new IFilter[]
-                            {
-                                new Filter("snake_case_property", EqualTo, "10"),
-                                new Filter("PascalCaseProperty", EqualTo, "value")
-                            }
-                        }
-                    );
                 }
+            },
 
-                return cases;
-            }
-        }
+            {
+                "DateTimeWithOffset=]2016-10-18T18:00:00Z TO 2016-10-18T23:00:00-02:00[",
+                new MultiFilter
+                {
+                    Logic = And,
+                    Filters = new IFilter[]
+                    {
+                        new Filter("DateTimeWithOffset", GreaterThan, 18.October(2016).Add(18.Hours()).ToDateTimeOffset()),
+                        new Filter("DateTimeWithOffset", FilterOperator.LessThan, 18.October(2016).Add(23.Hours()).ToDateTimeOffset(-2.Hours()))
+                    }
+                }
+            },
 
-        [Theory]
-        [MemberData(nameof(ToFilterWithFilterOptionsCases))]
-        public void Given_input_and_FilterOptions_ToFilter_should_create_corresponding_filter(string filter, FilterOptions options, IFilter expected)
+            {
+                "Nickname={Bat|Sup|Wonder}*,*m[ae]n",
+                new MultiFilter
+                {
+                    Logic = And,
+                    Filters = new[]
+                    {
+                        new MultiFilter
+                        {
+                            Logic = Or,
+                            Filters = new[]
+                            {
+                                new Filter(nameof(SuperHero.Nickname), StartsWith, "Bat"),
+                                new Filter(nameof(SuperHero.Nickname), StartsWith, "Sup"),
+                                new Filter(nameof(SuperHero.Nickname), StartsWith, "Wonder")
+                            }
+                        },
+                        new MultiFilter
+                        {
+                            Logic = Or,
+                            Filters = new[]
+                            {
+                                new Filter(nameof(SuperHero.Nickname), EndsWith, "man"),
+                                new Filter(nameof(SuperHero.Nickname), EndsWith, "men")
+                            }
+                        }
+                    }
+                }
+            },
+        };
+
+    [Theory]
+    [MemberData(nameof(ToFilterCases))]
+    public void ToFilter(string filter, IFilter expected)
+    {
+        outputHelper.WriteLine($"{nameof(filter)} : '{filter}'");
+
+        // Act
+        IFilter actual = filter.ToFilter<SuperHero>();
+
+        // Assert
+        actual.Should()
+            .NotBeSameAs(expected).And
+            .Be(expected);
+    }
+
+    [Fact]
+    public void Given_null_ToFilter_should_throw_ArgumentNullException()
+    {
+        // Act
+        Action action = () => ((string)null).ToFilter<Person>();
+
+        // Assert
+        action.Should()
+            .Throw<ArgumentNullException>().Which
+            .ParamName.Should()
+            .NotBeNullOrWhiteSpace();
+    }
+
+    public static TheoryData<string, PropertyNameResolutionStrategy, Filter> ToFilterWithPropertyNameResolutionStrategyCases
+        => new()
         {
-            // Act
-            IFilter actual = filter.ToFilter<Model>(options);
+            {
+                "SnakeCaseProperty=10",
+                PropertyNameResolutionStrategy.SnakeCase,
+                new Filter("snake_case_property", EqualTo, "10")
+            },
+            {
+                "pascal_case_property=10",
+                PropertyNameResolutionStrategy.PascalCase,
+                new Filter("PascalCaseProperty", EqualTo, "10")
+            }
+        };
 
-            // Assert
-            actual.Should()
-                  .Be(expected);
+    [Theory]
+    [MemberData(nameof(ToFilterWithPropertyNameResolutionStrategyCases))]
+    public void Given_input_and_casing_resolution_strategy_ToFilter_should_create_corresponding_filter(string filter, PropertyNameResolutionStrategy propertyNameResolutionStrategy, IFilter expected)
+    {
+        // Act
+        IFilter actual = filter.ToFilter<Model>(propertyNameResolutionStrategy);
+
+        // Assert
+        actual.Should()
+            .Be(expected);
+    }
+
+    public static TheoryData<string, FilterOptions, MultiFilter> ToFilterWithFilterOptionsCases
+    {
+        get
+        {
+            FilterLogic[] logics = [And, Or];
+            TheoryData<string, FilterOptions, MultiFilter> cases = [];
+            foreach (FilterLogic logic in logics)
+            {
+                cases.Add
+                (
+                    "snake_case_property=10&PascalCaseProperty=value",
+                    new FilterOptions { Logic = logic },
+                    new MultiFilter
+                    {
+                        Logic = logic,
+                        Filters = new IFilter[]
+                        {
+                            new Filter("snake_case_property", EqualTo, "10"),
+                            new Filter("PascalCaseProperty", EqualTo, "value"),
+                        }
+                    }
+                );
+
+                cases.Add
+                (
+                    "snake_case_property=10&PascalCaseProperty=value",
+                    new FilterOptions { Logic = logic },
+                    new MultiFilter
+                    {
+                        Logic = logic,
+                        Filters = new IFilter[]
+                        {
+                            new Filter("snake_case_property", EqualTo, "10"),
+                            new Filter("PascalCaseProperty", EqualTo, "value")
+                        }
+                    }
+                );
+            }
+
+            return cases;
         }
+    }
+
+    [Theory]
+    [MemberData(nameof(ToFilterWithFilterOptionsCases))]
+    public void Given_input_and_FilterOptions_ToFilter_should_create_corresponding_filter(string filter, FilterOptions options, IFilter expected)
+    {
+        // Act
+        IFilter actual = filter.ToFilter<Model>(options);
+
+        // Assert
+        actual.Should()
+            .Be(expected);
     }
 }

--- a/test/DataFilters.UnitTests/FilterTests.cs
+++ b/test/DataFilters.UnitTests/FilterTests.cs
@@ -1,337 +1,336 @@
-﻿namespace DataFilters.UnitTests
+﻿namespace DataFilters.UnitTests;
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Text.RegularExpressions;
+using DataFilters.UnitTests.Helpers;
+using FluentAssertions;
+using FsCheck;
+using FsCheck.Fluent;
+using FsCheck.Xunit;
+using Newtonsoft.Json.Linq;
+using Newtonsoft.Json.Schema;
+using Xunit;
+using Xunit.Abstractions;
+using Xunit.Categories;
+using static DataFilters.FilterLogic;
+using static DataFilters.FilterOperator;
+
+[UnitTest]
+public class FilterTests(ITestOutputHelper output)
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Collections.Immutable;
-    using System.Linq;
-    using System.Linq.Expressions;
-    using System.Text.RegularExpressions;
-    using DataFilters.UnitTests.Helpers;
-    using FluentAssertions;
-    using FsCheck;
-    using FsCheck.Fluent;
-    using FsCheck.Xunit;
-    using Newtonsoft.Json.Linq;
-    using Newtonsoft.Json.Schema;
-    using Xunit;
-    using Xunit.Abstractions;
-    using Xunit.Categories;
-    using static DataFilters.FilterLogic;
-    using static DataFilters.FilterOperator;
-
-    [UnitTest]
-    public class FilterTests(ITestOutputHelper output)
+    private static readonly IImmutableDictionary<string, FilterOperator> Operators = new Dictionary<string, FilterOperator>
     {
-        private static readonly IImmutableDictionary<string, FilterOperator> Operators = new Dictionary<string, FilterOperator>
-        {
-            ["contains"] = Contains,
-            ["endswith"] = EndsWith,
-            ["eq"] = EqualTo,
-            ["gt"] = GreaterThan,
-            ["gte"] = GreaterThanOrEqual,
-            ["isempty"] = IsEmpty,
-            ["isnotempty"] = IsNotEmpty,
-            ["isnotnull"] = IsNotNull,
-            ["isnull"] = IsNull,
-            ["lt"] = FilterOperator.LessThan,
-            ["lte"] = LessThanOrEqualTo,
-            ["neq"] = NotEqualTo,
-            ["startswith"] = StartsWith
-        }.ToImmutableDictionary();
+        ["contains"] = Contains,
+        ["endswith"] = EndsWith,
+        ["eq"] = EqualTo,
+        ["gt"] = GreaterThan,
+        ["gte"] = GreaterThanOrEqual,
+        ["isempty"] = IsEmpty,
+        ["isnotempty"] = IsNotEmpty,
+        ["isnotnull"] = IsNotNull,
+        ["isnull"] = IsNull,
+        ["lt"] = FilterOperator.LessThan,
+        ["lte"] = LessThanOrEqualTo,
+        ["neq"] = NotEqualTo,
+        ["startswith"] = StartsWith
+    }.ToImmutableDictionary();
 
-        /// <summary>
-        /// Deserialization of various json representation into <see cref="Filter"/>
-        /// </summary>
-        public static TheoryData<string, Expression<Func<IFilter, bool>>> FilterDeserializeCases
+    /// <summary>
+    /// Deserialization of various json representation into <see cref="Filter"/>
+    /// </summary>
+    public static TheoryData<string, Expression<Func<IFilter, bool>>> FilterDeserializeCases
+    {
+        get
         {
-            get
+            TheoryData<string, Expression<Func<IFilter, bool>>> cases = [];
+            foreach (KeyValuePair<string, FilterOperator> item in Operators)
             {
-                TheoryData<string, Expression<Func<IFilter, bool>>> cases = [];
-                foreach (KeyValuePair<string, FilterOperator> item in Operators)
-                {
-                    cases.Add
-                    (
-                        @$"{{ ""field"" : ""Firstname"", ""op"" : ""{item.Key}"",  ""Value"" : ""Batman""}}",
-                        result => result is Filter
-                                                                    && "Firstname".Equals(((Filter)result).Field)
-                                                                    && item.Value.Equals(((Filter)result).Operator)
-                                                                    && "Batman".Equals(((Filter)result).Value)
+                cases.Add
+                (
+                    @$"{{ ""field"" : ""Firstname"", ""op"" : ""{item.Key}"",  ""Value"" : ""Batman""}}",
+                    result => result is Filter
+                              && "Firstname".Equals(((Filter)result).Field)
+                              && item.Value.Equals(((Filter)result).Operator)
+                              && "Batman".Equals(((Filter)result).Value)
 
-                    );
-                }
-
-                return cases;
+                );
             }
+
+            return cases;
         }
+    }
 
-        public static TheoryData<MultiFilter, Expression<Func<string, bool>>> CompositeFilterToJsonCases
-           => new() {
-                {
-                    new MultiFilter  {
-                        Logic = Or,
-                        Filters = new [] {
-                            new Filter (field : "Nickname", @operator : EqualTo, value : "Batman"),
-                            new Filter (field : "Nickname", @operator : EqualTo, value : "Robin")
-                        }
-                    },
-                    json =>
-                        JObject.Parse(json).Properties().Count() == 2
-
-                        && "or".Equals((string) JObject.Parse(json)[MultiFilter.LogicJsonPropertyName])
-
-                        && "Nickname".Equals((string)JObject.Parse(json)[MultiFilter.FiltersJsonPropertyName][0][Filter.FieldJsonPropertyName])
-                        && "eq".Equals((string)JObject.Parse(json)[MultiFilter.FiltersJsonPropertyName][0][Filter.OperatorJsonPropertyName])
-                        && "Batman".Equals((string)JObject.Parse(json)[MultiFilter.FiltersJsonPropertyName][0][Filter.ValueJsonPropertyName])
-                        && "Nickname".Equals((string)JObject.Parse(json)[MultiFilter.FiltersJsonPropertyName][1][Filter.FieldJsonPropertyName])
-                        && "eq".Equals((string)JObject.Parse(json)[MultiFilter.FiltersJsonPropertyName][1][Filter.OperatorJsonPropertyName])
-                        && "Robin".Equals((string)JObject.Parse(json)[MultiFilter.FiltersJsonPropertyName][1][Filter.ValueJsonPropertyName])
-
-                },
-                {
-                    new MultiFilter  {
-                        Filters = new [] {
-                            new Filter (field : "Nickname", @operator : EqualTo, value : "Batman"),
-                            new Filter (field : "Nickname", @operator : EqualTo, value : "Robin")
-                        }
-                    },
-                    json =>
-                        JObject.Parse(json).Properties().Count() == 2
-
-                        && "and".Equals((string) JObject.Parse(json)[MultiFilter.LogicJsonPropertyName])
-
-                        && "Nickname".Equals((string)JObject.Parse(json)[MultiFilter.FiltersJsonPropertyName][0][Filter.FieldJsonPropertyName])
-                        && "eq".Equals((string)JObject.Parse(json)[MultiFilter.FiltersJsonPropertyName][0][Filter.OperatorJsonPropertyName])
-                        && "Batman".Equals((string)JObject.Parse(json)[MultiFilter.FiltersJsonPropertyName][0][Filter.ValueJsonPropertyName])
-                               &&
-                        "Nickname".Equals((string)JObject.Parse(json)[MultiFilter.FiltersJsonPropertyName][1][Filter.FieldJsonPropertyName])
-                        && "eq".Equals((string)JObject.Parse(json)[MultiFilter.FiltersJsonPropertyName][1][Filter.OperatorJsonPropertyName])
-                        && "Robin".Equals((string)JObject.Parse(json)[MultiFilter.FiltersJsonPropertyName][1][Filter.ValueJsonPropertyName])
-
-                }
-            };
-
-        /// <summary>
-        /// Serialization of instance of <see cref="Filter"/> test cases
-        /// </summary>
-        public static TheoryData<Filter, Expression<Func<string, bool>>> FilterToJsonCases
-            => new()
-                {
-                    {
-                        new Filter (field : "Firstname", @operator  : EqualTo,  value : "Batman"),
-                        json =>
-                            "Firstname".Equals((string) JObject.Parse(json)[Filter.FieldJsonPropertyName])
-                            && "eq".Equals((string) JObject.Parse(json)[Filter.OperatorJsonPropertyName])
-                            && "Batman".Equals((string) JObject.Parse(json)[Filter.ValueJsonPropertyName])
-
+    public static TheoryData<MultiFilter, Expression<Func<string, bool>>> CompositeFilterToJsonCases
+        => new() {
+            {
+                new MultiFilter  {
+                    Logic = Or,
+                    Filters = new [] {
+                        new Filter (field : "Nickname", @operator : EqualTo, value : "Batman"),
+                        new Filter (field : "Nickname", @operator : EqualTo, value : "Robin")
                     }
-                };
-        [Theory]
-        [MemberData(nameof(FilterToJsonCases))]
-        public void FilterToJson(Filter filter, Expression<Func<string, bool>> jsonMatcher)
-            => ToJson(filter, jsonMatcher);
+                },
+                json =>
+                    JObject.Parse(json).Properties().Count() == 2
 
-        private void ToJson(IFilter filter, Expression<Func<string, bool>> jsonMatcher)
+                    && "or".Equals((string) JObject.Parse(json)[MultiFilter.LogicJsonPropertyName])
+
+                    && "Nickname".Equals((string)JObject.Parse(json)[MultiFilter.FiltersJsonPropertyName][0][Filter.FieldJsonPropertyName])
+                    && "eq".Equals((string)JObject.Parse(json)[MultiFilter.FiltersJsonPropertyName][0][Filter.OperatorJsonPropertyName])
+                    && "Batman".Equals((string)JObject.Parse(json)[MultiFilter.FiltersJsonPropertyName][0][Filter.ValueJsonPropertyName])
+                    && "Nickname".Equals((string)JObject.Parse(json)[MultiFilter.FiltersJsonPropertyName][1][Filter.FieldJsonPropertyName])
+                    && "eq".Equals((string)JObject.Parse(json)[MultiFilter.FiltersJsonPropertyName][1][Filter.OperatorJsonPropertyName])
+                    && "Robin".Equals((string)JObject.Parse(json)[MultiFilter.FiltersJsonPropertyName][1][Filter.ValueJsonPropertyName])
+
+            },
+            {
+                new MultiFilter  {
+                    Filters = new [] {
+                        new Filter (field : "Nickname", @operator : EqualTo, value : "Batman"),
+                        new Filter (field : "Nickname", @operator : EqualTo, value : "Robin")
+                    }
+                },
+                json =>
+                    JObject.Parse(json).Properties().Count() == 2
+
+                    && "and".Equals((string) JObject.Parse(json)[MultiFilter.LogicJsonPropertyName])
+
+                    && "Nickname".Equals((string)JObject.Parse(json)[MultiFilter.FiltersJsonPropertyName][0][Filter.FieldJsonPropertyName])
+                    && "eq".Equals((string)JObject.Parse(json)[MultiFilter.FiltersJsonPropertyName][0][Filter.OperatorJsonPropertyName])
+                    && "Batman".Equals((string)JObject.Parse(json)[MultiFilter.FiltersJsonPropertyName][0][Filter.ValueJsonPropertyName])
+                    &&
+                    "Nickname".Equals((string)JObject.Parse(json)[MultiFilter.FiltersJsonPropertyName][1][Filter.FieldJsonPropertyName])
+                    && "eq".Equals((string)JObject.Parse(json)[MultiFilter.FiltersJsonPropertyName][1][Filter.OperatorJsonPropertyName])
+                    && "Robin".Equals((string)JObject.Parse(json)[MultiFilter.FiltersJsonPropertyName][1][Filter.ValueJsonPropertyName])
+
+            }
+        };
+
+    /// <summary>
+    /// Serialization of instance of <see cref="Filter"/> test cases
+    /// </summary>
+    public static TheoryData<Filter, Expression<Func<string, bool>>> FilterToJsonCases
+        => new()
         {
-            output.WriteLine($"Testing : {filter}{Environment.NewLine} against {Environment.NewLine} {jsonMatcher} ");
+            {
+                new Filter (field : "Firstname", @operator  : EqualTo,  value : "Batman"),
+                json =>
+                    "Firstname".Equals((string) JObject.Parse(json)[Filter.FieldJsonPropertyName])
+                    && "eq".Equals((string) JObject.Parse(json)[Filter.OperatorJsonPropertyName])
+                    && "Batman".Equals((string) JObject.Parse(json)[Filter.ValueJsonPropertyName])
 
-            // Act
-            string json = filter.ToJson();
+            }
+        };
+    [Theory]
+    [MemberData(nameof(FilterToJsonCases))]
+    public void FilterToJson(Filter filter, Expression<Func<string, bool>> jsonMatcher)
+        => ToJson(filter, jsonMatcher);
 
-            // Assert
-            output.WriteLine($"ToJson result is '{json}'");
-            json.Should().Match(jsonMatcher);
-        }
+    private void ToJson(IFilter filter, Expression<Func<string, bool>> jsonMatcher)
+    {
+        output.WriteLine($"Testing : {filter}{Environment.NewLine} against {Environment.NewLine} {jsonMatcher} ");
 
-        public static TheoryData<string, FilterOperator, bool> FilterSchemaTestCases
-            => new()
+        // Act
+        string json = filter.ToJson();
+
+        // Assert
+        output.WriteLine($"ToJson result is '{json}'");
+        json.Should().Match(jsonMatcher);
+    }
+
+    public static TheoryData<string, FilterOperator, bool> FilterSchemaTestCases
+        => new()
+        {
+            {
+                $"{{{Filter.FieldJsonPropertyName} : 'nickname', {Filter.OperatorJsonPropertyName} : 'eq', {Filter.ValueJsonPropertyName} :'batman' }}",
+                EqualTo,
+                true
+            },
+
+            {
+                $"{{{Filter.FieldJsonPropertyName} : 'nickname', {Filter.OperatorJsonPropertyName} : 'eq', {Filter.ValueJsonPropertyName} : null }}",
+                EqualTo,
+                false
+            },
+
+            {
+                $"{{{Filter.FieldJsonPropertyName} : 'nickname', {Filter.OperatorJsonPropertyName} : 'eq' }}",
+                EqualTo,
+                false
+            },
+
+            {
+                $"{{{Filter.FieldJsonPropertyName} : 'nickname', {Filter.OperatorJsonPropertyName} : 'contains', {Filter.ValueJsonPropertyName} : 'br' }}",
+                Contains,
+                true
+            },
+
+            {
+                $"{{{Filter.FieldJsonPropertyName} : 'nickname', {Filter.OperatorJsonPropertyName} : 'contains', {Filter.ValueJsonPropertyName} : 6 }}",
+                Contains,
+                false
+            },
+
+            {
+                $"{{{Filter.FieldJsonPropertyName} : 'nickname', {Filter.OperatorJsonPropertyName} : 'isnull', {Filter.ValueJsonPropertyName} : 6 }}",
+                IsNull,
+                false
+            }
+        };
+
+    [Theory]
+    [MemberData(nameof(FilterSchemaTestCases))]
+    public void FilterSchema(string json, FilterOperator @operator, bool expectedValidity)
+    {
+        output.WriteLine($"{nameof(json)} : {json}");
+        output.WriteLine($"{nameof(FilterOperator)} : {@operator}");
+
+        // Arrange
+        JSchema schema = Filter.Schema(@operator);
+
+        // Act
+        bool isValid = JObject.Parse(json).IsValid(schema);
+
+        // Arrange
+        isValid.Should().Be(expectedValidity);
+    }
+
+    public static TheoryData<Filter, Filter, bool> FilterEquatableCases
+    {
+        get
+        {
+            TheoryData<Filter, Filter, bool> cases = new()
             {
                 {
-                    $"{{{Filter.FieldJsonPropertyName} : 'nickname', {Filter.OperatorJsonPropertyName} : 'eq', {Filter.ValueJsonPropertyName} :'batman' }}",
-                    EqualTo,
+                    new Filter("property", EqualTo, "value"),
+                    new Filter("property", EqualTo, "value"),
                     true
                 },
 
                 {
-                    $"{{{Filter.FieldJsonPropertyName} : 'nickname', {Filter.OperatorJsonPropertyName} : 'eq', {Filter.ValueJsonPropertyName} : null }}",
-                    EqualTo,
-                    false
-                },
-
-                {
-                    $"{{{Filter.FieldJsonPropertyName} : 'nickname', {Filter.OperatorJsonPropertyName} : 'eq' }}",
-                    EqualTo,
-                    false
-                },
-
-                {
-                    $"{{{Filter.FieldJsonPropertyName} : 'nickname', {Filter.OperatorJsonPropertyName} : 'contains', {Filter.ValueJsonPropertyName} : 'br' }}",
-                    Contains,
+                    new Filter("property", IsNull),
+                    new Filter("property", IsNull, null),
                     true
                 },
 
                 {
-                    $"{{{Filter.FieldJsonPropertyName} : 'nickname', {Filter.OperatorJsonPropertyName} : 'contains', {Filter.ValueJsonPropertyName} : 6 }}",
-                    Contains,
+                    new Filter("property", EqualTo, null),
+                    new Filter("property", IsNull),
+                    true
+                },
+
+                {
+                    new Filter("property", EqualTo, "value"),
+                    new Filter("property", NotEqualTo, "value"),
                     false
                 },
 
                 {
-                    $"{{{Filter.FieldJsonPropertyName} : 'nickname', {Filter.OperatorJsonPropertyName} : 'isnull', {Filter.ValueJsonPropertyName} : 6 }}",
-                    IsNull,
+                    new Filter("Property", EqualTo, "value"),
+                    new Filter("property", EqualTo, "value"),
                     false
-                }
+                },
             };
 
-        [Theory]
-        [MemberData(nameof(FilterSchemaTestCases))]
-        public void FilterSchema(string json, FilterOperator @operator, bool expectedValidity)
-        {
-            output.WriteLine($"{nameof(json)} : {json}");
-            output.WriteLine($"{nameof(FilterOperator)} : {@operator}");
+            Filter current = new("Property", EqualTo, "value");
 
-            // Arrange
-            JSchema schema = Filter.Schema(@operator);
+            cases.Add(current, current, true);
 
-            // Act
-            bool isValid = JObject.Parse(json).IsValid(schema);
+            Guid guid = Guid.NewGuid();
+            cases.Add(new Filter("Prop", EqualTo, guid), new Filter("Prop", EqualTo, guid),
+                true);
 
-            // Arrange
-            isValid.Should().Be(expectedValidity);
+            return cases;
         }
+    }
 
-        public static TheoryData<Filter, Filter, bool> FilterEquatableCases
-        {
-            get
-            {
-                TheoryData<Filter, Filter, bool> cases = new()
-                {
-                    {
-                        new Filter("property", EqualTo, "value"),
-                        new Filter("property", EqualTo, "value"),
-                        true
-                    },
+    [Theory]
+    [MemberData(nameof(FilterEquatableCases))]
+    public void FilterImplementsEquatableProperly(Filter first, Filter second, bool expectedResult)
+    {
+        output.WriteLine($"first : {first}");
+        output.WriteLine($"second : {second}");
 
-                    {
-                        new Filter("property", IsNull),
-                        new Filter("property", IsNull, null),
-                        true
-                    },
+        // Act
+        bool result = first.Equals(second);
 
-                    {
-                        new Filter("property", EqualTo, null),
-                        new Filter("property", IsNull),
-                        true
-                    },
+        // Assert
+        result.Should()
+            .Be(expectedResult);
+    }
 
-                    {
-                        new Filter("property", EqualTo, "value"),
-                        new Filter("property", NotEqualTo, "value"),
-                        false
-                    },
+    [Fact]
+    public void Ctor_should_build_valid_instance()
+    {
+        // Act
 
-                    {
-                        new Filter("Property", EqualTo, "value"),
-                        new Filter("property", EqualTo, "value"),
-                        false
-                    },
-                };
+        Regex validFieldNameRegex = new(Filter.ValidFieldNamePattern, RegexOptions.IgnoreCase, TimeSpan.FromSeconds(1));
 
-                Filter current = new("Property", EqualTo, "value");
-
-                cases.Add(current, current, true);
-
-                Guid guid = Guid.NewGuid();
-                cases.Add(new Filter("Prop", EqualTo, guid), new Filter("Prop", EqualTo, guid),
-                        true);
-
-                return cases;
-            }
-        }
-
-        [Theory]
-        [MemberData(nameof(FilterEquatableCases))]
-        public void FilterImplementsEquatableProperly(Filter first, Filter second, bool expectedResult)
-        {
-            output.WriteLine($"first : {first}");
-            output.WriteLine($"second : {second}");
-
-            // Act
-            bool result = first.Equals(second);
-
-            // Assert
-            result.Should()
-                .Be(expectedResult);
-        }
-
-        [Fact]
-        public void Ctor_should_build_valid_instance()
-        {
-            // Act
-
-            Regex validFieldNameRegex = new(Filter.ValidFieldNamePattern, RegexOptions.IgnoreCase, TimeSpan.FromSeconds(1));
-
-            Prop.ForAll<string, FilterOperator, object>((field, @operator, value) =>
+        Prop.ForAll<string, FilterOperator, object>((field, @operator, value) =>
             {
                 Lazy<Filter> filterCtor = new(() => new Filter(field, @operator, value));
                 Filter filter = null;
                 Action invokingCtor = () => filter = filterCtor.Value;
                 // Assertion
                 ((Action)(() => invokingCtor.Should().Throw<ArgumentOutOfRangeException>())).When(field is not null && !validFieldNameRegex.IsMatch(field))
-                                                                               .Label($"'{field}' doesnt not match expected regex ")
+                    .Label($"'{field}' doesnt not match expected regex ")
                     //.Trivial(field is not null && !validFieldNameRegex.IsMatch(field))
                     .Or(() =>
                     {
                         return filter.Field == field
-                            && filter.Operator == @operator
-                            && filter.Value is null;
+                               && filter.Operator == @operator
+                               && filter.Value is null;
                     }).When(Filter.UnaryOperators.Contains(@operator)).Label("Unary operator")
                     .Or(() =>
                     {
                         Filter filter = filterCtor.Value;
 
                         return filter.Field == field
-                            && filter.Operator == @operator
-                            && value.Equals(filter.Value);
+                               && filter.Operator == @operator
+                               && value.Equals(filter.Value);
                     }).When(!Filter.UnaryOperators.Contains(@operator)).Label("Binary operator")
                     .VerboseCheck(output);
             })
             .VerboseCheck(output);
-        }
+    }
 
-        [Property(Arbitrary = [typeof(FilterGenerators)])]
-        public void Given_filter_instance_Negate_should_work_as_expected(NonNull<Filter> source)
-        {
-            // Arrange
-            Filter original = source.Item;
+    [Property(Arbitrary = [typeof(FilterGenerators)])]
+    public void Given_filter_instance_Negate_should_work_as_expected(NonNull<Filter> source)
+    {
+        // Arrange
+        Filter original = source.Item;
 
-            // Act
-            IFilter oppositeFilter = original.Negate();
+        // Act
+        IFilter oppositeFilter = original.Negate();
 
-            // Assert
-            oppositeFilter.Should()
-                          .BeOfType<Filter>()
-                          .Which
-                          .Operator.Should()
-                                   .Be(original.Operator switch
-                                   {
-                                       EqualTo => NotEqualTo,
-                                       NotEqualTo => EqualTo,
-                                       IsNull => IsNotNull,
-                                       IsNotNull => IsNull,
-                                       FilterOperator.LessThan => GreaterThan,
-                                       GreaterThan => FilterOperator.LessThan,
-                                       GreaterThanOrEqual => LessThanOrEqualTo,
-                                       StartsWith => NotStartsWith,
-                                       NotStartsWith => StartsWith,
-                                       EndsWith => NotEndsWith,
-                                       NotEndsWith => EndsWith,
-                                       Contains => NotContains,
-                                       NotContains => Contains,
-                                       IsEmpty => IsNotEmpty,
-                                       IsNotEmpty => IsEmpty,
-                                       LessThanOrEqualTo => GreaterThanOrEqual,
-                                       _ => throw new NotSupportedException($"The original {original.Operator} operator is not supported"),
-                                   }, "the resulting filter should have the opposite operator");
-        }
+        // Assert
+        oppositeFilter.Should()
+            .BeOfType<Filter>()
+            .Which
+            .Operator.Should()
+            .Be(original.Operator switch
+            {
+                EqualTo => NotEqualTo,
+                NotEqualTo => EqualTo,
+                IsNull => IsNotNull,
+                IsNotNull => IsNull,
+                FilterOperator.LessThan => GreaterThan,
+                GreaterThan => FilterOperator.LessThan,
+                GreaterThanOrEqual => LessThanOrEqualTo,
+                StartsWith => NotStartsWith,
+                NotStartsWith => StartsWith,
+                EndsWith => NotEndsWith,
+                NotEndsWith => EndsWith,
+                Contains => NotContains,
+                NotContains => Contains,
+                IsEmpty => IsNotEmpty,
+                IsNotEmpty => IsEmpty,
+                LessThanOrEqualTo => GreaterThanOrEqual,
+                _ => throw new NotSupportedException($"The original {original.Operator} operator is not supported"),
+            }, "the resulting filter should have the opposite operator");
     }
 }

--- a/test/DataFilters.UnitTests/Grammar/Parsing/FilterTokenParserTests.cs
+++ b/test/DataFilters.UnitTests/Grammar/Parsing/FilterTokenParserTests.cs
@@ -1168,50 +1168,29 @@ I&_Oj
             AssertThatShould_parse(actual, expected);
         }
 
-        public static TheoryData<GroupExpression, string> ParseGroupCases
-        {
-            get
+        public static TheoryData<GroupExpression> ParseGroupCases
+            => new()
             {
-                TheoryData<GroupExpression, string> cases = [];
-                string[] cultures = ["fr-FR", "en-GB", "en-US"];
-                
-                foreach (string culture in cultures)
-                {
-                    cases.Add
-                    (
-                        new GroupExpression(new DateTimeExpression(new DateExpression(2090, 10, 10), new TimeExpression(3, 0, 40, 583), OffsetExpression.Zero)),
-                        culture
-                    );
-
-                    cases.Add
-                    (
-                        new GroupExpression(new DateTimeExpression(new DateExpression(2010, 06, 02), new TimeExpression(23, 45, 54, 331), OffsetExpression.Zero)),
-                        culture
-                    );
-                    
-                    
-                }
-                return cases;
-            }
-        }
+                new GroupExpression(new DateTimeExpression(new DateExpression(2090, 10, 10),
+                    new TimeExpression(3, 0, 40, 583), OffsetExpression.Zero)),
+                new GroupExpression(new DateTimeExpression(new DateExpression(2010, 06, 02),
+                    new TimeExpression(23, 45, 54, 331), OffsetExpression.Zero)),
+            };
         
 
         [Theory]
         [MemberData(nameof(ParseGroupCases))]
-        public void Given_GroupExpression_EscapedParseableString_as_input_Parser_should_return_GroupExpression_that_is_equivalent_to_input(GroupExpression expected, string culture)
+        public void Given_GroupExpression_EscapedParseableString_as_input_Parser_should_return_GroupExpression_that_is_equivalent_to_input(GroupExpression expected)
         {
-            _cultureSwitcher.Run(culture, () =>
-            {
-                _outputHelper.WriteLine($"Current culture is '{_cultureSwitcher.CurrentCulture}'");
-                _outputHelper.WriteLine($"input : '{expected.EscapedParseableString}'");
-                TokenList<FilterToken> tokens = _tokenizer.Tokenize(expected.EscapedParseableString);
+            _outputHelper.WriteLine($"Current culture is '{_cultureSwitcher.CurrentCulture}'");
+            _outputHelper.WriteLine($"input : '{expected.EscapedParseableString}'");
+            TokenList<FilterToken> tokens = _tokenizer.Tokenize(expected.EscapedParseableString);
 
-                // Act
-                GroupExpression actual = FilterTokenParser.Group.Parse(tokens);
+            // Act
+            GroupExpression actual = FilterTokenParser.Group.Parse(tokens);
 
-                // Assert
-                AssertThatShould_parse(actual, expected);
-            });
+            // Assert
+            AssertThatShould_parse(actual, expected);
         }
 
         public static TheoryData<CultureInfo, NumericValueExpression> ParseNumberCases

--- a/test/DataFilters.UnitTests/Grammar/Parsing/FilterTokenParserTests.cs
+++ b/test/DataFilters.UnitTests/Grammar/Parsing/FilterTokenParserTests.cs
@@ -1,1299 +1,1298 @@
-﻿namespace DataFilters.UnitTests.Grammar.Parsing
+﻿namespace DataFilters.UnitTests.Grammar.Parsing;
+
+using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Globalization;
+using System.Linq;
+using System.Linq.Expressions;
+using DataFilters.Grammar.Parsing;
+using DataFilters.Grammar.Syntax;
+using DataFilters.UnitTests.Helpers;
+using FluentAssertions;
+using FluentAssertions.Execution;
+using FsCheck;
+using FsCheck.Fluent;
+using FsCheck.Xunit;
+using Superpower;
+using Superpower.Model;
+using Xunit;
+using Xunit.Abstractions;
+using Xunit.Categories;
+
+/// <summary>
+/// Unit tests for  <see cref="FilterTokenParser"/>
+/// </summary>
+[UnitTest]
+[Feature(nameof(DataFilters.Grammar.Parsing))]
+[Feature(nameof(FilterTokenParser))]
+public class FilterTokenParserTests : IClassFixture<CultureSwitcher>, IDisposable
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Data;
-    using System.Globalization;
-    using System.Linq;
-    using System.Linq.Expressions;
-    using DataFilters.Grammar.Parsing;
-    using DataFilters.Grammar.Syntax;
-    using DataFilters.UnitTests.Helpers;
-    using FluentAssertions;
-    using FluentAssertions.Execution;
-    using FsCheck;
-    using FsCheck.Fluent;
-    using FsCheck.Xunit;
-    using Superpower;
-    using Superpower.Model;
-    using Xunit;
-    using Xunit.Abstractions;
-    using Xunit.Categories;
+    private readonly FilterTokenizer _tokenizer;
+    private readonly ITestOutputHelper _outputHelper;
+    private readonly CultureSwitcher _cultureSwitcher;
+    private static readonly Bogus.Faker Faker = new();
 
-    /// <summary>
-    /// Unit tests for  <see cref="FilterTokenParser"/>
-    /// </summary>
-    [UnitTest]
-    [Feature(nameof(DataFilters.Grammar.Parsing))]
-    [Feature(nameof(FilterTokenParser))]
-    public class FilterTokenParserTests : IClassFixture<CultureSwitcher>, IDisposable
+    public FilterTokenParserTests(ITestOutputHelper outputHelper, CultureSwitcher cultureSwitcher)
     {
-        private readonly FilterTokenizer _tokenizer;
-        private readonly ITestOutputHelper _outputHelper;
-        private readonly CultureSwitcher _cultureSwitcher;
-        private static readonly Bogus.Faker Faker = new();
+        _tokenizer = new FilterTokenizer();
+        _outputHelper = outputHelper;
+        _cultureSwitcher = cultureSwitcher;
+        _cultureSwitcher.DefaultCulture = CultureInfo.GetCultureInfo("fr-FR");
 
-        public FilterTokenParserTests(ITestOutputHelper outputHelper, CultureSwitcher cultureSwitcher)
+        _outputHelper.WriteLine($"Current culture is '{_cultureSwitcher.CurrentCulture}'");
+    }
+
+    ///<inheritdoc/>
+    public void Dispose() => _cultureSwitcher?.Dispose();
+
+    [Fact]
+    public void IsParser() => typeof(FilterTokenParser).Should()
+        .BeStatic().And
+        .HaveProperty<TokenListParser<FilterToken, ConstantValueExpression>>("AlphaNumeric").And
+        .HaveProperty<TokenListParser<FilterToken, PropertyName>>("Property").And
+        .HaveProperty<TokenListParser<FilterToken, StartsWithExpression>>("StartsWith").And
+        .HaveProperty<TokenListParser<FilterToken, EndsWithExpression>>("EndsWith").And
+        .HaveProperty<TokenListParser<FilterToken, OneOfExpression>>("OneOf").And
+        .HaveProperty<TokenListParser<FilterToken, ContainsExpression>>("Contains").And
+        .HaveProperty<TokenListParser<FilterToken, AsteriskExpression>>("Asterisk").And
+        .HaveProperty<TokenListParser<FilterToken, GroupExpression>>("Group").And
+        .HaveProperty<TokenListParser<FilterToken, AndExpression>>("And").And
+        .HaveProperty<TokenListParser<FilterToken, IntervalExpression>>("Interval").And
+        .HaveProperty<TokenListParser<FilterToken, NotExpression>>("Not").And
+        .HaveProperty<TokenListParser<FilterToken, NumericValueExpression>>("Number").And
+        .HaveProperty<TokenListParser<FilterToken, GuidValueExpression>>("GlobalUniqueIdentifier").And
+        .HaveProperty<TokenListParser<FilterToken, OrExpression>>("Or");
+
+    public static TheoryData<string, ConstantValueExpression> AlphaNumericCases
+        => new()
         {
-            _tokenizer = new FilterTokenizer();
-            _outputHelper = outputHelper;
-            _cultureSwitcher = cultureSwitcher;
-            _cultureSwitcher.DefaultCulture = CultureInfo.GetCultureInfo("fr-FR");
+            {
+                "Bruce",
+                new StringValueExpression("Bruce")
+            },
 
-            _outputHelper.WriteLine($"Current culture is '{_cultureSwitcher.CurrentCulture}'");
-        }
+            {
+                @"Vandal\*",
+                new StringValueExpression("Vandal*")
+            },
 
-        ///<inheritdoc/>
-        public void Dispose() => _cultureSwitcher?.Dispose();
+            {
+                @"Van\*dal",
+                new StringValueExpression("Van*dal")
+            },
 
-        [Fact]
-        public void IsParser() => typeof(FilterTokenParser).Should()
-                                                           .BeStatic().And
-                                                           .HaveProperty<TokenListParser<FilterToken, ConstantValueExpression>>("AlphaNumeric").And
-                                                           .HaveProperty<TokenListParser<FilterToken, PropertyName>>("Property").And
-                                                           .HaveProperty<TokenListParser<FilterToken, StartsWithExpression>>("StartsWith").And
-                                                           .HaveProperty<TokenListParser<FilterToken, EndsWithExpression>>("EndsWith").And
-                                                           .HaveProperty<TokenListParser<FilterToken, OneOfExpression>>("OneOf").And
-                                                           .HaveProperty<TokenListParser<FilterToken, ContainsExpression>>("Contains").And
-                                                           .HaveProperty<TokenListParser<FilterToken, AsteriskExpression>>("Asterisk").And
-                                                           .HaveProperty<TokenListParser<FilterToken, GroupExpression>>("Group").And
-                                                           .HaveProperty<TokenListParser<FilterToken, AndExpression>>("And").And
-                                                           .HaveProperty<TokenListParser<FilterToken, IntervalExpression>>("Interval").And
-                                                           .HaveProperty<TokenListParser<FilterToken, NotExpression>>("Not").And
-                                                           .HaveProperty<TokenListParser<FilterToken, NumericValueExpression>>("Number").And
-                                                           .HaveProperty<TokenListParser<FilterToken, GuidValueExpression>>("GlobalUniqueIdentifier").And
-                                                           .HaveProperty<TokenListParser<FilterToken, OrExpression>>("Or");
+            {
+                "1Bruce",
+                new StringValueExpression("1Bruce")
+            },
 
-        public static TheoryData<string, ConstantValueExpression> AlphaNumericCases
-            => new()
-                {
-                    {
-                        "Bruce",
-                        new StringValueExpression("Bruce")
-                    },
+            {
+                @"0\ \,i#y",
+                new StringValueExpression("0 ,i#y")
+            },
 
-                    {
-                        @"Vandal\*",
-                        new StringValueExpression("Vandal*")
-                    },
-
-                    {
-                        @"Van\*dal",
-                        new StringValueExpression("Van*dal")
-                    },
-
-                    {
-                        "1Bruce",
-                        new StringValueExpression("1Bruce")
-                    },
-
-                    {
-                        @"0\ \,i#y",
-                        new StringValueExpression("0 ,i#y")
-                    },
-
-                    {
-                        @"E
+            {
+                @"E
 I\&_Oj
 \.",
-                        new StringValueExpression(@"E
+                new StringValueExpression(@"E
 I&_Oj
 .")
-                    },
+            },
 
-                    {
-                        "39.95173047301258862",
-                        new NumericValueExpression("39.95173047301258862")
-                    },
-
-                    {
-                        "5aa8f391",
-                        new StringValueExpression("5aa8f391")
-                    },
-                    {
-                        "6P%",
-                        new StringValueExpression("6P%")
-                    },
-                    {
-                        "gHuQ>a0\\!>\\:\t\\-\\021+o\\]AL2oVmf\\029\\!",
-                        new StringValueExpression("gHuQ>a0!>:\t-\\021+o]AL2oVmf\\029!")
-                    }
-                };
-
-        [Theory]
-        [MemberData(nameof(AlphaNumericCases))]
-        public void Should_parse_AlphaNumeric(string input, ConstantValueExpression expected)
-        {
-            // Arrange
-            _outputHelper.WriteLine($"input : '{input}'");
-            TokenList<FilterToken> tokens = _tokenizer.Tokenize(input);
-            _outputHelper.WriteLine($"Tokens : ${StringifyTokens(tokens)}");
-
-            // Act
-            FilterExpression actual = FilterTokenParser.AlphaNumeric.Parse(tokens);
-
-            _outputHelper.WriteLine($"actual is '{actual.EscapedParseableString}'");
-
-            // Assert
-            AssertThatShould_parse(actual, expected);
-        }
-
-        [Property]
-        public void Given_double_as_string_Number_should_parse_to_a_ConstantValueExpression_where_Value_property_holds_the_input(NormalFloat value)
-        {
-            // Arrange
-            NumericValueExpression expected = new(value.Item.ToString(CultureInfo.InvariantCulture));
-            string input = expected.EscapedParseableString;
-
-            TokenList<FilterToken> tokens = _tokenizer.Tokenize(input);
-            _outputHelper.WriteLine($"Tokens : ${StringifyTokens(tokens)}");
-
-            // Act
-            NumericValueExpression actual = FilterTokenParser.Number.Parse(tokens);
-
-            // Assert
-            AssertThatShould_parse(actual, expected);
-        }
-
-        [Property]
-        public void Given_long_as_string_Number_should_parse_to_a_ConstantValueExpression_where_Value_property_holds_the_input(long value)
-        {
-            // Arrange
-            NumericValueExpression expected = new(value.ToString());
-            string input = expected.EscapedParseableString;
-
-            TokenList<FilterToken> tokens = _tokenizer.Tokenize(input);
-            _outputHelper.WriteLine($"Tokens : ${StringifyTokens(tokens)}");
-
-            // Act
-            NumericValueExpression actual = FilterTokenParser.Number.Parse(tokens);
-
-            // Assert
-            AssertThatShould_parse(actual, expected);
-        }
-
-        [Property]
-        public void Given_int_as_string_Number_should_parse_to_a_ConstantValueExpression_where_Value_property_holds_the_input(int value)
-        {
-            // Arrange
-            NumericValueExpression expected = new(value.ToString());
-            string input = expected.EscapedParseableString;
-
-            TokenList<FilterToken> tokens = _tokenizer.Tokenize(input);
-            _outputHelper.WriteLine($"Tokens : ${StringifyTokens(tokens)}");
-
-            // Act
-            NumericValueExpression actual = FilterTokenParser.Number.Parse(tokens);
-
-            // Assert
-            AssertThatShould_parse(actual, expected);
-        }
-
-        [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
-        public void Should_parse_StartsWith(StartsWithExpression expected)
-        {
-            // Arrange
-            _outputHelper.WriteLine($"input : '{expected.EscapedParseableString}'");
-            TokenList<FilterToken> tokens = _tokenizer.Tokenize(expected.EscapedParseableString);
-            _outputHelper.WriteLine($"Tokens : ${StringifyTokens(tokens)}");
-
-            // Act
-            StartsWithExpression expression = FilterTokenParser.StartsWith.Parse(tokens);
-
-            // Assert
-            AssertThatShould_parse(expression, expected);
-        }
-
-        [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
-        public void Should_parse_EndsWith(EndsWithExpression expected)
-        {
-            // Arrange
-            _outputHelper.WriteLine($"input : '{expected.EscapedParseableString}'");
-            TokenList<FilterToken> tokens = _tokenizer.Tokenize(expected.EscapedParseableString);
-            _outputHelper.WriteLine($"Tokens : ${StringifyTokens(tokens)}");
-
-            // Act
-            EndsWithExpression expression = FilterTokenParser.EndsWith.Parse(tokens);
-
-            // Assert
-            AssertThatShould_parse(expression, expected);
-        }
-
-        public static TheoryData<string, EndsWithExpression> EndsWithData
-            => new TheoryData<string, EndsWithExpression>()
             {
-                {
-                    @"*gHuQ>a0\!>\:	\-\021+o\]AL2oVmf\029\!",
-                    new EndsWithExpression(@"gHuQ>a0!>:	-\021+o]AL2oVmf\029!")
-                }
-            };
+                "39.95173047301258862",
+                new NumericValueExpression("39.95173047301258862")
+            },
 
-        [Theory]
-        [MemberData(nameof(EndsWithData))]
-        public void Given_ends_with_input_EndsWith_should_return_expected_EndsWithExpression(string input, EndsWithExpression expected)
-        {
-            // Arrange
-            // Arrange
-            TokenList<FilterToken> tokens = _tokenizer.Tokenize(input);
-            _outputHelper.WriteLine($"Tokens : ${StringifyTokens(tokens)}");
-
-            // Act
-            EndsWithExpression expression = FilterTokenParser.EndsWith.Parse(tokens);
-
-            // Assert
-            AssertThatShould_parse(expression, expected);
-        }
-        
-        private static string StringifyTokens(TokenList<FilterToken> tokens)
-            => tokens.Select(token => new { Kind = token.Kind.ToString(), Value = token.ToStringValue() }).Jsonify();
-
-        public static TheoryData<string, ContainsExpression> ContainsCases
-        {
-            get
             {
-                TheoryData<string, ContainsExpression> cases = new()
-                {
-                    { "*bat*", new ContainsExpression("bat")},
-                    { @"*bat\*man*", new ContainsExpression("bat*man")},
-                    {"*d3aa022d-ec52-47aa-be13-6823c478c60a*", new ContainsExpression("d3aa022d-ec52-47aa-be13-6823c478c60a")},
-                    {"*\"Oi\012j8G]t:JK%H6m>+r{)[5\n6\"*", AsteriskExpression.Instance + new StringValueExpression("Oi\012j8G]t:JK%H6m>+r{)[5\n6") + AsteriskExpression.Instance}
-                };
-
-                string[] punctuations = [".", "-", ":", "_"];
-
-                foreach (string punctuation in punctuations)
-                {
-                    cases.Add
-                    (
-                        $"*{punctuation}*",
-                        new ContainsExpression(punctuation)
-                    );
-                }
-
-                return cases;
+                "5aa8f391",
+                new StringValueExpression("5aa8f391")
+            },
+            {
+                "6P%",
+                new StringValueExpression("6P%")
+            },
+            {
+                "gHuQ>a0\\!>\\:\t\\-\\021+o\\]AL2oVmf\\029\\!",
+                new StringValueExpression("gHuQ>a0!>:\t-\\021+o]AL2oVmf\\029!")
             }
-        }
+        };
 
-        [Theory]
-        [MemberData(nameof(ContainsCases))]
-        public void Should_parse_Contains(string input, ContainsExpression expectedContains)
+    [Theory]
+    [MemberData(nameof(AlphaNumericCases))]
+    public void Should_parse_AlphaNumeric(string input, ConstantValueExpression expected)
+    {
+        // Arrange
+        _outputHelper.WriteLine($"input : '{input}'");
+        TokenList<FilterToken> tokens = _tokenizer.Tokenize(input);
+        _outputHelper.WriteLine($"Tokens : ${StringifyTokens(tokens)}");
+
+        // Act
+        FilterExpression actual = FilterTokenParser.AlphaNumeric.Parse(tokens);
+
+        _outputHelper.WriteLine($"actual is '{actual.EscapedParseableString}'");
+
+        // Assert
+        AssertThatShould_parse(actual, expected);
+    }
+
+    [Property]
+    public void Given_double_as_string_Number_should_parse_to_a_ConstantValueExpression_where_Value_property_holds_the_input(NormalFloat value)
+    {
+        // Arrange
+        NumericValueExpression expected = new(value.Item.ToString(CultureInfo.InvariantCulture));
+        string input = expected.EscapedParseableString;
+
+        TokenList<FilterToken> tokens = _tokenizer.Tokenize(input);
+        _outputHelper.WriteLine($"Tokens : ${StringifyTokens(tokens)}");
+
+        // Act
+        NumericValueExpression actual = FilterTokenParser.Number.Parse(tokens);
+
+        // Assert
+        AssertThatShould_parse(actual, expected);
+    }
+
+    [Property]
+    public void Given_long_as_string_Number_should_parse_to_a_ConstantValueExpression_where_Value_property_holds_the_input(long value)
+    {
+        // Arrange
+        NumericValueExpression expected = new(value.ToString());
+        string input = expected.EscapedParseableString;
+
+        TokenList<FilterToken> tokens = _tokenizer.Tokenize(input);
+        _outputHelper.WriteLine($"Tokens : ${StringifyTokens(tokens)}");
+
+        // Act
+        NumericValueExpression actual = FilterTokenParser.Number.Parse(tokens);
+
+        // Assert
+        AssertThatShould_parse(actual, expected);
+    }
+
+    [Property]
+    public void Given_int_as_string_Number_should_parse_to_a_ConstantValueExpression_where_Value_property_holds_the_input(int value)
+    {
+        // Arrange
+        NumericValueExpression expected = new(value.ToString());
+        string input = expected.EscapedParseableString;
+
+        TokenList<FilterToken> tokens = _tokenizer.Tokenize(input);
+        _outputHelper.WriteLine($"Tokens : ${StringifyTokens(tokens)}");
+
+        // Act
+        NumericValueExpression actual = FilterTokenParser.Number.Parse(tokens);
+
+        // Assert
+        AssertThatShould_parse(actual, expected);
+    }
+
+    [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
+    public void Should_parse_StartsWith(StartsWithExpression expected)
+    {
+        // Arrange
+        _outputHelper.WriteLine($"input : '{expected.EscapedParseableString}'");
+        TokenList<FilterToken> tokens = _tokenizer.Tokenize(expected.EscapedParseableString);
+        _outputHelper.WriteLine($"Tokens : ${StringifyTokens(tokens)}");
+
+        // Act
+        StartsWithExpression expression = FilterTokenParser.StartsWith.Parse(tokens);
+
+        // Assert
+        AssertThatShould_parse(expression, expected);
+    }
+
+    [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
+    public void Should_parse_EndsWith(EndsWithExpression expected)
+    {
+        // Arrange
+        _outputHelper.WriteLine($"input : '{expected.EscapedParseableString}'");
+        TokenList<FilterToken> tokens = _tokenizer.Tokenize(expected.EscapedParseableString);
+        _outputHelper.WriteLine($"Tokens : ${StringifyTokens(tokens)}");
+
+        // Act
+        EndsWithExpression expression = FilterTokenParser.EndsWith.Parse(tokens);
+
+        // Assert
+        AssertThatShould_parse(expression, expected);
+    }
+
+    public static TheoryData<string, EndsWithExpression> EndsWithData
+        => new TheoryData<string, EndsWithExpression>()
         {
-            // Arrange
-            _outputHelper.WriteLine($"input : '{input}'");
-            TokenList<FilterToken> tokens = _tokenizer.Tokenize(input);
-            _outputHelper.WriteLine($"Tokens : ${StringifyTokens(tokens)}");
-
-            // Act
-            ContainsExpression expression = FilterTokenParser.Contains.Parse(tokens);
-
-            // Assert
-            AssertThatShould_parse(expression, expectedContains);
-        }
-
-        public static TheoryData<string, OrExpression> OrExpressionCases
-            => new()
             {
-                {
-                    "Bruce|bat*",
-                    new OrExpression(new StringValueExpression("Bruce"), new StartsWithExpression("bat"))
-                },
-                {
-                    "Bruce|Wayne",
-                    new OrExpression(new StringValueExpression("Bruce"), new StringValueExpression("Wayne"))
-                },
-                {
-                    "Bru*|Di*",
-                    new OrExpression(new StartsWithExpression("Bru"), new StartsWithExpression("Di"))
-                },
-                {
-                    "(!(Bat*|Sup*))|!*man",
-                    new OrExpression(
-                        left : new GroupExpression(
-                                new NotExpression(
-                                    new GroupExpression(
-                                        new OrExpression(new StartsWithExpression("Bat"), new StartsWithExpression("Sup"))
-                                    )
-                                )
-                            ),
-                        right: new NotExpression(new EndsWithExpression("man"))
-                    )
-                },
-                {
-                    "(Bat|Wonder)|Sup",
-                    new OrExpression(new OrExpression(new StringValueExpression("Bat"),
-                                                      new StringValueExpression("Wonder")),
-                                    new StringValueExpression("Sup"))
-                },
+                @"*gHuQ>a0\!>\:	\-\021+o\]AL2oVmf\029\!",
+                new EndsWithExpression(@"gHuQ>a0!>:	-\021+o]AL2oVmf\029!")
+            }
+        };
 
-                {
-                    (new StringValueExpression("5aa8f391") | new GroupExpression(new GroupExpression(new GroupExpression(new StringValueExpression("6P%"))))).EscapedParseableString,
-                    new OrExpression(
-                        new StringValueExpression("5aa8f391"),
-                        new GroupExpression(new GroupExpression(new GroupExpression(new StringValueExpression("6P%"))))
-                    )
-                },
+    [Theory]
+    [MemberData(nameof(EndsWithData))]
+    public void Given_ends_with_input_EndsWith_should_return_expected_EndsWithExpression(string input, EndsWithExpression expected)
+    {
+        // Arrange
+        // Arrange
+        TokenList<FilterToken> tokens = _tokenizer.Tokenize(input);
+        _outputHelper.WriteLine($"Tokens : ${StringifyTokens(tokens)}");
 
-                {
-                    (new StringValueExpression("5aa8f391") | new StringValueExpression("6P%")).EscapedParseableString,
-                    new StringValueExpression("5aa8f391") | new StringValueExpression("6P%")
-                },
-                
-                {
-                    (new StringValueExpression("AB") | new StringValueExpression("6P%")).EscapedParseableString,
-                    new StringValueExpression("AB") | new StringValueExpression("6P%")
-                },
-                {
-                    (new EndsWithExpression("Foo") | new ContainsExpression("Bar")).EscapedParseableString,
-                    new EndsWithExpression("Foo") | new ContainsExpression("Bar")
-                },
-                {
-                    (new EndsWithExpression("Foo") | new EndsWithExpression("Bar")).EscapedParseableString,
-                    new EndsWithExpression("Foo") | new EndsWithExpression("Bar")
-                },
-                {
-                    (new StartsWithExpression("Foo") | new EndsWithExpression("Bar")).EscapedParseableString,
-                    new StartsWithExpression("Foo") | new EndsWithExpression("Bar")
-                },
-                {
-                    @"*N\=FW|i*",
-                    new EndsWithExpression("N=FW") | new StartsWithExpression("i")
-                },
+        // Act
+        EndsWithExpression expression = FilterTokenParser.EndsWith.Parse(tokens);
+
+        // Assert
+        AssertThatShould_parse(expression, expected);
+    }
+        
+    private static string StringifyTokens(TokenList<FilterToken> tokens)
+        => tokens.Select(token => new { Kind = token.Kind.ToString(), Value = token.ToStringValue() }).Jsonify();
+
+    public static TheoryData<string, ContainsExpression> ContainsCases
+    {
+        get
+        {
+            TheoryData<string, ContainsExpression> cases = new()
+            {
+                { "*bat*", new ContainsExpression("bat")},
+                { @"*bat\*man*", new ContainsExpression("bat*man")},
+                {"*d3aa022d-ec52-47aa-be13-6823c478c60a*", new ContainsExpression("d3aa022d-ec52-47aa-be13-6823c478c60a")},
+                {"*\"Oi\012j8G]t:JK%H6m>+r{)[5\n6\"*", AsteriskExpression.Instance + new StringValueExpression("Oi\012j8G]t:JK%H6m>+r{)[5\n6") + AsteriskExpression.Instance}
             };
 
-        [Theory]
-        [MemberData(nameof(OrExpressionCases))]
-        public void Should_parse_OrExpression(string input, OrExpression expected)
+            string[] punctuations = [".", "-", ":", "_"];
+
+            foreach (string punctuation in punctuations)
+            {
+                cases.Add
+                (
+                    $"*{punctuation}*",
+                    new ContainsExpression(punctuation)
+                );
+            }
+
+            return cases;
+        }
+    }
+
+    [Theory]
+    [MemberData(nameof(ContainsCases))]
+    public void Should_parse_Contains(string input, ContainsExpression expectedContains)
+    {
+        // Arrange
+        _outputHelper.WriteLine($"input : '{input}'");
+        TokenList<FilterToken> tokens = _tokenizer.Tokenize(input);
+        _outputHelper.WriteLine($"Tokens : ${StringifyTokens(tokens)}");
+
+        // Act
+        ContainsExpression expression = FilterTokenParser.Contains.Parse(tokens);
+
+        // Assert
+        AssertThatShould_parse(expression, expectedContains);
+    }
+
+    public static TheoryData<string, OrExpression> OrExpressionCases
+        => new()
+        {
+            {
+                "Bruce|bat*",
+                new OrExpression(new StringValueExpression("Bruce"), new StartsWithExpression("bat"))
+            },
+            {
+                "Bruce|Wayne",
+                new OrExpression(new StringValueExpression("Bruce"), new StringValueExpression("Wayne"))
+            },
+            {
+                "Bru*|Di*",
+                new OrExpression(new StartsWithExpression("Bru"), new StartsWithExpression("Di"))
+            },
+            {
+                "(!(Bat*|Sup*))|!*man",
+                new OrExpression(
+                    left : new GroupExpression(
+                        new NotExpression(
+                            new GroupExpression(
+                                new OrExpression(new StartsWithExpression("Bat"), new StartsWithExpression("Sup"))
+                            )
+                        )
+                    ),
+                    right: new NotExpression(new EndsWithExpression("man"))
+                )
+            },
+            {
+                "(Bat|Wonder)|Sup",
+                new OrExpression(new OrExpression(new StringValueExpression("Bat"),
+                        new StringValueExpression("Wonder")),
+                    new StringValueExpression("Sup"))
+            },
+
+            {
+                (new StringValueExpression("5aa8f391") | new GroupExpression(new GroupExpression(new GroupExpression(new StringValueExpression("6P%"))))).EscapedParseableString,
+                new OrExpression(
+                    new StringValueExpression("5aa8f391"),
+                    new GroupExpression(new GroupExpression(new GroupExpression(new StringValueExpression("6P%"))))
+                )
+            },
+
+            {
+                (new StringValueExpression("5aa8f391") | new StringValueExpression("6P%")).EscapedParseableString,
+                new StringValueExpression("5aa8f391") | new StringValueExpression("6P%")
+            },
+                
+            {
+                (new StringValueExpression("AB") | new StringValueExpression("6P%")).EscapedParseableString,
+                new StringValueExpression("AB") | new StringValueExpression("6P%")
+            },
+            {
+                (new EndsWithExpression("Foo") | new ContainsExpression("Bar")).EscapedParseableString,
+                new EndsWithExpression("Foo") | new ContainsExpression("Bar")
+            },
+            {
+                (new EndsWithExpression("Foo") | new EndsWithExpression("Bar")).EscapedParseableString,
+                new EndsWithExpression("Foo") | new EndsWithExpression("Bar")
+            },
+            {
+                (new StartsWithExpression("Foo") | new EndsWithExpression("Bar")).EscapedParseableString,
+                new StartsWithExpression("Foo") | new EndsWithExpression("Bar")
+            },
+            {
+                @"*N\=FW|i*",
+                new EndsWithExpression("N=FW") | new StartsWithExpression("i")
+            },
+        };
+
+    [Theory]
+    [MemberData(nameof(OrExpressionCases))]
+    public void Should_parse_OrExpression(string input, OrExpression expected)
+    {
+        // Arrange
+        _outputHelper.WriteLine($"input : '{input}'");
+        TokenList<FilterToken> tokens = _tokenizer.Tokenize(input);
+            
+        _outputHelper.WriteLine(StringifyTokens(tokens));
+
+        // Act
+        FilterExpression expression = FilterTokenParser.Or.Parse(tokens);
+
+        // Assert
+        AssertThatShould_parse(expression, expected);
+    }
+
+    public static TheoryData<string, AndExpression> AndExpressionCases
+        => new()
+        {
+            {
+                "bat*,man*",
+                new AndExpression(new StartsWithExpression("bat"), new StartsWithExpression("man"))
+            },
+            {
+                "*bat,man*",
+                new EndsWithExpression("bat") & new StartsWithExpression("man")
+            },
+            {
+                "(!(Bat*|Sup*)),!*man",
+                new AndExpression(
+                    left: new GroupExpression
+                    (
+                        new NotExpression(
+                            new GroupExpression(
+                                new OrExpression(new StartsWithExpression("Bat"), new StartsWithExpression("Sup"))
+                            )
+                        )
+                    ),
+                    right: new NotExpression(new EndsWithExpression("man"))
+                )
+            },
+            {
+                "bat*man",
+                new AndExpression(new StartsWithExpression("bat"), new EndsWithExpression("man"))
+            },
+            {
+                @"bat*\)",
+                new AndExpression(new StartsWithExpression("bat"), new EndsWithExpression(")"))
+            },
+            {
+                "bat*man*",
+                new AndExpression(new StartsWithExpression("bat"), new ContainsExpression("man"))
+            },
+            {
+                //@"*""1.\""Foo!"",*""2.\""Bar!""*",
+                new AndExpression(
+                    AsteriskExpression.Instance + new TextExpression(@"1.""Foo!"),
+                    AsteriskExpression.Instance + new TextExpression(@"2.""Bar!") + AsteriskExpression.Instance
+                ).EscapedParseableString,
+                new AndExpression(
+                    AsteriskExpression.Instance + new TextExpression(@"1.""Foo!"),
+                    AsteriskExpression.Instance + new TextExpression(@"2.""Bar!") + AsteriskExpression.Instance
+                )
+            }
+        };
+
+    [Theory]
+    [MemberData(nameof(AndExpressionCases))]
+    public void Should_parse_AndExpression(string input, AndExpression expected)
+    {
+        // Arrange
+        _outputHelper.WriteLine($"input : '{input}'");
+        TokenList<FilterToken> tokens = _tokenizer.Tokenize(input);
+        _outputHelper.WriteLine($"Tokens : {StringifyTokens(tokens)}");
+
+        // Act
+        FilterExpression expression = FilterTokenParser.And.Parse(tokens);
+
+        // Assert
+        AssertThatShould_parse(expression, expected);
+    }
+
+    [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
+    public void Should_parse_NotExpression(NotExpression expected)
+    {
+        // Arrange
+        _outputHelper.WriteLine($"input : '{expected.EscapedParseableString}' ");
+        _outputHelper.WriteLine($"input (debug view) : '{expected:d}' ");
+        _outputHelper.WriteLine($"input (full view) : '{expected:f}' ");
+        TokenList<FilterToken> tokens = _tokenizer.Tokenize(expected.EscapedParseableString);
+            
+        // Act
+        NotExpression expression = FilterTokenParser.Not.Parse(tokens);
+
+        // Assert
+        AssertThatShould_parse(expression, expected);
+            
+    }
+
+    public static TheoryData<string, NotExpression> NotParsingCases
+        => new()
+        {   
+            {
+                "!!(w%A*@,2088-08-10)",
+                new NotExpression(
+                    new NotExpression(
+                        new GroupExpression(
+                            new AndExpression(
+                                new StartsWithExpression("w%A") + new EndsWithExpression("@"),
+                                new DateExpression(2088, 8, 10)
+                            )
+                        )
+                    )
+                )
+            },
+            {
+                "!!!!!(w%A*@,2088-08-10)",
+                !!!!!new GroupExpression(
+                    new AndExpression(
+                        new StartsWithExpression("w%A") + new EndsWithExpression("@"),
+                        new DateExpression(2088, 8, 10)
+                    )
+                )
+            },
+            {
+                "!![50 TO 60]",
+                !!new IntervalExpression(min: new BoundaryExpression(new NumericValueExpression("50"), true),
+                    max: new BoundaryExpression(new NumericValueExpression("60"), true))
+            },
+                
+            {
+                "!((word))",
+                !new GroupExpression
+                (
+                    new GroupExpression
+                    (
+                        new StringValueExpression("word")
+                    )
+                )
+            },
+
+            {
+                "!((1)|(2))",
+                !new GroupExpression(
+                    new OrExpression(
+                        new GroupExpression(
+                            new NumericValueExpression("1")
+                        ),
+                        new GroupExpression(
+                            new NumericValueExpression("2")
+                        )
+                    )
+                )
+            },
+            {
+                (! (new StringValueExpression("5aa8f391") | new GroupExpression(new GroupExpression(new GroupExpression(new StringValueExpression("6P%")))))).EscapedParseableString,
+                ! (new StringValueExpression("5aa8f391") | new GroupExpression(new GroupExpression(new GroupExpression(new StringValueExpression("6P%")))))
+            },
+            {
+                (! (new StringValueExpression("5aa8f391") | new StringValueExpression("6P%"))).EscapedParseableString,
+                ! (new StringValueExpression("5aa8f391") | new StringValueExpression("6P%"))
+            },
+            {
+                // "!!(*gHuQ>a0\\!>\\:\t\\-\\021+o\\]AL2oVmf\\029\\!,*\"Oi\\012j8G]t:JK%H6m>+r{)[5\n6\"*)",
+                (!!(new EndsWithExpression("gHuQ>a0!>:\t-\\021+o\\]AL2oVmf\\029!")
+                    &
+                    new ContainsExpression(new TextExpression("Oi\\012j8G]t:JK%H6m>+r{)[5\n6")))).EscapedParseableString,
+                !!(
+                    new EndsWithExpression("gHuQ>a0!>:\t-\\021+o\\]AL2oVmf\\029!")
+                    &
+                    new ContainsExpression(new TextExpression("Oi\\012j8G]t:JK%H6m>+r{)[5\n6"))
+                )
+            }
+
+        };
+
+    [Theory]
+    [MemberData(nameof(NotParsingCases))]
+    public void Given_NotExpression_as_parseable_string_Not_should_parse_the_input(string input, NotExpression expected)
+    {
+        // Arrange
+        _outputHelper.WriteLine($"input : '{input}'");
+        _outputHelper.WriteLine($"expected : {expected:d}");
+        TokenList<FilterToken> tokens = _tokenizer.Tokenize(input);
+            
+        _outputHelper.WriteLine(StringifyTokens(tokens));
+
+        // Act
+        NotExpression expression = FilterTokenParser.Not.Parse(tokens);
+            
+        _outputHelper.WriteLine($"Parsed expression : {expression:d}");
+
+        // Assert
+        AssertThatShould_parse(expression, expected);
+    }
+
+    public static TheoryData<string, OneOfExpression> OneOfExpressionCases
+        => new()
+        {
+            {
+                "[Bb]",
+                new OneOfExpression(new StringValueExpression("B"), new StringValueExpression("b"))
+            },
+
+            {
+                "[Bb]ruce",
+                new OneOfExpression(new StringValueExpression("Bruce"), new StringValueExpression("bruce"))
+            },
+
+            {
+                "[Bb]at*",
+                new OneOfExpression(new StartsWithExpression("Bat"), new StartsWithExpression("bat"))
+            },
+
+            {
+                "Ma*[Nn]",
+                new OneOfExpression(
+                    new StartsWithExpression("Ma") & new EndsWithExpression("N"),
+                    new StartsWithExpression("Ma") & new EndsWithExpression("n")
+                )
+            },
+
+            {
+                "cat[Ww]oman",
+                new OneOfExpression(new StringValueExpression("catWoman"), new StringValueExpression("catwoman"))
+            },
+
+            {
+                "*Br[Uu]",
+                new OneOfExpression(new EndsWithExpression("BrU"), new EndsWithExpression("Bru"))
+            },
+
+            {
+                "Bo[Bb]",
+                new OneOfExpression(new StringValueExpression("BoB"), new StringValueExpression("Bob"))
+            },
+
+            {
+                "[Bb]*ob",
+                new OneOfExpression(new StartsWithExpression("B") & new EndsWithExpression("ob"),
+                    new StartsWithExpression("b") &  new EndsWithExpression("ob"))
+            },
+
+            {
+                "*[Mm]an",
+                new OneOfExpression(new EndsWithExpression("Man"), new EndsWithExpression("man"))
+            },
+
+            {
+                "*[Mm]",
+                new OneOfExpression(new EndsWithExpression("M"), new EndsWithExpression("m"))
+            },
+
+            {
+                "[a-z]",
+                new OneOfExpression([ .. GetCharacters('a', 'z').Select(chr => new StringValueExpression(chr.ToString())) ])
+            },
+
+            {
+                "[a-zA-Z0-9]",
+                new OneOfExpression([.. GetCharacters('a', 'z').Concat(GetCharacters('A', 'Z'))
+                    .Concat(GetCharacters('0', '9'))
+                    .Select(chr => new StringValueExpression(chr.ToString()))
+                ])
+            },
+
+            {
+                "{Bat|Sup|Wonder}*",
+                new OneOfExpression(new StartsWithExpression("Bat"),
+                    new StartsWithExpression("Sup"),
+                    new StartsWithExpression("Wonder"))
+            },
+
+            {
+                "[ab][cd]",
+                new OneOfExpression(new StringValueExpression("ac"),
+                    new StringValueExpression("ad"),
+                    new StringValueExpression("bc"),
+                    new StringValueExpression("bd"))
+            },
+
+            {
+                "{Bat|Sup|Wonder}",
+                new OneOfExpression(new StringValueExpression("Bat"),
+                    new StringValueExpression("Sup"),
+                    new StringValueExpression("Wonder"))
+            },
+            {
+                "*m[ae]n",
+                new OneOfExpression(new EndsWithExpression("man"),
+                    new EndsWithExpression("men"))
+            }
+        };
+
+    private static IEnumerable<char> GetCharacters(char regexStart, char regexEnd)
+        => Enumerable.Range(regexStart, regexEnd - regexStart + 1)
+            .Select(ascii => (char)ascii);
+
+    [Theory]
+    [MemberData(nameof(OneOfExpressionCases))]
+    public void Should_parse_OneOfExpression(string input, OneOfExpression expected)
+    {
+        // Arrange
+        _outputHelper.WriteLine($"input : '{input}'");
+        TokenList<FilterToken> tokens = _tokenizer.Tokenize(input);
+
+        // Act
+        OneOfExpression expression = FilterTokenParser.OneOf.Parse(tokens);
+
+        // Assert
+        AssertThatShould_parse(expression, expected);
+    }
+
+    [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
+    public void Given_bracket_expression_OneOf_can_parse_input(NonNull<BracketValue> bracketExpression)
+    {
+        // Arrange
+        string input = bracketExpression.Item.EscapedParseableString;
+        _outputHelper.WriteLine($"input : '{input}'");
+        TokenList<FilterToken> tokens = _tokenizer.Tokenize(input);
+
+        OneOfExpression expected = bracketExpression.Item switch
+        {
+            ConstantBracketValue constant => new OneOfExpression([.. constant.Value.Select(chr => new StringValueExpression(chr.ToString()))]),
+            RangeBracketValue range => new OneOfExpression([.. Enumerable.Range(range.Start, range.End - range.Start + 1)
+                .Select(ascii => (char)ascii)
+                .Select(chr => new StringValueExpression(chr.ToString()))]),
+            _ => throw new NotSupportedException()
+        };
+
+        // Act
+        FilterExpression expression = FilterTokenParser.OneOf.Parse(tokens);
+
+        // Assert
+        expression.IsEquivalentTo(expected).ToProperty();
+    }
+
+    [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
+    public void Should_parse_Interval(CultureInfo culture, IntervalExpression expected)
+    {
+        _cultureSwitcher.Run(culture, () =>
         {
             // Arrange
-            _outputHelper.WriteLine($"input : '{input}'");
-            TokenList<FilterToken> tokens = _tokenizer.Tokenize(input);
-            
-            _outputHelper.WriteLine(StringifyTokens(tokens));
+            _outputHelper.WriteLine($"Culture : '{culture.Name}'");
+            _outputHelper.WriteLine($"input : '{expected.EscapedParseableString}'");
+            TokenList<FilterToken> tokens = _tokenizer.Tokenize(expected.EscapedParseableString);
 
             // Act
-            FilterExpression expression = FilterTokenParser.Or.Parse(tokens);
+            IntervalExpression expression = FilterTokenParser.Interval.Parse(tokens);
 
             // Assert
             AssertThatShould_parse(expression, expected);
-        }
+        });
+    }
 
-        public static TheoryData<string, AndExpression> AndExpressionCases
-            => new()
+    public static TheoryData<string, string, IntervalExpression> IntervalCases
+    {
+        get
+        {
+            TheoryData<string, string, IntervalExpression> cases = [];
+            string[] cultures = [string.Empty, "fr-FR", "en-GB", "en-US"];
+            foreach (string culture in cultures)
             {
-                {
-                    "bat*,man*",
-                    new AndExpression(new StartsWithExpression("bat"), new StartsWithExpression("man"))
-                },
-                {
-                    "*bat,man*",
-                    new EndsWithExpression("bat") & new StartsWithExpression("man")
-                },
-                {
-                    "(!(Bat*|Sup*)),!*man",
-                    new AndExpression(
-                        left: new GroupExpression
-                        (
-                            new NotExpression(
-                                new GroupExpression(
-                                    new OrExpression(new StartsWithExpression("Bat"), new StartsWithExpression("Sup"))
-                                )
-                            )
-                        ),
-                        right: new NotExpression(new EndsWithExpression("man"))
-                    )
-                },
-                {
-                    "bat*man",
-                    new AndExpression(new StartsWithExpression("bat"), new EndsWithExpression("man"))
-                },
-                {
-                    @"bat*\)",
-                    new AndExpression(new StartsWithExpression("bat"), new EndsWithExpression(")"))
-                },
-                {
-                    "bat*man*",
-                    new AndExpression(new StartsWithExpression("bat"), new ContainsExpression("man"))
-                },
-                {
-                    //@"*""1.\""Foo!"",*""2.\""Bar!""*",
-                    new AndExpression(
-                        AsteriskExpression.Instance + new TextExpression(@"1.""Foo!"),
-                        AsteriskExpression.Instance + new TextExpression(@"2.""Bar!") + AsteriskExpression.Instance
-                    ).EscapedParseableString,
-                    new AndExpression(
-                        AsteriskExpression.Instance + new TextExpression(@"1.""Foo!"),
-                        AsteriskExpression.Instance + new TextExpression(@"2.""Bar!") + AsteriskExpression.Instance
-                    )
-                }
-            };
+                cases.Add
+                (
+                    culture,
+                    "[5 TO 5[",
+                    new IntervalExpression(new BoundaryExpression(new NumericValueExpression("5"), true), new BoundaryExpression(new NumericValueExpression("5"), false))
+                );
 
-        [Theory]
-        [MemberData(nameof(AndExpressionCases))]
-        public void Should_parse_AndExpression(string input, AndExpression expected)
+                cases.Add
+                (
+                    culture,
+                    "[1993-08-04T00:25:05.155Z TO 1908-06-08T03:18:46.745-09:50[",
+                    new IntervalExpression(new BoundaryExpression(new DateTimeExpression(new DateExpression(1993, 8, 4), new TimeExpression(0, 25, 5, 155), OffsetExpression.Zero), true),
+                        new BoundaryExpression(new DateTimeExpression(new DateExpression(1908, 6, 8), new TimeExpression(3, 18, 46, 745), new OffsetExpression(NumericSign.Minus, 9, 50)), false))
+                );
+
+                cases.Add
+                (
+                    culture,
+                    "]* TO 1963-06-03T15:53:44.609Z]",
+                    new IntervalExpression(max: new BoundaryExpression(new DateTimeExpression(new DateExpression(1963, 6, 3), new TimeExpression(15, 53, 44, 609), OffsetExpression.Zero), true))
+                );
+
+                cases.Add
+                (
+                    culture,
+                    "]2E-05 TO 32[",
+                    new IntervalExpression(
+                        min: new BoundaryExpression(new NumericValueExpression("2E-05"), included: false),
+                        max: new BoundaryExpression(new NumericValueExpression("32"), included: false))
+                );
+                cases.Add
+                (
+                    culture,
+                    "]-2E-05 TO 32[",
+                    new IntervalExpression(
+                        min: new BoundaryExpression(new NumericValueExpression("-2E-05"), included: false),
+                        max: new BoundaryExpression(new NumericValueExpression("32"), included: false))
+                );
+                cases.Add
+                (
+                    culture,
+                    "]+2E-05 TO 32[",
+                    new IntervalExpression(
+                        min: new BoundaryExpression(new NumericValueExpression("2E-05"), included: false),
+                        max: new BoundaryExpression(new NumericValueExpression("32"), included: false))
+                );
+                    
+                cases.Add
+                (
+                    culture,
+                    "[-9.867877565428173625E-05 TO -1[",
+                    new IntervalExpression(
+                        min: new BoundaryExpression(new NumericValueExpression("-9.867877565428173625E-05"), included: true),
+                        max: new BoundaryExpression(new NumericValueExpression("-1"), included: false))
+                );
+            }
+
+            return cases;
+        }
+    }
+
+    [Theory]
+    [MemberData(nameof(IntervalCases))]
+    public void Given_interval_as_string_Parser_should_parse_to_IntervalExpression(string culture, string input, IntervalExpression expected)
+    {
+        _cultureSwitcher.Run(culture, () =>
         {
             // Arrange
             _outputHelper.WriteLine($"input : '{input}'");
             TokenList<FilterToken> tokens = _tokenizer.Tokenize(input);
+
             _outputHelper.WriteLine($"Tokens : {StringifyTokens(tokens)}");
 
             // Act
-            FilterExpression expression = FilterTokenParser.And.Parse(tokens);
+            IntervalExpression expression = FilterTokenParser.Interval.Parse(tokens);
 
             // Assert
             AssertThatShould_parse(expression, expected);
-        }
+        });
+    }
 
-        [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
-        public void Should_parse_NotExpression(NotExpression expected)
+    [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
+    public void Should_parse_text(CultureInfo culture, TextExpression expected)
+    {
+        _cultureSwitcher.Run(culture, () =>
         {
             // Arrange
-            _outputHelper.WriteLine($"input : '{expected.EscapedParseableString}' ");
-            _outputHelper.WriteLine($"input (debug view) : '{expected:d}' ");
-            _outputHelper.WriteLine($"input (full view) : '{expected:f}' ");
+            _outputHelper.WriteLine($"Culture : '{culture.Name}'");
+            _outputHelper.WriteLine($"input : '{expected.EscapedParseableString}'");
             TokenList<FilterToken> tokens = _tokenizer.Tokenize(expected.EscapedParseableString);
-            
+            _outputHelper.WriteLine($"Tokens : {StringifyTokens(tokens)}");
+
             // Act
-            NotExpression expression = FilterTokenParser.Not.Parse(tokens);
+            TextExpression actual = FilterTokenParser.Text.Parse(tokens);
 
             // Assert
-            AssertThatShould_parse(expression, expected);
-            
-        }
+            AssertThatShould_parse(actual, expected);
+        });
+    }
 
-        public static TheoryData<string, NotExpression> NotParsingCases
-            => new()
-            {   
-                {
-                    "!!(w%A*@,2088-08-10)",
+    public static TheoryData<string, PropertyName> PropertyNameCases
+        => new()
+        {
+            {
+                "Firstname=Bruce",
+                new PropertyName("Firstname")
+            },
+
+            {
+                @"Henchmen[""Name""]=*rob*",
+                new PropertyName(@"Henchmen[""Name""]")
+            },
+
+            {
+                @"Henchmen[""Powers""][""Description""]=*strength*",
+                new PropertyName(@"Henchmen[""Powers""][""Description""]")
+            },
+
+            {
+                @"Henchmen[""first_name""]=*rob*",
+                new PropertyName(@"Henchmen[""first_name""]")
+            },
+
+            {
+                "first_name=Bruce",
+                new PropertyName("first_name")
+            },
+        };
+
+    [Theory]
+    [MemberData(nameof(PropertyNameCases))]
+    public void Should_parse_PropertyNameExpression(string input, PropertyName expected)
+    {
+        // Arrange
+        _outputHelper.WriteLine($"input : '{input}'");
+        TokenList<FilterToken> tokens = _tokenizer.Tokenize(input);
+
+        // Act
+        PropertyName expression = FilterTokenParser.Property.Parse(tokens);
+
+        // Assert
+        expression.Should()
+            .NotBeSameAs(expected).And
+            .Be(expected);
+    }
+
+    public static TheoryData<string, (PropertyName prop, FilterExpression expression)> CriterionCases
+        => new()
+        {
+            {
+                "Name=Vandal",
+                (
+                    new PropertyName("Name"),
+                    new StringValueExpression("Vandal")
+                )
+            },
+            {
+                "first_name=Vandal",
+                (
+                    new PropertyName("first_name"),
+                    new StringValueExpression("Vandal")
+                )
+            },
+            {
+                "Name=Vandal|Banner",
+                (
+                    new PropertyName("Name"),
+                    new OrExpression(new StringValueExpression("Vandal"), new StringValueExpression("Banner"))
+                )
+            },
+            {
+                "Name=Vandal|Banner",
+                (
+                    new PropertyName("Name"),
+                    new OrExpression(new StringValueExpression("Vandal"), new StringValueExpression("Banner"))
+                )
+            },
+            {
+                "Size=[10 TO 20]",
+                (
+                    new PropertyName("Size"),
+                    new IntervalExpression(min: new BoundaryExpression(new NumericValueExpression("10"),
+                            included: true),
+                        max: new BoundaryExpression(new NumericValueExpression("20"),
+                            included: true))
+                )
+            },
+            {
+                @"Acolytes[""Name""][""Superior""]=Vandal|Banner",
+                (
+                    new PropertyName(@"Acolytes[""Name""][""Superior""]"),
+                    new OrExpression(new StringValueExpression("Vandal"), new StringValueExpression("Banner"))
+                )
+            },
+            {
+                @"Appointment[""Date""]=]2012-10-19T15:03:45Z TO 2012-10-19T15:30:45+01:00[",
+                (
+                    new PropertyName(@"Appointment[""Date""]"),
+                    new IntervalExpression(min: new BoundaryExpression(new DateTimeExpression(new DateExpression(year: 2012, month: 10, day: 19 ),
+                                new TimeExpression(hours : 15, minutes: 03, seconds: 45),
+                                OffsetExpression.Zero),
+                            included: false),
+                        max: new BoundaryExpression(new DateTimeExpression(new DateExpression(year: 2012, month: 10, day: 19 ),
+                                new TimeExpression(hours : 15, minutes: 30, seconds: 45),
+                                new OffsetExpression(hours: 1)),
+                            included: false)
+                    )
+                )
+            },
+            {
+                "Name=*[Mm]an",
+                (
+                    new PropertyName("Name"),
+                    new OneOfExpression(new EndsWithExpression("Man"),
+                        new EndsWithExpression("man"))
+                )
+            },
+            {
+                "Name=[Bb]o[Bb]",
+                (
+                    new PropertyName("Name"),
+                    new OneOfExpression(new StringValueExpression("BoB"),
+                        new StringValueExpression("Bob"),
+                        new StringValueExpression("boB"),
+                        new StringValueExpression("bob"))
+                )
+            },
+            {
+                "Firstname=*Br[uU]",
+                (
+                    new PropertyName("Firstname"),
+                    new OneOfExpression(new EndsWithExpression("Bru"),
+                        new EndsWithExpression("BrU"))
+                )
+            },
+            {
+                "prop=!(((1908-09-30T00:31:33.127+05:13|2000-06-19)|(00:01:40.443|*))|((2003-05-27|89ae5244-2a98-16cc-6f99-d17658594604)|(s*|*0$)))",
+                (
+                    new PropertyName("prop"),
                     new NotExpression(
-                        new NotExpression(
-                            new GroupExpression(
-                                new AndExpression(
-                                    new StartsWithExpression("w%A") + new EndsWithExpression("@"),
-                                    new DateExpression(2088, 8, 10)
-                                )
-                            )
-                        )
-                    )
-                },
-                {
-                    "!!!!!(w%A*@,2088-08-10)",
-                    !!!!!new GroupExpression(
-                                new AndExpression(
-                                new StartsWithExpression("w%A") + new EndsWithExpression("@"),
-                                new DateExpression(2088, 8, 10)
-                                )
-                        )
-                },
-                {
-                    "!![50 TO 60]",
-                    !!new IntervalExpression(min: new BoundaryExpression(new NumericValueExpression("50"), true),
-                                             max: new BoundaryExpression(new NumericValueExpression("60"), true))
-                },
-                
-                {
-                    "!((word))",
-                    !new GroupExpression
-                    (
-                        new GroupExpression
-                        (
-                            new StringValueExpression("word")
-                        )
-                    )
-                },
-
-                {
-                    "!((1)|(2))",
-                    !new GroupExpression(
                         new OrExpression(
-                        new GroupExpression(
-                                new NumericValueExpression("1")
+                            new OrExpression(
+
+                                new OrExpression(new DateTimeExpression(new DateExpression(1908, 9, 30),
+                                        new TimeExpression(0, 31, 33, 127),
+                                        new OffsetExpression(hours: 5, minutes: 13)),
+                                    new DateExpression(2000, 6, 19)),
+                                new OrExpression(new TimeExpression(minutes: 1, seconds: 40, milliseconds: 443),
+                                    new EndsWithExpression(""))
                             ),
-                            new GroupExpression(
-                                    new NumericValueExpression("2")
-                                )
-                        )
-                    )
-                },
-                {
-                    (! (new StringValueExpression("5aa8f391") | new GroupExpression(new GroupExpression(new GroupExpression(new StringValueExpression("6P%")))))).EscapedParseableString,
-                    ! (new StringValueExpression("5aa8f391") | new GroupExpression(new GroupExpression(new GroupExpression(new StringValueExpression("6P%")))))
-                },
-                {
-                    (! (new StringValueExpression("5aa8f391") | new StringValueExpression("6P%"))).EscapedParseableString,
-                    ! (new StringValueExpression("5aa8f391") | new StringValueExpression("6P%"))
-                },
-                {
-                    // "!!(*gHuQ>a0\\!>\\:\t\\-\\021+o\\]AL2oVmf\\029\\!,*\"Oi\\012j8G]t:JK%H6m>+r{)[5\n6\"*)",
-                    (!!(new EndsWithExpression("gHuQ>a0!>:\t-\\021+o\\]AL2oVmf\\029!")
-                    &
-                    new ContainsExpression(new TextExpression("Oi\\012j8G]t:JK%H6m>+r{)[5\n6")))).EscapedParseableString,
-                    !!(
-                        new EndsWithExpression("gHuQ>a0!>:\t-\\021+o\\]AL2oVmf\\029!")
-                        &
-                        new ContainsExpression(new TextExpression("Oi\\012j8G]t:JK%H6m>+r{)[5\n6"))
-                    )
-                }
-
-            };
-
-        [Theory]
-        [MemberData(nameof(NotParsingCases))]
-        public void Given_NotExpression_as_parseable_string_Not_should_parse_the_input(string input, NotExpression expected)
-        {
-            // Arrange
-            _outputHelper.WriteLine($"input : '{input}'");
-            _outputHelper.WriteLine($"expected : {expected:d}");
-            TokenList<FilterToken> tokens = _tokenizer.Tokenize(input);
-            
-            _outputHelper.WriteLine(StringifyTokens(tokens));
-
-            // Act
-            NotExpression expression = FilterTokenParser.Not.Parse(tokens);
-            
-            _outputHelper.WriteLine($"Parsed expression : {expression:d}");
-
-            // Assert
-            AssertThatShould_parse(expression, expected);
-        }
-
-        public static TheoryData<string, OneOfExpression> OneOfExpressionCases
-            => new()
+                            new OrExpression(new OrExpression(new DateExpression(2003, 5, 27),
+                                    new GuidValueExpression("89ae5244-2a98-16cc-6f99-d17658594604")),
+                                new OrExpression(new StartsWithExpression("s"), new EndsWithExpression("0$"))
+                            )
+                        ))
+                )
+            },
             {
-                {
-                    "[Bb]",
-                    new OneOfExpression(new StringValueExpression("B"), new StringValueExpression("b"))
-                },
-
-                {
-                    "[Bb]ruce",
-                    new OneOfExpression(new StringValueExpression("Bruce"), new StringValueExpression("bruce"))
-                },
-
-                {
-                    "[Bb]at*",
-                    new OneOfExpression(new StartsWithExpression("Bat"), new StartsWithExpression("bat"))
-                },
-
-                {
-                    "Ma*[Nn]",
-                    new OneOfExpression(
-                        new StartsWithExpression("Ma") & new EndsWithExpression("N"),
-                        new StartsWithExpression("Ma") & new EndsWithExpression("n")
-                    )
-                },
-
-                {
-                    "cat[Ww]oman",
-                    new OneOfExpression(new StringValueExpression("catWoman"), new StringValueExpression("catwoman"))
-                },
-
-                {
-                    "*Br[Uu]",
-                    new OneOfExpression(new EndsWithExpression("BrU"), new EndsWithExpression("Bru"))
-                },
-
-                {
-                    "Bo[Bb]",
-                    new OneOfExpression(new StringValueExpression("BoB"), new StringValueExpression("Bob"))
-                },
-
-                {
-                    "[Bb]*ob",
-                    new OneOfExpression(new StartsWithExpression("B") & new EndsWithExpression("ob"),
-                                        new StartsWithExpression("b") &  new EndsWithExpression("ob"))
-                },
-
-                {
-                    "*[Mm]an",
-                    new OneOfExpression(new EndsWithExpression("Man"), new EndsWithExpression("man"))
-                },
-
-                {
-                    "*[Mm]",
-                    new OneOfExpression(new EndsWithExpression("M"), new EndsWithExpression("m"))
-                },
-
-                {
-                    "[a-z]",
-                    new OneOfExpression([ .. GetCharacters('a', 'z').Select(chr => new StringValueExpression(chr.ToString())) ])
-                },
-
-                {
-                    "[a-zA-Z0-9]",
-                    new OneOfExpression([.. GetCharacters('a', 'z').Concat(GetCharacters('A', 'Z'))
-                                                               .Concat(GetCharacters('0', '9'))
-                                                               .Select(chr => new StringValueExpression(chr.ToString()))
-                                                               ])
-                },
-
-                {
-                    "{Bat|Sup|Wonder}*",
+                "Nickname={Bat|Sup|Wonder}*",
+                (
+                    new PropertyName("Nickname"),
                     new OneOfExpression(new StartsWithExpression("Bat"),
-                                        new StartsWithExpression("Sup"),
-                                        new StartsWithExpression("Wonder"))
-                },
+                        new StartsWithExpression("Sup"),
+                        new StartsWithExpression("Wonder"))
+                )
+            },
 
-                {
-                    "[ab][cd]",
-                    new OneOfExpression(new StringValueExpression("ac"),
-                                        new StringValueExpression("ad"),
-                                        new StringValueExpression("bc"),
-                                        new StringValueExpression("bd"))
-                },
-
-                {
-                    "{Bat|Sup|Wonder}",
-                    new OneOfExpression(new StringValueExpression("Bat"),
-                                        new StringValueExpression("Sup"),
-                                        new StringValueExpression("Wonder"))
-                },
-                {
-                    "*m[ae]n",
-                    new OneOfExpression(new EndsWithExpression("man"),
-                                        new EndsWithExpression("men"))
-                }
-            };
-
-        private static IEnumerable<char> GetCharacters(char regexStart, char regexEnd)
-            => Enumerable.Range(regexStart, regexEnd - regexStart + 1)
-                         .Select(ascii => (char)ascii);
-
-        [Theory]
-        [MemberData(nameof(OneOfExpressionCases))]
-        public void Should_parse_OneOfExpression(string input, OneOfExpression expected)
-        {
-            // Arrange
-            _outputHelper.WriteLine($"input : '{input}'");
-            TokenList<FilterToken> tokens = _tokenizer.Tokenize(input);
-
-            // Act
-            OneOfExpression expression = FilterTokenParser.OneOf.Parse(tokens);
-
-            // Assert
-            AssertThatShould_parse(expression, expected);
-        }
-
-        [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
-        public void Given_bracket_expression_OneOf_can_parse_input(NonNull<BracketValue> bracketExpression)
-        {
-            // Arrange
-            string input = bracketExpression.Item.EscapedParseableString;
-            _outputHelper.WriteLine($"input : '{input}'");
-            TokenList<FilterToken> tokens = _tokenizer.Tokenize(input);
-
-            OneOfExpression expected = bracketExpression.Item switch
             {
-                ConstantBracketValue constant => new OneOfExpression([.. constant.Value.Select(chr => new StringValueExpression(chr.ToString()))]),
-                RangeBracketValue range => new OneOfExpression([.. Enumerable.Range(range.Start, range.End - range.Start + 1)
-                                                         .Select(ascii => (char)ascii)
-                                                         .Select(chr => new StringValueExpression(chr.ToString()))]),
-                _ => throw new NotSupportedException()
-            };
-
-            // Act
-            FilterExpression expression = FilterTokenParser.OneOf.Parse(tokens);
-
-            // Assert
-            expression.IsEquivalentTo(expected).ToProperty();
-        }
-
-        [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
-        public void Should_parse_Interval(CultureInfo culture, IntervalExpression expected)
-        {
-            _cultureSwitcher.Run(culture, () =>
+                "Value=!!5",
+                (
+                    new PropertyName("Value"),
+                    !!new NumericValueExpression("5")
+                )
+            },
             {
-                // Arrange
-                _outputHelper.WriteLine($"Culture : '{culture.Name}'");
-                _outputHelper.WriteLine($"input : '{expected.EscapedParseableString}'");
-                TokenList<FilterToken> tokens = _tokenizer.Tokenize(expected.EscapedParseableString);
-
-                // Act
-                IntervalExpression expression = FilterTokenParser.Interval.Parse(tokens);
-
-                // Assert
-                AssertThatShould_parse(expression, expected);
-            });
-        }
-
-        public static TheoryData<string, string, IntervalExpression> IntervalCases
-        {
-            get
+                @"Value=%f<\,N\:`aAp#*\)",
+                (
+                    new PropertyName("Value"),
+                    new StartsWithExpression(@"%f<,N:`aAp#") &  new EndsWithExpression(@")")
+                )
+            },
             {
-                TheoryData<string, string, IntervalExpression> cases = [];
-                string[] cultures = [string.Empty, "fr-FR", "en-GB", "en-US"];
-                foreach (string culture in cultures)
-                {
-                    cases.Add
-                    (
-                        culture,
-                        "[5 TO 5[",
-                        new IntervalExpression(new BoundaryExpression(new NumericValueExpression("5"), true), new BoundaryExpression(new NumericValueExpression("5"), false))
-                    );
-
-                    cases.Add
-                    (
-                        culture,
-                        "[1993-08-04T00:25:05.155Z TO 1908-06-08T03:18:46.745-09:50[",
-                        new IntervalExpression(new BoundaryExpression(new DateTimeExpression(new DateExpression(1993, 8, 4), new TimeExpression(0, 25, 5, 155), OffsetExpression.Zero), true),
-                                               new BoundaryExpression(new DateTimeExpression(new DateExpression(1908, 6, 8), new TimeExpression(3, 18, 46, 745), new OffsetExpression(NumericSign.Minus, 9, 50)), false))
-                    );
-
-                    cases.Add
-                    (
-                        culture,
-                        "]* TO 1963-06-03T15:53:44.609Z]",
-                        new IntervalExpression(max: new BoundaryExpression(new DateTimeExpression(new DateExpression(1963, 6, 3), new TimeExpression(15, 53, 44, 609), OffsetExpression.Zero), true))
-                    );
-
-                    cases.Add
-                    (
-                        culture,
-                        "]2E-05 TO 32[",
-                        new IntervalExpression(
-                            min: new BoundaryExpression(new NumericValueExpression("2E-05"), included: false),
-                            max: new BoundaryExpression(new NumericValueExpression("32"), included: false))
-                    );
-                    cases.Add
-                    (
-                        culture,
-                        "]-2E-05 TO 32[",
-                        new IntervalExpression(
-                            min: new BoundaryExpression(new NumericValueExpression("-2E-05"), included: false),
-                            max: new BoundaryExpression(new NumericValueExpression("32"), included: false))
-                    );
-                    cases.Add
-                    (
-                        culture,
-                        "]+2E-05 TO 32[",
-                        new IntervalExpression(
-                            min: new BoundaryExpression(new NumericValueExpression("2E-05"), included: false),
-                            max: new BoundaryExpression(new NumericValueExpression("32"), included: false))
-                    );
-                    
-                    cases.Add
-                    (
-                        culture,
-                        "[-9.867877565428173625E-05 TO -1[",
-                        new IntervalExpression(
-                            min: new BoundaryExpression(new NumericValueExpression("-9.867877565428173625E-05"), included: true),
-                            max: new BoundaryExpression(new NumericValueExpression("-1"), included: false))
-                    );
-                }
-
-                return cases;
+                $"Prop={(new StartsWithExpression(@"1\.\""Foo\!") & new ContainsExpression(@"2\.\""Bar\!")).EscapedParseableString}",
+                (
+                    new PropertyName("Prop"),
+                    new StartsWithExpression(@"1\.\""Foo\!") & new ContainsExpression(@"2\.\""Bar\!")
+                )
+            },
+            {
+                $"Prop={(new EndsWithExpression("Foo") & new ContainsExpression("Bar")).EscapedParseableString}",
+                (
+                    new PropertyName("Prop"),
+                    new EndsWithExpression("Foo") & new ContainsExpression("Bar")
+                )
             }
-        }
-
-        [Theory]
-        [MemberData(nameof(IntervalCases))]
-        public void Given_interval_as_string_Parser_should_parse_to_IntervalExpression(string culture, string input, IntervalExpression expected)
-        {
-            _cultureSwitcher.Run(culture, () =>
+            ,
             {
-                // Arrange
-                _outputHelper.WriteLine($"input : '{input}'");
-                TokenList<FilterToken> tokens = _tokenizer.Tokenize(input);
-
-                _outputHelper.WriteLine($"Tokens : {StringifyTokens(tokens)}");
-
-                // Act
-                IntervalExpression expression = FilterTokenParser.Interval.Parse(tokens);
-
-                // Assert
-                AssertThatShould_parse(expression, expected);
-            });
-        }
-
-        [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
-        public void Should_parse_text(CultureInfo culture, TextExpression expected)
-        {
-            _cultureSwitcher.Run(culture, () =>
-            {
-                // Arrange
-                _outputHelper.WriteLine($"Culture : '{culture.Name}'");
-                _outputHelper.WriteLine($"input : '{expected.EscapedParseableString}'");
-                TokenList<FilterToken> tokens = _tokenizer.Tokenize(expected.EscapedParseableString);
-                _outputHelper.WriteLine($"Tokens : {StringifyTokens(tokens)}");
-
-                // Act
-                TextExpression actual = FilterTokenParser.Text.Parse(tokens);
-
-                // Assert
-                AssertThatShould_parse(actual, expected);
-            });
-        }
-
-        public static TheoryData<string, PropertyName> PropertyNameCases
-            => new()
-            {
-                {
-                    "Firstname=Bruce",
-                    new PropertyName("Firstname")
-                },
-
-                {
-                    @"Henchmen[""Name""]=*rob*",
-                    new PropertyName(@"Henchmen[""Name""]")
-                },
-
-                {
-                    @"Henchmen[""Powers""][""Description""]=*strength*",
-                    new PropertyName(@"Henchmen[""Powers""][""Description""]")
-                },
-
-                {
-                    @"Henchmen[""first_name""]=*rob*",
-                    new PropertyName(@"Henchmen[""first_name""]")
-                },
-
-                {
-                    "first_name=Bruce",
-                    new PropertyName("first_name")
-                },
-            };
-
-        [Theory]
-        [MemberData(nameof(PropertyNameCases))]
-        public void Should_parse_PropertyNameExpression(string input, PropertyName expected)
-        {
-            // Arrange
-            _outputHelper.WriteLine($"input : '{input}'");
-            TokenList<FilterToken> tokens = _tokenizer.Tokenize(input);
-
-            // Act
-            PropertyName expression = FilterTokenParser.Property.Parse(tokens);
-
-            // Assert
-            expression.Should()
-                      .NotBeSameAs(expected).And
-                      .Be(expected);
-        }
-
-        public static TheoryData<string, (PropertyName prop, FilterExpression expression)> CriterionCases
-            => new()
-            {
-                {
-                    "Name=Vandal",
-                    (
-                        new PropertyName("Name"),
-                        new StringValueExpression("Vandal")
-                    )
-                },
-                {
-                    "first_name=Vandal",
-                    (
-                        new PropertyName("first_name"),
-                        new StringValueExpression("Vandal")
-                    )
-                },
-                {
-                    "Name=Vandal|Banner",
-                    (
-                        new PropertyName("Name"),
-                        new OrExpression(new StringValueExpression("Vandal"), new StringValueExpression("Banner"))
-                    )
-                },
-                {
-                    "Name=Vandal|Banner",
-                    (
-                        new PropertyName("Name"),
-                        new OrExpression(new StringValueExpression("Vandal"), new StringValueExpression("Banner"))
-                    )
-                },
-                {
-                    "Size=[10 TO 20]",
-                    (
-                        new PropertyName("Size"),
-                        new IntervalExpression(min: new BoundaryExpression(new NumericValueExpression("10"),
-                                                                                           included: true),
-                                                               max: new BoundaryExpression(new NumericValueExpression("20"),
-                                                                                           included: true))
-                    )
-                },
-                {
-                    @"Acolytes[""Name""][""Superior""]=Vandal|Banner",
-                    (
-                        new PropertyName(@"Acolytes[""Name""][""Superior""]"),
-                        new OrExpression(new StringValueExpression("Vandal"), new StringValueExpression("Banner"))
-                    )
-                },
-                {
-                    @"Appointment[""Date""]=]2012-10-19T15:03:45Z TO 2012-10-19T15:30:45+01:00[",
-                    (
-                        new PropertyName(@"Appointment[""Date""]"),
-                        new IntervalExpression(min: new BoundaryExpression(new DateTimeExpression(new DateExpression(year: 2012, month: 10, day: 19 ),
-                                                                                                  new TimeExpression(hours : 15, minutes: 03, seconds: 45),
-                                                                                                  OffsetExpression.Zero),
-                                                                           included: false),
-                                              max: new BoundaryExpression(new DateTimeExpression(new DateExpression(year: 2012, month: 10, day: 19 ),
-                                                                                                 new TimeExpression(hours : 15, minutes: 30, seconds: 45),
-                                                                                                 new OffsetExpression(hours: 1)),
-                                                                          included: false)
-                        )
-                    )
-                },
-                {
-                    "Name=*[Mm]an",
-                    (
-                        new PropertyName("Name"),
-                        new OneOfExpression(new EndsWithExpression("Man"),
-                                            new EndsWithExpression("man"))
-                    )
-                },
-                {
-                    "Name=[Bb]o[Bb]",
-                    (
-                        new PropertyName("Name"),
-                        new OneOfExpression(new StringValueExpression("BoB"),
-                                            new StringValueExpression("Bob"),
-                                            new StringValueExpression("boB"),
-                                            new StringValueExpression("bob"))
-                    )
-                },
-                {
-                    "Firstname=*Br[uU]",
-                    (
-                        new PropertyName("Firstname"),
-                        new OneOfExpression(new EndsWithExpression("Bru"),
-                                            new EndsWithExpression("BrU"))
-                    )
-                },
-                {
-                    "prop=!(((1908-09-30T00:31:33.127+05:13|2000-06-19)|(00:01:40.443|*))|((2003-05-27|89ae5244-2a98-16cc-6f99-d17658594604)|(s*|*0$)))",
-                    (
-                        new PropertyName("prop"),
-                        new NotExpression(
-                                new OrExpression(
-                                new OrExpression(
-
-                                        new OrExpression(new DateTimeExpression(new DateExpression(1908, 9, 30),
-                                                                                          new TimeExpression(0, 31, 33, 127),
-                                                                                          new OffsetExpression(hours: 5, minutes: 13)),
-                                                              new DateExpression(2000, 6, 19)),
-                                        new OrExpression(new TimeExpression(minutes: 1, seconds: 40, milliseconds: 443),
-                                                              new EndsWithExpression(""))
-                                    ),
-                                        new OrExpression(new OrExpression(new DateExpression(2003, 5, 27),
-                                                                                    new GuidValueExpression("89ae5244-2a98-16cc-6f99-d17658594604")),
-                                                              new OrExpression(new StartsWithExpression("s"), new EndsWithExpression("0$"))
-                                        )
-                                ))
-                    )
-                },
-                {
-                    "Nickname={Bat|Sup|Wonder}*",
-                    (
-                        new PropertyName("Nickname"),
-                        new OneOfExpression(new StartsWithExpression("Bat"),
-                                            new StartsWithExpression("Sup"),
-                                            new StartsWithExpression("Wonder"))
-                    )
-                },
-
-                {
-                    "Value=!!5",
-                    (
-                        new PropertyName("Value"),
-                        !!new NumericValueExpression("5")
-                    )
-                },
-                {
-                    @"Value=%f<\,N\:`aAp#*\)",
-                    (
-                        new PropertyName("Value"),
-                        new StartsWithExpression(@"%f<,N:`aAp#") &  new EndsWithExpression(@")")
-                    )
-                },
-                {
-                    $"Prop={(new StartsWithExpression(@"1\.\""Foo\!") & new ContainsExpression(@"2\.\""Bar\!")).EscapedParseableString}",
-                    (
-                        new PropertyName("Prop"),
-                        new StartsWithExpression(@"1\.\""Foo\!") & new ContainsExpression(@"2\.\""Bar\!")
-                    )
-                },
-                {
-                    $"Prop={(new EndsWithExpression("Foo") & new ContainsExpression("Bar")).EscapedParseableString}",
-                    (
-                        new PropertyName("Prop"),
-                        new EndsWithExpression("Foo") & new ContainsExpression("Bar")
-                    )
-                }
-                ,
-                {
-                    $"Prop={(new ContainsExpression("Foo") & new EndsWithExpression("Bar")).EscapedParseableString}",
-                    (
-                        new PropertyName("Prop"),
-                        new ContainsExpression("Foo") & new EndsWithExpression("Bar")
-                    )
-                }
-            };
-
-        /// <summary>
-        /// Tests if <see cref="FilterTokenParser.Criteria"/> can parse a criteria
-        /// </summary>
-        /// <param name="input"></param>
-        /// <param name="expected"></param>
-        [Theory]
-        [MemberData(nameof(CriterionCases))]
-        public void Should_parse_Criterion(string input, (PropertyName prop, FilterExpression expression) expected)
-        {
-            _outputHelper.WriteLine($"{nameof(input)} : '{input}'");
-
-            // Arrange
-            TokenList<FilterToken> tokens = _tokenizer.Tokenize(input);
-
-            // Act
-            (PropertyName prop, FilterExpression expression) = FilterTokenParser.Criterion.Parse(tokens);
-
-            // Assert
-            using AssertionScope _ = new();
-            prop.Should()
-                .NotBeSameAs(expected.prop).And
-                .Be(expected.prop);
-
-            expression.Should()
-                .NotBeSameAs(expected.expression).And
-                .Be(expected.expression);
-        }
-
-        public static TheoryData<string, Expression<Func<IEnumerable<(PropertyName prop, FilterExpression expression)>, bool>>> CriteriaCases
-        {
-            get
-            {
-                TheoryData<string, Expression<Func<IEnumerable<(PropertyName prop, FilterExpression expression)>, bool>>> cases = new()
-                {
-                    {
-                        "Firstname=Vandal&Lastname=Savage",
-                        expressions => expressions.Exactly(2)
-                            && expressions.Once(expr => expr.prop.Equals(new PropertyName("Firstname")) && expr.expression.Equals(new StringValueExpression("Vandal")))
-                            && expressions.Once(expr => expr.prop.Equals(new PropertyName("Lastname")) && expr.expression.Equals(new StringValueExpression("Savage")))
-
-                    },
-                    {
-                        "Firstname=[Vv]andal",
-                        expressions => expressions.Exactly(1)
-                            && expressions.Once(expr => expr.prop.Equals(new PropertyName("Firstname"))
-                                && expr.expression.Equals(new OneOfExpression(new StringValueExpression("Vandal"),
-                                                                                  new StringValueExpression("vandal"))))
-                    }
-                };
-
-                foreach (char c in FilterTokenizer.SpecialCharacters)
-                {
-                    cases.Add
-                    (
-                        $@"Firstname=Vand\{c}al&Lastname=Savage",
-                        expressions => expressions.Exactly(2)
-                               && expressions.Once(expr => expr.prop.Equals(new PropertyName("Firstname")) && expr.expression.Equals(new StringValueExpression($"Vand{c}al")))
-                               && expressions.Once(expr => expr.prop.Equals(new PropertyName("Lastname")) && expr.expression.Equals(new StringValueExpression("Savage")))
-                    );
-                }
-
-                foreach (char c in FilterTokenizer.SpecialCharacters)
-                {
-                    cases.Add
-                    (
-                        $@"first_name=Vand\{c}al&last_name=Savage",
-                        expressions => expressions.Exactly(2)
-                               && expressions.Once(expr => expr.prop.Equals(new PropertyName("first_name")) && expr.expression.Equals(new StringValueExpression($"Vand{c}al")))
-                               && expressions.Once(expr => expr.prop.Equals(new PropertyName("last_name")) && expr.expression.Equals(new StringValueExpression("Savage")))
-                    );
-                }
-
-                return cases;
+                $"Prop={(new ContainsExpression("Foo") & new EndsWithExpression("Bar")).EscapedParseableString}",
+                (
+                    new PropertyName("Prop"),
+                    new ContainsExpression("Foo") & new EndsWithExpression("Bar")
+                )
             }
-        }
+        };
 
-        /// <summary>
-        /// Tests if <see cref="FilterTokenParser.Criteria"/> can parse a criteria
-        /// </summary>
-        /// <param name="input"></param>
-        /// <param name="expectation"></param>
-        [Theory]
-        [MemberData(nameof(CriteriaCases))]
-        public void Should_parse_Criteria(string input, Expression<Func<IEnumerable<(PropertyName prop, FilterExpression expression)>, bool>> expectation)
+    /// <summary>
+    /// Tests if <see cref="FilterTokenParser.Criteria"/> can parse a criteria
+    /// </summary>
+    /// <param name="input"></param>
+    /// <param name="expected"></param>
+    [Theory]
+    [MemberData(nameof(CriterionCases))]
+    public void Should_parse_Criterion(string input, (PropertyName prop, FilterExpression expression) expected)
+    {
+        _outputHelper.WriteLine($"{nameof(input)} : '{input}'");
+
+        // Arrange
+        TokenList<FilterToken> tokens = _tokenizer.Tokenize(input);
+
+        // Act
+        (PropertyName prop, FilterExpression expression) = FilterTokenParser.Criterion.Parse(tokens);
+
+        // Assert
+        using AssertionScope _ = new();
+        prop.Should()
+            .NotBeSameAs(expected.prop).And
+            .Be(expected.prop);
+
+        expression.Should()
+            .NotBeSameAs(expected.expression).And
+            .Be(expected.expression);
+    }
+
+    public static TheoryData<string, Expression<Func<IEnumerable<(PropertyName prop, FilterExpression expression)>, bool>>> CriteriaCases
+    {
+        get
         {
-            // Arrange
-            _outputHelper.WriteLine($"input : '{input}'");
-            TokenList<FilterToken> tokens = _tokenizer.Tokenize(input);
-
-            // Act
-            IEnumerable<(PropertyName prop, FilterExpression expression)> actual = FilterTokenParser.Criteria.Parse(tokens);
-
-            // Assert
-            actual.Should()
-                .Match(expectation);
-        }
-
-        [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
-        public void Should_parse_DateAndTime(DateTimeExpression expected)
-        {
-            // Arrange
-            _outputHelper.WriteLine($"input : '{expected.EscapedParseableString}'");
-            TokenList<FilterToken> tokens = _tokenizer.Tokenize(expected.EscapedParseableString);
-
-            // Act
-            DateTimeExpression actual = FilterTokenParser.DateAndTime.Parse(tokens);
-
-            // Assert
-            AssertThatShould_parse(actual, expected);
-        }
-
-        [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
-        public void Should_parse_DateCases(DateExpression expected)
-        {
-            // Arrange
-            _outputHelper.WriteLine($"input : '{expected.EscapedParseableString}'");
-            TokenList<FilterToken> tokens = _tokenizer.Tokenize(expected.EscapedParseableString);
-
-            // Act
-            DateExpression actual = FilterTokenParser.Date.Parse(tokens);
-
-            // Assert
-            AssertThatShould_parse(actual, expected);
-        }
-
-        [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
-        public void Should_parse_Groups(GroupExpression expected)
-        {
-            // Arrange
-            _outputHelper.WriteLine($"input : '{expected.EscapedParseableString}'");
-            TokenList<FilterToken> tokens = _tokenizer.Tokenize(expected.EscapedParseableString);
-
-            // Act
-            GroupExpression actual = FilterTokenParser.Group.Parse(tokens);
-
-            // Assert
-            AssertThatShould_parse(actual, expected);
-        }
-
-        public static TheoryData<GroupExpression> ParseGroupCases
-            => new()
+            TheoryData<string, Expression<Func<IEnumerable<(PropertyName prop, FilterExpression expression)>, bool>>> cases = new()
             {
-                new GroupExpression(new DateTimeExpression(new DateExpression(2090, 10, 10),
-                    new TimeExpression(3, 0, 40, 583), OffsetExpression.Zero)),
-                new GroupExpression(new DateTimeExpression(new DateExpression(2010, 06, 02),
-                    new TimeExpression(23, 45, 54, 331), OffsetExpression.Zero)),
+                {
+                    "Firstname=Vandal&Lastname=Savage",
+                    expressions => expressions.Exactly(2)
+                                   && expressions.Once(expr => expr.prop.Equals(new PropertyName("Firstname")) && expr.expression.Equals(new StringValueExpression("Vandal")))
+                                   && expressions.Once(expr => expr.prop.Equals(new PropertyName("Lastname")) && expr.expression.Equals(new StringValueExpression("Savage")))
+
+                },
+                {
+                    "Firstname=[Vv]andal",
+                    expressions => expressions.Exactly(1)
+                                   && expressions.Once(expr => expr.prop.Equals(new PropertyName("Firstname"))
+                                                               && expr.expression.Equals(new OneOfExpression(new StringValueExpression("Vandal"),
+                                                                   new StringValueExpression("vandal"))))
+                }
             };
+
+            foreach (char c in FilterTokenizer.SpecialCharacters)
+            {
+                cases.Add
+                (
+                    $@"Firstname=Vand\{c}al&Lastname=Savage",
+                    expressions => expressions.Exactly(2)
+                                   && expressions.Once(expr => expr.prop.Equals(new PropertyName("Firstname")) && expr.expression.Equals(new StringValueExpression($"Vand{c}al")))
+                                   && expressions.Once(expr => expr.prop.Equals(new PropertyName("Lastname")) && expr.expression.Equals(new StringValueExpression("Savage")))
+                );
+            }
+
+            foreach (char c in FilterTokenizer.SpecialCharacters)
+            {
+                cases.Add
+                (
+                    $@"first_name=Vand\{c}al&last_name=Savage",
+                    expressions => expressions.Exactly(2)
+                                   && expressions.Once(expr => expr.prop.Equals(new PropertyName("first_name")) && expr.expression.Equals(new StringValueExpression($"Vand{c}al")))
+                                   && expressions.Once(expr => expr.prop.Equals(new PropertyName("last_name")) && expr.expression.Equals(new StringValueExpression("Savage")))
+                );
+            }
+
+            return cases;
+        }
+    }
+
+    /// <summary>
+    /// Tests if <see cref="FilterTokenParser.Criteria"/> can parse a criteria
+    /// </summary>
+    /// <param name="input"></param>
+    /// <param name="expectation"></param>
+    [Theory]
+    [MemberData(nameof(CriteriaCases))]
+    public void Should_parse_Criteria(string input, Expression<Func<IEnumerable<(PropertyName prop, FilterExpression expression)>, bool>> expectation)
+    {
+        // Arrange
+        _outputHelper.WriteLine($"input : '{input}'");
+        TokenList<FilterToken> tokens = _tokenizer.Tokenize(input);
+
+        // Act
+        IEnumerable<(PropertyName prop, FilterExpression expression)> actual = FilterTokenParser.Criteria.Parse(tokens);
+
+        // Assert
+        actual.Should()
+            .Match(expectation);
+    }
+
+    [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
+    public void Should_parse_DateAndTime(DateTimeExpression expected)
+    {
+        // Arrange
+        _outputHelper.WriteLine($"input : '{expected.EscapedParseableString}'");
+        TokenList<FilterToken> tokens = _tokenizer.Tokenize(expected.EscapedParseableString);
+
+        // Act
+        DateTimeExpression actual = FilterTokenParser.DateAndTime.Parse(tokens);
+
+        // Assert
+        AssertThatShould_parse(actual, expected);
+    }
+
+    [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
+    public void Should_parse_DateCases(DateExpression expected)
+    {
+        // Arrange
+        _outputHelper.WriteLine($"input : '{expected.EscapedParseableString}'");
+        TokenList<FilterToken> tokens = _tokenizer.Tokenize(expected.EscapedParseableString);
+
+        // Act
+        DateExpression actual = FilterTokenParser.Date.Parse(tokens);
+
+        // Assert
+        AssertThatShould_parse(actual, expected);
+    }
+
+    [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
+    public void Should_parse_Groups(GroupExpression expected)
+    {
+        // Arrange
+        _outputHelper.WriteLine($"input : '{expected.EscapedParseableString}'");
+        TokenList<FilterToken> tokens = _tokenizer.Tokenize(expected.EscapedParseableString);
+
+        // Act
+        GroupExpression actual = FilterTokenParser.Group.Parse(tokens);
+
+        // Assert
+        AssertThatShould_parse(actual, expected);
+    }
+
+    public static TheoryData<GroupExpression> ParseGroupCases
+        => new()
+        {
+            new GroupExpression(new DateTimeExpression(new DateExpression(2090, 10, 10),
+                new TimeExpression(3, 0, 40, 583), OffsetExpression.Zero)),
+            new GroupExpression(new DateTimeExpression(new DateExpression(2010, 06, 02),
+                new TimeExpression(23, 45, 54, 331), OffsetExpression.Zero)),
+        };
         
 
-        [Theory]
-        [MemberData(nameof(ParseGroupCases))]
-        public void Given_GroupExpression_EscapedParseableString_as_input_Parser_should_return_GroupExpression_that_is_equivalent_to_input(GroupExpression expected)
+    [Theory]
+    [MemberData(nameof(ParseGroupCases))]
+    public void Given_GroupExpression_EscapedParseableString_as_input_Parser_should_return_GroupExpression_that_is_equivalent_to_input(GroupExpression expected)
+    {
+        _outputHelper.WriteLine($"Current culture is '{_cultureSwitcher.CurrentCulture}'");
+        _outputHelper.WriteLine($"input : '{expected.EscapedParseableString}'");
+        TokenList<FilterToken> tokens = _tokenizer.Tokenize(expected.EscapedParseableString);
+
+        // Act
+        GroupExpression actual = FilterTokenParser.Group.Parse(tokens);
+
+        // Assert
+        AssertThatShould_parse(actual, expected);
+    }
+
+    public static TheoryData<CultureInfo, NumericValueExpression> ParseNumberCases
+        => new ()
+        {
+            {
+                CultureInfo.InvariantCulture,
+                new NumericValueExpression(float.MinValue.ToString(CultureInfo.InvariantCulture))
+            },
+            {
+                CultureInfo.InvariantCulture,
+                new NumericValueExpression(float.MaxValue.ToString(CultureInfo.InvariantCulture))
+            },
+            {
+                CultureInfo.InvariantCulture,
+                new NumericValueExpression("2E-05")
+            }
+        };
+        
+    [Theory]
+    [MemberData(nameof(ParseNumberCases))]
+    public void Should_parse_Number(CultureInfo culture, NumericValueExpression expected)
+    {
+        _cultureSwitcher.Run(culture, () =>
         {
             _outputHelper.WriteLine($"Current culture is '{_cultureSwitcher.CurrentCulture}'");
             _outputHelper.WriteLine($"input : '{expected.EscapedParseableString}'");
             TokenList<FilterToken> tokens = _tokenizer.Tokenize(expected.EscapedParseableString);
 
             // Act
-            GroupExpression actual = FilterTokenParser.Group.Parse(tokens);
+            NumericValueExpression actual = FilterTokenParser.Number.Parse(tokens);
 
             // Assert
             AssertThatShould_parse(actual, expected);
-        }
+        });
+    }
 
-        public static TheoryData<CultureInfo, NumericValueExpression> ParseNumberCases
-            => new ()
-            {
-                {
-                    CultureInfo.InvariantCulture,
-                    new NumericValueExpression(float.MinValue.ToString(CultureInfo.InvariantCulture))
-                },
-                {
-                    CultureInfo.InvariantCulture,
-                    new NumericValueExpression(float.MaxValue.ToString(CultureInfo.InvariantCulture))
-                },
-                {
-                    CultureInfo.InvariantCulture,
-                    new NumericValueExpression("2E-05")
-                }
-            };
+
+    [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
+    public void Should_parse_TimeExpression(NonNull<TimeExpression> expected)
+    {
+        // Arrange
+        _outputHelper.WriteLine($"input : '{expected.Item.EscapedParseableString}'");
+        TokenList<FilterToken> tokens = _tokenizer.Tokenize(expected.Item.EscapedParseableString);
+
+        // Act
+        TimeExpression actual = FilterTokenParser.Time.Parse(tokens);
+
+        // Assert
+        AssertThatShould_parse(actual, expected.Item);
+    }
         
-        [Theory]
-        [MemberData(nameof(ParseNumberCases))]
-        public void Should_parse_Number(CultureInfo culture, NumericValueExpression expected)
-        {
-            _cultureSwitcher.Run(culture, () =>
-            {
-                _outputHelper.WriteLine($"Current culture is '{_cultureSwitcher.CurrentCulture}'");
-                _outputHelper.WriteLine($"input : '{expected.EscapedParseableString}'");
-                TokenList<FilterToken> tokens = _tokenizer.Tokenize(expected.EscapedParseableString);
+    [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
+    public void Should_parse_DurationExpression(DurationExpression expected)
+    {
+        // Arrange
+        _outputHelper.WriteLine($"input : '{expected.EscapedParseableString}'");
+        TokenList<FilterToken> tokens = _tokenizer.Tokenize(expected.EscapedParseableString);
 
-                // Act
-                NumericValueExpression actual = FilterTokenParser.Number.Parse(tokens);
+        // Act
+        DurationExpression actual = FilterTokenParser.Duration.Parse(tokens);
 
-                // Assert
-                AssertThatShould_parse(actual, expected);
-            });
-        }
+        // Assert
+        AssertThatShould_parse(actual, expected);
+    }
 
+    [Theory]
+    [InlineData("P", "time separator and duration unit are missing")]
+    [InlineData("P1Y", "the time separator 'T' is missing after the 'year' duration")]
+    [InlineData("P0S", "the time separator 'T' is missing before the 'second' duration")]
+    [InlineData("PT", "the duration string does not contain any duration")]
+    public void Given_incorrect_input_for_duration_Parser_should_throw_ParseException(string input, string reason)
+    {
+        // Arrange
+        _outputHelper.WriteLine($"input : '{input}'");
+        TokenList<FilterToken> tokens = _tokenizer.Tokenize(input);
 
-        [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
-        public void Should_parse_TimeExpression(NonNull<TimeExpression> expected)
-        {
-            // Arrange
-            _outputHelper.WriteLine($"input : '{expected.Item.EscapedParseableString}'");
-            TokenList<FilterToken> tokens = _tokenizer.Tokenize(expected.Item.EscapedParseableString);
+        // Act
+        Action callingParserWithInvalidStringInput = () => FilterTokenParser.Duration.Parse(tokens);
 
-            // Act
-            TimeExpression actual = FilterTokenParser.Time.Parse(tokens);
+        // Assert
+        AssertThatParseExceptionIsThrown(callingParserWithInvalidStringInput, reason);
+    }
 
-            // Assert
-            AssertThatShould_parse(actual, expected.Item);
-        }
-        
-        [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
-        public void Should_parse_DurationExpression(DurationExpression expected)
-        {
-            // Arrange
-            _outputHelper.WriteLine($"input : '{expected.EscapedParseableString}'");
-            TokenList<FilterToken> tokens = _tokenizer.Tokenize(expected.EscapedParseableString);
+    /// <summary>
+    /// Asserts that <paramref name="actual"/> and <paramref name="expected"/> are
+    /// <list type="bullet">
+    ///     <item>not the same :</item>
+    ///     <item>equal</item>
+    /// </list> 
+    /// </summary>
+    /// <param name="actual">The expression onto which to make assertions.</param>
+    /// <param name="expected">The reference expression</param>
+    /// <param name="reason">a string that will be displayed if the assertion fails</param>
+    private static void AssertThatShould_parse(FilterExpression actual, FilterExpression expected, string reason = "")
+        => actual.Should()
+            .NotBeSameAs(expected).And
+            .Be(expected, reason);
 
-            // Act
-            DurationExpression actual = FilterTokenParser.Duration.Parse(tokens);
-
-            // Assert
-            AssertThatShould_parse(actual, expected);
-        }
-
-        [Theory]
-        [InlineData("P", "time separator and duration unit are missing")]
-        [InlineData("P1Y", "the time separator 'T' is missing after the 'year' duration")]
-        [InlineData("P0S", "the time separator 'T' is missing before the 'second' duration")]
-        [InlineData("PT", "the duration string does not contain any duration")]
-        public void Given_incorrect_input_for_duration_Parser_should_throw_ParseException(string input, string reason)
-        {
-            // Arrange
-            _outputHelper.WriteLine($"input : '{input}'");
-            TokenList<FilterToken> tokens = _tokenizer.Tokenize(input);
-
-            // Act
-            Action callingParserWithInvalidStringInput = () => FilterTokenParser.Duration.Parse(tokens);
-
-            // Assert
-            AssertThatParseExceptionIsThrown(callingParserWithInvalidStringInput, reason);
-        }
-
-        /// <summary>
-        /// Asserts that <paramref name="actual"/> and <paramref name="expected"/> are
-        /// <list type="bullet">
-        ///     <item>not the same :</item>
-        ///     <item>equal</item>
-        /// </list> 
-        /// </summary>
-        /// <param name="actual">The expression onto which to make assertions.</param>
-        /// <param name="expected">The reference expression</param>
-        /// <param name="reason">a string that will be displayed if the assertion fails</param>
-        private static void AssertThatShould_parse(FilterExpression actual, FilterExpression expected, string reason = "")
-            => actual.Should()
-                     .NotBeSameAs(expected).And
-                     .Be(expected, reason);
-
-        private static void AssertThatParseExceptionIsThrown(Action action, string reason)
-        {
-            // Act
-            action.Should().ThrowExactly<ParseException>(reason);
-        }
+    private static void AssertThatParseExceptionIsThrown(Action action, string reason)
+    {
+        // Act
+        action.Should().ThrowExactly<ParseException>(reason);
     }
 }

--- a/test/DataFilters.UnitTests/Grammar/Parsing/FilterTokenizerTests.cs
+++ b/test/DataFilters.UnitTests/Grammar/Parsing/FilterTokenizerTests.cs
@@ -1,36 +1,36 @@
-﻿namespace DataFilters.UnitTests.Grammar.Parsing
+﻿namespace DataFilters.UnitTests.Grammar.Parsing;
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using DataFilters.Grammar.Parsing;
+using FluentAssertions;
+using Superpower;
+using Superpower.Model;
+using Xunit;
+using Xunit.Abstractions;
+using Xunit.Categories;
+using static DataFilters.Grammar.Parsing.FilterToken;
+
+[UnitTest]
+[Feature(nameof(DataFilters.Grammar.Parsing))]
+[Feature(nameof(FilterTokenizer))]
+public class FilterTokenizerTests(ITestOutputHelper outputHelper)
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Linq;
-    using System.Linq.Expressions;
-    using DataFilters.Grammar.Parsing;
-    using FluentAssertions;
-    using Superpower;
-    using Superpower.Model;
-    using Xunit;
-    using Xunit.Abstractions;
-    using Xunit.Categories;
-    using static DataFilters.Grammar.Parsing.FilterToken;
+    private readonly FilterTokenizer _sut = new();
 
-    [UnitTest]
-    [Feature(nameof(DataFilters.Grammar.Parsing))]
-    [Feature(nameof(FilterTokenizer))]
-    public class FilterTokenizerTests(ITestOutputHelper outputHelper)
+    [Fact]
+    public void IsTokenizer() => typeof(FilterTokenizer).Should()
+        .HaveDefaultConstructor().And
+        .BeAssignableTo<Tokenizer<FilterToken>>();
+
+    public static TheoryData<string, Expression<Func<TokenList<FilterToken>, bool>>> RecognizeTokensCases
     {
-        private readonly FilterTokenizer _sut = new();
-
-        [Fact]
-        public void IsTokenizer() => typeof(FilterTokenizer).Should()
-                                                            .HaveDefaultConstructor().And
-                                                            .BeAssignableTo<Tokenizer<FilterToken>>();
-
-        public static TheoryData<string, Expression<Func<TokenList<FilterToken>, bool>>> RecognizeTokensCases
+        get
         {
-            get
+            TheoryData<string, Expression<Func<TokenList<FilterToken>, bool>>> cases = new()
             {
-                TheoryData<string, Expression<Func<TokenList<FilterToken>, bool>>> cases = new()
-                {
                 {
                     "Firstname=Bruce",
                     results => results.Exactly(15)
@@ -180,7 +180,7 @@
                 {
                     " ",
                     results => results.Once()
-                                                                                && results.Once(result => result.Kind == Whitespace && result.Span.EqualsValue(" "))
+                               && results.Once(result => result.Kind == Whitespace && result.Span.EqualsValue(" "))
 
                 },
 
@@ -193,17 +193,17 @@
 
                 {
                     "2019-10-22",
-                     results => results.Exactly(10)
-                                && results.Once(result => result.Kind == Digit && result.Span.EqualsValue("2") && result.Position.Column == 1)
-                                && results.Once(result => result.Kind == Digit && result.Span.EqualsValue("0") && result.Position.Column == 2)
-                                && results.Once(result => result.Kind == Digit && result.Span.EqualsValue("1") && result.Position.Column == 3)
-                                && results.Once(result => result.Kind == Digit && result.Span.EqualsValue("9") && result.Position.Column == 4)
-                                && results.Once(result => result.Kind == Dash  && result.Span.EqualsValue("-") && result.Position.Column == 5)
-                                && results.Once(result => result.Kind == Digit && result.Span.EqualsValue("1") && result.Position.Column == 6)
-                                && results.Once(result => result.Kind == Digit && result.Span.EqualsValue("0") && result.Position.Column == 7)
-                                && results.Once(result => result.Kind == Dash  && result.Span.EqualsValue("-") && result.Position.Column == 8)
-                                && results.Once(result => result.Kind == Digit && result.Span.EqualsValue("2") && result.Position.Column == 9)
-                                && results.Once(result => result.Kind == Digit && result.Span.EqualsValue("2") && result.Position.Column == 10)
+                    results => results.Exactly(10)
+                               && results.Once(result => result.Kind == Digit && result.Span.EqualsValue("2") && result.Position.Column == 1)
+                               && results.Once(result => result.Kind == Digit && result.Span.EqualsValue("0") && result.Position.Column == 2)
+                               && results.Once(result => result.Kind == Digit && result.Span.EqualsValue("1") && result.Position.Column == 3)
+                               && results.Once(result => result.Kind == Digit && result.Span.EqualsValue("9") && result.Position.Column == 4)
+                               && results.Once(result => result.Kind == Dash  && result.Span.EqualsValue("-") && result.Position.Column == 5)
+                               && results.Once(result => result.Kind == Digit && result.Span.EqualsValue("1") && result.Position.Column == 6)
+                               && results.Once(result => result.Kind == Digit && result.Span.EqualsValue("0") && result.Position.Column == 7)
+                               && results.Once(result => result.Kind == Dash  && result.Span.EqualsValue("-") && result.Position.Column == 8)
+                               && results.Once(result => result.Kind == Digit && result.Span.EqualsValue("2") && result.Position.Column == 9)
+                               && results.Once(result => result.Kind == Digit && result.Span.EqualsValue("2") && result.Position.Column == 10)
 
                 },
 
@@ -248,146 +248,145 @@
                 {
                     "_a",
                     results => results.Exactly(2)
-                        && results.Exactly(result => result.Kind == Underscore && result.Span.EqualsValue("_"), 1)
-                        && results.Exactly(result => result.Kind == Letter && result.Span.EqualsValue("a"), 1)
+                               && results.Exactly(result => result.Kind == Underscore && result.Span.EqualsValue("_"), 1)
+                               && results.Exactly(result => result.Kind == Letter && result.Span.EqualsValue("a"), 1)
 
                 }
-                };
+            };
 
-                foreach (char c in FilterTokenizer.SpecialCharacters)
-                {
-                    cases.Add
-                    (
-                        $"Firstname=Bru{FilterTokenizer.BackSlash}{c}",
-                        results => results.Exactly(14)
-                                   && results.Once(result => result.Kind == Letter && result.Span.EqualsValue("F") && result.Span.Position.Column == 1)
-                                   && results.Once(result => result.Kind == Letter && result.Span.EqualsValue("i") && result.Span.Position.Column == 2)
-                                   && results.Once(result => result.Kind == Letter && result.Span.EqualsValue("r") && result.Span.Position.Column == 3)
-                                   && results.Once(result => result.Kind == Letter && result.Span.EqualsValue("s") && result.Span.Position.Column == 4)
-                                   && results.Once(result => result.Kind == Letter && result.Span.EqualsValue("t") && result.Span.Position.Column == 5)
-                                   && results.Once(result => result.Kind == Letter && result.Span.EqualsValue("n") && result.Span.Position.Column == 6)
-                                   && results.Once(result => result.Kind == Letter && result.Span.EqualsValue("a") && result.Span.Position.Column == 7)
-                                   && results.Once(result => result.Kind == Letter && result.Span.EqualsValue("m") && result.Span.Position.Column == 8)
-                                   && results.Once(result => result.Kind == Letter && result.Span.EqualsValue("e") && result.Span.Position.Column == 9)
-                                   && results.Once(result => result.Kind == Equal && result.Span.EqualsValue("=") && result.Span.Position.Column == 10)
-                                   && results.Once(result => result.Kind == Letter && result.Span.EqualsValue("B") && result.Span.Position.Column == 11)
-                                   && results.Once(result => result.Kind == Letter && result.Span.EqualsValue("r") && result.Span.Position.Column == 12)
-                                   && results.Once(result => result.Kind == Letter && result.Span.EqualsValue("u") && result.Span.Position.Column == 13)
-                                   && results.Once(result => result.Kind == Escaped && result.Span.EqualsValue(c.ToString()) && result.Span.Position.Column == 15)
-
-                    );
-                }
-
+            foreach (char c in FilterTokenizer.SpecialCharacters)
+            {
                 cases.Add
                 (
-                    @"\",
-                    results =>
-                        results.Exactly(1)
-                        && results.Once(result => result.Kind == Letter && result.Span.EqualsValue(@"\"))
+                    $"Firstname=Bru{FilterTokenizer.BackSlash}{c}",
+                    results => results.Exactly(14)
+                               && results.Once(result => result.Kind == Letter && result.Span.EqualsValue("F") && result.Span.Position.Column == 1)
+                               && results.Once(result => result.Kind == Letter && result.Span.EqualsValue("i") && result.Span.Position.Column == 2)
+                               && results.Once(result => result.Kind == Letter && result.Span.EqualsValue("r") && result.Span.Position.Column == 3)
+                               && results.Once(result => result.Kind == Letter && result.Span.EqualsValue("s") && result.Span.Position.Column == 4)
+                               && results.Once(result => result.Kind == Letter && result.Span.EqualsValue("t") && result.Span.Position.Column == 5)
+                               && results.Once(result => result.Kind == Letter && result.Span.EqualsValue("n") && result.Span.Position.Column == 6)
+                               && results.Once(result => result.Kind == Letter && result.Span.EqualsValue("a") && result.Span.Position.Column == 7)
+                               && results.Once(result => result.Kind == Letter && result.Span.EqualsValue("m") && result.Span.Position.Column == 8)
+                               && results.Once(result => result.Kind == Letter && result.Span.EqualsValue("e") && result.Span.Position.Column == 9)
+                               && results.Once(result => result.Kind == Equal && result.Span.EqualsValue("=") && result.Span.Position.Column == 10)
+                               && results.Once(result => result.Kind == Letter && result.Span.EqualsValue("B") && result.Span.Position.Column == 11)
+                               && results.Once(result => result.Kind == Letter && result.Span.EqualsValue("r") && result.Span.Position.Column == 12)
+                               && results.Once(result => result.Kind == Letter && result.Span.EqualsValue("u") && result.Span.Position.Column == 13)
+                               && results.Once(result => result.Kind == Escaped && result.Span.EqualsValue(c.ToString()) && result.Span.Position.Column == 15)
 
                 );
-
-                cases.Add
-                (
-                    @"\\t",
-                    results =>
-                        results.Exactly(2)
-                        && results.Once(result => result.Kind == Escaped && result.Span.EqualsValue("\\"))
-                        && results.Once(result => result.Kind == Letter && result.Span.EqualsValue("t"))
-
-                );
-
-                cases.Add
-                (
-                    @"""",
-                    results =>
-                        results.Exactly(1)
-                        && results.Once(result => result.Kind == DoubleQuote && result.Span.EqualsValue(@""""))
-
-                );
-
-                cases.Add
-                (
-                    "+",
-                    results => results.Once()
-                                                                                && results.Once(result => result.Kind == None && result.Span.EqualsValue("+"))
-
-                );
-
-                foreach (char chr in FilterTokenizer.SpecialCharacters)
-                {
-                    switch (chr)
-                    {
-                        case FilterTokenizer.DoubleQuote:
-                            cases.Add
-                            (
-                                @$"""\{chr}""",
-                                results => results.Exactly(3) && results.Once(result => result.Kind == DoubleQuote
-                                                                                              && result.Position.Column == 1)
-                                                                    && results.Once(result => result.Kind == Escaped
-                                                                                                && result.Position.Column == 3
-                                                                                                && result.Span.EqualsValue(@""""))
-                                                                    && results.Once(result => result.Kind == DoubleQuote
-                                                                                                && result.Position.Column == 4)
-
-                            );
-                            break;
-                        case FilterTokenizer.BackSlash:
-                            cases.Add
-                            (
-                                @$"""\{chr}""",
-                                results => results.Exactly(3)
-                                            && results.Once(result => result.Kind == DoubleQuote && result.Position.Column == 1)
-                                            && results.Once(result => result.Kind == Escaped
-                                                                        && result.Position.Column == 3
-                                                                        && result.Span.EqualsValue(@"\"))
-                                            && results.Once(result => result.Kind == DoubleQuote
-                                                                        && result.Position.Column == 4)
-
-                            );
-                            break;
-                        default:
-                            cases.Add
-                            (
-                                @$"""\{chr}""",
-                                results => results.Exactly(4)
-                                           && results.Once(result => result.Kind == DoubleQuote && result.Position.Column == 1)
-                                           && results.Once(result => result.Kind == Escaped && result.Position.Column == 2 && result.Span.EqualsValue("\\"))
-                                           && results.Once(result => result.Kind == Escaped && result.Position.Column == 3 && result.Span.EqualsValue($"{chr}"))
-                                           && results.Once(result => result.Kind == DoubleQuote && result.Position.Column == 4)
-
-                            );
-                            break;
-                    }
-                }
-
-                cases.Add
-                (
-                    @"""\[",
-                    results => results.Exactly(3)
-                               && results.Once(result => result.Kind == DoubleQuote && result.Span.EqualsValue(@""""))
-                               && results.Once(result => result.Kind == Escaped && result.Span.EqualsValue(@"\"))
-                               && results.Once(result => result.Kind == Escaped && result.Span.EqualsValue("["))
-
-                );
-
-                return cases;
             }
+
+            cases.Add
+            (
+                @"\",
+                results =>
+                    results.Exactly(1)
+                    && results.Once(result => result.Kind == Letter && result.Span.EqualsValue(@"\"))
+
+            );
+
+            cases.Add
+            (
+                @"\\t",
+                results =>
+                    results.Exactly(2)
+                    && results.Once(result => result.Kind == Escaped && result.Span.EqualsValue("\\"))
+                    && results.Once(result => result.Kind == Letter && result.Span.EqualsValue("t"))
+
+            );
+
+            cases.Add
+            (
+                @"""",
+                results =>
+                    results.Exactly(1)
+                    && results.Once(result => result.Kind == DoubleQuote && result.Span.EqualsValue(@""""))
+
+            );
+
+            cases.Add
+            (
+                "+",
+                results => results.Once()
+                           && results.Once(result => result.Kind == None && result.Span.EqualsValue("+"))
+
+            );
+
+            foreach (char chr in FilterTokenizer.SpecialCharacters)
+            {
+                switch (chr)
+                {
+                    case FilterTokenizer.DoubleQuote:
+                        cases.Add
+                        (
+                            @$"""\{chr}""",
+                            results => results.Exactly(3) && results.Once(result => result.Kind == DoubleQuote
+                                                              && result.Position.Column == 1)
+                                                          && results.Once(result => result.Kind == Escaped
+                                                              && result.Position.Column == 3
+                                                              && result.Span.EqualsValue(@""""))
+                                                          && results.Once(result => result.Kind == DoubleQuote
+                                                              && result.Position.Column == 4)
+
+                        );
+                        break;
+                    case FilterTokenizer.BackSlash:
+                        cases.Add
+                        (
+                            @$"""\{chr}""",
+                            results => results.Exactly(3)
+                                       && results.Once(result => result.Kind == DoubleQuote && result.Position.Column == 1)
+                                       && results.Once(result => result.Kind == Escaped
+                                                                 && result.Position.Column == 3
+                                                                 && result.Span.EqualsValue(@"\"))
+                                       && results.Once(result => result.Kind == DoubleQuote
+                                                                 && result.Position.Column == 4)
+
+                        );
+                        break;
+                    default:
+                        cases.Add
+                        (
+                            @$"""\{chr}""",
+                            results => results.Exactly(4)
+                                       && results.Once(result => result.Kind == DoubleQuote && result.Position.Column == 1)
+                                       && results.Once(result => result.Kind == Escaped && result.Position.Column == 2 && result.Span.EqualsValue("\\"))
+                                       && results.Once(result => result.Kind == Escaped && result.Position.Column == 3 && result.Span.EqualsValue($"{chr}"))
+                                       && results.Once(result => result.Kind == DoubleQuote && result.Position.Column == 4)
+
+                        );
+                        break;
+                }
+            }
+
+            cases.Add
+            (
+                @"""\[",
+                results => results.Exactly(3)
+                           && results.Once(result => result.Kind == DoubleQuote && result.Span.EqualsValue(@""""))
+                           && results.Once(result => result.Kind == Escaped && result.Span.EqualsValue(@"\"))
+                           && results.Once(result => result.Kind == Escaped && result.Span.EqualsValue("["))
+
+            );
+
+            return cases;
         }
+    }
 
-        [Theory]
-        [MemberData(nameof(RecognizeTokensCases))]
-        public void RecognizeTokens(string input, Expression<Func<TokenList<FilterToken>, bool>> expectation)
-        {
-            outputHelper.WriteLine($"input : '{input}'");
-            // Act
-            TokenList<FilterToken> tokens = _sut.Tokenize(input);
+    [Theory]
+    [MemberData(nameof(RecognizeTokensCases))]
+    public void RecognizeTokens(string input, Expression<Func<TokenList<FilterToken>, bool>> expectation)
+    {
+        outputHelper.WriteLine($"input : '{input}'");
+        // Act
+        TokenList<FilterToken> tokens = _sut.Tokenize(input);
 
-            // Assert 
-            outputHelper.WriteLine($"Tokens : {tokens.Select(token => new { Value = token.ToStringValue(), Kind = token.Kind.ToString(), token.Position.Column }).Jsonify()}");
+        // Assert 
+        outputHelper.WriteLine($"Tokens : {tokens.Select(token => new { Value = token.ToStringValue(), Kind = token.Kind.ToString(), token.Position.Column }).Jsonify()}");
 
-            tokens.Should()
-                .Match(expectation);
-        }
+        tokens.Should()
+            .Match(expectation);
     }
 }

--- a/test/DataFilters.UnitTests/Grammar/Syntax/AndExpressionTests.cs
+++ b/test/DataFilters.UnitTests/Grammar/Syntax/AndExpressionTests.cs
@@ -1,220 +1,219 @@
-﻿namespace DataFilters.UnitTests.Grammar.Syntax
+﻿namespace DataFilters.UnitTests.Grammar.Syntax;
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using DataFilters.Grammar.Syntax;
+using DataFilters.UnitTests.Helpers;
+using FluentAssertions;
+using FsCheck;
+using FsCheck.Xunit;
+using Xunit;
+using Xunit.Abstractions;
+using Xunit.Categories;
+
+[UnitTest]
+[Feature(nameof(AndExpression))]
+public class AndExpressionTests(ITestOutputHelper outputHelper)
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Linq;
-    using DataFilters.Grammar.Syntax;
-    using DataFilters.UnitTests.Helpers;
-    using FluentAssertions;
-    using FsCheck;
-    using FsCheck.Xunit;
-    using Xunit;
-    using Xunit.Abstractions;
-    using Xunit.Categories;
+    [Fact]
+    public void IsFilterExpression() => typeof(AndExpression).Should()
+        .BeAssignableTo<FilterExpression>().And
+        .Implement<IEquatable<AndExpression>>().And
+        .Implement<IHaveComplexity>().And
+        .HaveConstructor(new[] { typeof(FilterExpression), typeof(FilterExpression) }).And
+        .HaveProperty<FilterExpression>("Left").And
+        .HaveProperty<FilterExpression>("Right");
 
-    [UnitTest]
-    [Feature(nameof(AndExpression))]
-    public class AndExpressionTests(ITestOutputHelper outputHelper)
+    public static TheoryData<FilterExpression, FilterExpression> ArgumentNullExceptionCases
     {
-        [Fact]
-        public void IsFilterExpression() => typeof(AndExpression).Should()
-                                                                 .BeAssignableTo<FilterExpression>().And
-                                                                 .Implement<IEquatable<AndExpression>>().And
-                                                                 .Implement<IHaveComplexity>().And
-                                                                 .HaveConstructor(new[] { typeof(FilterExpression), typeof(FilterExpression) }).And
-                                                                 .HaveProperty<FilterExpression>("Left").And
-                                                                 .HaveProperty<FilterExpression>("Right");
-
-        public static TheoryData<FilterExpression, FilterExpression> ArgumentNullExceptionCases
+        get
         {
-            get
+            FilterExpression[] left = [new StartsWithExpression("ce"), null];
+            TheoryData<FilterExpression, FilterExpression> cases = [];
+
+            left.CrossJoin(left, (left, right) => (left, right))
+                .Where(tuple => tuple.left == null || tuple.right is null)
+                .ForEach(tuple => cases.Add(tuple.left, tuple.right));
+
+            return cases;
+        }
+    }
+
+    [Theory]
+    [MemberData(nameof(ArgumentNullExceptionCases))]
+    public void Ctor_Throws_ArgumentNullException_When_Argument_Is_Null(FilterExpression left, FilterExpression right)
+    {
+        // Act
+        Action action = () => _ = new AndExpression(left, right);
+
+        // Assert
+        action.Should()
+            .ThrowExactly<ArgumentNullException>("The parameter of the constructor cannot be null");
+    }
+
+    public static TheoryData<AndExpression, object, bool, string> EqualsCases
+        => new()
+        {
             {
-                FilterExpression[] left = [new StartsWithExpression("ce"), null];
-                TheoryData<FilterExpression, FilterExpression> cases = [];
-
-                left.CrossJoin(left, (left, right) => (left, right))
-                           .Where(tuple => tuple.left == null || tuple.right is null)
-                           .ForEach(tuple => cases.Add(tuple.left, tuple.right));
-
-                return cases;
+                new AndExpression(new StartsWithExpression("prop1"), new StartsWithExpression("prop2")),
+                new AndExpression(new StartsWithExpression("prop1"), new StartsWithExpression("prop2")),
+                true,
+                "operands are the same and in the same order"
+            },
+            {
+                new AndExpression(new StartsWithExpression("prop1"), new StartsWithExpression("prop2")),
+                new AndExpression(new StartsWithExpression("prop1"), new StartsWithExpression("prop3")),
+                false,
+                "one operand is different"
+            },
+            {
+                new AndExpression(new StartsWithExpression("prop1"), new StartsWithExpression("prop2")),
+                new AndExpression(new StartsWithExpression("prop2"), new StartsWithExpression("prop1")),
+                true,
+                "operands are the same but their order differs"
             }
-        }
+        };
 
-        [Theory]
-        [MemberData(nameof(ArgumentNullExceptionCases))]
-        public void Ctor_Throws_ArgumentNullException_When_Argument_Is_Null(FilterExpression left, FilterExpression right)
+    [Theory]
+    [MemberData(nameof(EqualsCases))]
+    public void Equals_should_behave_as_expected(AndExpression first, object other, bool expected, string reason)
+    {
+        outputHelper.WriteLine($"First instance : {first}");
+        outputHelper.WriteLine($"Second instance : {other}");
+
+        // Act
+        bool actual = first.Equals(other);
+
+        // Assert
+        actual.Should()
+            .Be(expected, reason);
+    }
+
+    [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
+    public void Given_AndExpression_GetComplexity_should_return_left_complexity_multiply_by_right_complexity(AndExpression and)
+    {
+        // Arrange
+        double expected = and.Left.Complexity * and.Right.Complexity;
+
+        // Act
+        double actual = and.Complexity;
+
+        // Assert
+        actual.Should().Be(expected);
+    }
+
+    public static TheoryData<AndExpression, FilterExpression> SimplifyCases
+        => new()
         {
-            // Act
-            Action action = () => _ = new AndExpression(left, right);
-
-            // Assert
-            action.Should()
-                .ThrowExactly<ArgumentNullException>("The parameter of the constructor cannot be null");
-        }
-
-        public static TheoryData<AndExpression, object, bool, string> EqualsCases
-            => new()
             {
-                {
-                    new AndExpression(new StartsWithExpression("prop1"), new StartsWithExpression("prop2")),
-                    new AndExpression(new StartsWithExpression("prop1"), new StartsWithExpression("prop2")),
-                    true,
-                    "operands are the same and in the same order"
-                },
-                {
-                    new AndExpression(new StartsWithExpression("prop1"), new StartsWithExpression("prop2")),
-                    new AndExpression(new StartsWithExpression("prop1"), new StartsWithExpression("prop3")),
-                    false,
-                    "one operand is different"
-                },
-                {
-                    new AndExpression(new StartsWithExpression("prop1"), new StartsWithExpression("prop2")),
-                    new AndExpression(new StartsWithExpression("prop2"), new StartsWithExpression("prop1")),
-                    true,
-                    "operands are the same but their order differs"
-                }
-            };
-
-        [Theory]
-        [MemberData(nameof(EqualsCases))]
-        public void Equals_should_behave_as_expected(AndExpression first, object other, bool expected, string reason)
-        {
-            outputHelper.WriteLine($"First instance : {first}");
-            outputHelper.WriteLine($"Second instance : {other}");
-
-            // Act
-            bool actual = first.Equals(other);
-
-            // Assert
-            actual.Should()
-                  .Be(expected, reason);
-        }
-
-        [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
-        public void Given_AndExpression_GetComplexity_should_return_left_complexity_multiply_by_right_complexity(AndExpression and)
-        {
-            // Arrange
-            double expected = and.Left.Complexity * and.Right.Complexity;
-
-            // Act
-            double actual = and.Complexity;
-
-            // Assert
-            actual.Should().Be(expected);
-        }
-
-        public static TheoryData<AndExpression, FilterExpression> SimplifyCases
-            => new()
+                new AndExpression(new StringValueExpression("val"), new StringValueExpression("val")),
+                new StringValueExpression("val")
+            },
             {
-                {
-                    new AndExpression(new StringValueExpression("val"), new StringValueExpression("val")),
-                    new StringValueExpression("val")
-                },
-                {
-                    new AndExpression(new StringValueExpression("val"), new OrExpression(new StringValueExpression("val"), new StringValueExpression("val"))),
-                    new StringValueExpression("val")
-                },
-                {
-                    new AndExpression(new OrExpression(new StringValueExpression("val"), new StringValueExpression("val")), new StringValueExpression("val")),
-                    new StringValueExpression("val")
-                },
-                {
-                    new AndExpression(new IntervalExpression(new BoundaryExpression(new NumericValueExpression("-1"), true),
-                                                                new BoundaryExpression(new NumericValueExpression("-1"), true)),
-                                        new IntervalExpression(new BoundaryExpression(new NumericValueExpression("-1"), true),
-                                                        new BoundaryExpression(new NumericValueExpression("-1"), true))),
-                    new NumericValueExpression("-1")
-                }
-            };
+                new AndExpression(new StringValueExpression("val"), new OrExpression(new StringValueExpression("val"), new StringValueExpression("val"))),
+                new StringValueExpression("val")
+            },
+            {
+                new AndExpression(new OrExpression(new StringValueExpression("val"), new StringValueExpression("val")), new StringValueExpression("val")),
+                new StringValueExpression("val")
+            },
+            {
+                new AndExpression(new IntervalExpression(new BoundaryExpression(new NumericValueExpression("-1"), true),
+                        new BoundaryExpression(new NumericValueExpression("-1"), true)),
+                    new IntervalExpression(new BoundaryExpression(new NumericValueExpression("-1"), true),
+                        new BoundaryExpression(new NumericValueExpression("-1"), true))),
+                new NumericValueExpression("-1")
+            }
+        };
 
-        [Theory]
-        [MemberData(nameof(SimplifyCases))]
-        public void Given_AndExpression_Simplify_should_return_the_expected_expression(AndExpression andExpression, FilterExpression expected)
-        {
-            // Act
-            FilterExpression actual = andExpression.Simplify();
+    [Theory]
+    [MemberData(nameof(SimplifyCases))]
+    public void Given_AndExpression_Simplify_should_return_the_expected_expression(AndExpression andExpression, FilterExpression expected)
+    {
+        // Act
+        FilterExpression actual = andExpression.Simplify();
 
-            // Assert
-            actual.Should()
-                  .Be(expected);
-        }
+        // Assert
+        actual.Should()
+            .Be(expected);
+    }
 
-        [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
-        public void Given_two_AndExpression_instances_one_and_two_where_oneU002Eleft_eq_twoU002Eright_and_oneU002Eright_eq_twoU002Eleft_IsEquivalentTo_should_return_true(FilterExpression first, FilterExpression second)
-        {
-            // Arrange
-            AndExpression one = new(first, second);
-            AndExpression two = new(second, first);
+    [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
+    public void Given_two_AndExpression_instances_one_and_two_where_oneU002Eleft_eq_twoU002Eright_and_oneU002Eright_eq_twoU002Eleft_IsEquivalentTo_should_return_true(FilterExpression first, FilterExpression second)
+    {
+        // Arrange
+        AndExpression one = new(first, second);
+        AndExpression two = new(second, first);
 
-            // Act
-            bool actual = one.IsEquivalentTo(two);
+        // Act
+        bool actual = one.IsEquivalentTo(two);
 
-            // Assert
-            actual.Should()
-                  .BeTrue();
-        }
+        // Assert
+        actual.Should()
+            .BeTrue();
+    }
 
-        [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
-        public void IsEquivalent_should_be_reflexive(AndExpression and) => and.IsEquivalentTo(and).Should().BeTrue();
+    [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
+    public void IsEquivalent_should_be_reflexive(AndExpression and) => and.IsEquivalentTo(and).Should().BeTrue();
 
-        [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
-        public void Given_two_AndExpression_instances_first_and_second_and_firstU002ERight_eq_secondU002Eright_and_firstU002ELeft_eq_secondU002ELeft_Equals_should_returns_true(FilterExpression left, FilterExpression right)
-        {
-            // Arrange
-            AndExpression first = new(left, right);
-            AndExpression second = new(left, right);
+    [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
+    public void Given_two_AndExpression_instances_first_and_second_and_firstU002ERight_eq_secondU002Eright_and_firstU002ELeft_eq_secondU002ELeft_Equals_should_returns_true(FilterExpression left, FilterExpression right)
+    {
+        // Arrange
+        AndExpression first = new(left, right);
+        AndExpression second = new(left, right);
 
-            // Assert
-            first.Should().Be(second);
-        }
+        // Assert
+        first.Should().Be(second);
+    }
 
-        [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
-        public void An_AndExpression_Equals_should_neq_false(FilterExpression left, FilterExpression right)
-        {
-            // Arrange
-            AndExpression first = new(left, right);
+    [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
+    public void An_AndExpression_Equals_should_neq_false(FilterExpression left, FilterExpression right)
+    {
+        // Arrange
+        AndExpression first = new(left, right);
 
-            // Act
-            bool actual = first.Equals(null);
+        // Act
+        bool actual = first.Equals(null);
 
-            // Assert
-            actual.Should()
-                  .BeFalse();
-        }
+        // Assert
+        actual.Should()
+            .BeFalse();
+    }
 
-        [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
-        public void Given_AndExpression_instance_where_instanceU002ELeft_is_equivalent_to_instanceU002ERight_Simplify_should_return_the_expression_with_the_lowest_Complexity(FilterExpression expression, PositiveInt count)
-        {
-            // Arrange
-            OneOfExpression oneOfExpression = new([.. Enumerable.Repeat(expression, count.Item + 1)]); // if count == 1 we want to have at least two values in our OneOfExpression
+    [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
+    public void Given_AndExpression_instance_where_instanceU002ELeft_is_equivalent_to_instanceU002ERight_Simplify_should_return_the_expression_with_the_lowest_Complexity(FilterExpression expression, PositiveInt count)
+    {
+        // Arrange
+        OneOfExpression oneOfExpression = new([.. Enumerable.Repeat(expression, count.Item + 1)]); // if count == 1 we want to have at least two values in our OneOfExpression
 
-            outputHelper.WriteLine($"{nameof(oneOfExpression)} : '{oneOfExpression.EscapedParseableString}'");
-            outputHelper.WriteLine($"{nameof(oneOfExpression.Complexity)} : {oneOfExpression.Complexity}");
+        outputHelper.WriteLine($"{nameof(oneOfExpression)} : '{oneOfExpression.EscapedParseableString}'");
+        outputHelper.WriteLine($"{nameof(oneOfExpression.Complexity)} : {oneOfExpression.Complexity}");
 
-            AndExpression initial = new(oneOfExpression, expression);
+        AndExpression initial = new(oneOfExpression, expression);
 
-            // Act
-            FilterExpression actual = initial.Simplify();
-            bool isEquivalent = actual.IsEquivalentTo(oneOfExpression);
-            double actualComplexity = actual.Complexity;
+        // Act
+        FilterExpression actual = initial.Simplify();
+        bool isEquivalent = actual.IsEquivalentTo(oneOfExpression);
+        double actualComplexity = actual.Complexity;
 
-            // Assert
-            outputHelper.WriteLine($"actual : {actual.EscapedParseableString} (Complexity : {actual.Complexity})");
-            outputHelper.WriteLine($"actual is equivalent to expression : {isEquivalent})");
+        // Assert
+        outputHelper.WriteLine($"actual : {actual.EscapedParseableString} (Complexity : {actual.Complexity})");
+        outputHelper.WriteLine($"actual is equivalent to expression : {isEquivalent})");
 
-            isEquivalent.Should().BeTrue("Simplifying an expression should not change its meaning");
-            actualComplexity.Should().BeLessThan(initial.Complexity);
-        }
+        isEquivalent.Should().BeTrue("Simplifying an expression should not change its meaning");
+        actualComplexity.Should().BeLessThan(initial.Complexity);
+    }
 
-        [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
-        public void Given_left_operand_is_a_AndFilterExpression_instance_When_right_is_not_null_Constructor_should_wrap_left_inside_a_GroupExpression_instance(NonNull<AndExpression> left, NonNull<FilterExpression> right)
-        {
-            // Act
-            AndExpression and = new(left.Item, right.Item);
+    [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
+    public void Given_left_operand_is_a_AndFilterExpression_instance_When_right_is_not_null_Constructor_should_wrap_left_inside_a_GroupExpression_instance(NonNull<AndExpression> left, NonNull<FilterExpression> right)
+    {
+        // Act
+        AndExpression and = new(left.Item, right.Item);
 
-            // Assert
-            and.Left.Should()
-                    .BeOfType<GroupExpression>($"Left instance is a '{nameof(AndExpression)}'");
-        }
+        // Assert
+        and.Left.Should()
+            .BeOfType<GroupExpression>($"Left instance is a '{nameof(AndExpression)}'");
     }
 }

--- a/test/DataFilters.UnitTests/Grammar/Syntax/BoundaryExpressionTests.cs
+++ b/test/DataFilters.UnitTests/Grammar/Syntax/BoundaryExpressionTests.cs
@@ -1,115 +1,114 @@
-﻿namespace DataFilters.UnitTests.Grammar.Syntax
+﻿namespace DataFilters.UnitTests.Grammar.Syntax;
+
+using System;
+using DataFilters.Grammar.Syntax;
+using DataFilters.UnitTests.Helpers;
+using FluentAssertions;
+using FsCheck;
+using FsCheck.Xunit;
+using Xunit;
+using Xunit.Categories;
+
+[UnitTest]
+[Feature(nameof(DataFilters.Grammar.Syntax))]
+[Feature(nameof(IntervalExpression))]
+public class BoundaryExpressionTests
 {
-    using System;
-    using DataFilters.Grammar.Syntax;
-    using DataFilters.UnitTests.Helpers;
-    using FluentAssertions;
-    using FsCheck;
-    using FsCheck.Xunit;
-    using Xunit;
-    using Xunit.Categories;
-
-    [UnitTest]
-    [Feature(nameof(DataFilters.Grammar.Syntax))]
-    [Feature(nameof(IntervalExpression))]
-    public class BoundaryExpressionTests
+    [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
+    public void Given_a_BoundaryExpression_instance_should_be_equals_to_itself(BoundaryExpression input)
     {
-        [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
-        public void Given_a_BoundaryExpression_instance_should_be_equals_to_itself(BoundaryExpression input)
+        // Act
+        bool actual = input.Equals(input);
+
+        // Assert
+        actual.Should().BeTrue("'equals' implementation should be reflexive");
+    }
+
+    [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
+    public void A_BoundaryExpression_instance_should_not_be_equal_to_null(BoundaryExpression input)
+    {
+        // Act
+        bool actual = input.Equals(null);
+
+        // Assert
+        actual.Should().BeFalse("a not null boundaryexpression is not equal to null");
+    }
+
+    [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
+    public void Two_BoundaryExpressions_instances_with_same_expression_and_included_should_be_equal(BoundaryExpression source)
+    {
+        // Arrange
+        BoundaryExpression first = new(source.Expression, source.Included);
+        BoundaryExpression other = new(source.Expression, source.Included);
+
+        // Act
+        bool actual = first.Equals(other);
+        int firstHashCode = first.GetHashCode();
+        int otherHashCode = other.GetHashCode();
+
+        // Assert
+        actual.Should().BeTrue();
+        firstHashCode.Should().Be(otherHashCode);
+    }
+
+    [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
+    public void Ctor_should_throw_ArgumentNullException_when_expression_is_null(bool included)
+    {
+        // Act
+        Action buildInstanceWithNullExpression = () => new BoundaryExpression(null, included);
+
+        // Assert
+        buildInstanceWithNullExpression.Should()
+            .ThrowExactly<ArgumentNullException>();
+    }
+
+    [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
+    public void Equals_should_be_reflexive(NonNull<BoundaryExpression> expression)
+    {
+        // Act
+        bool actual = expression.Item.Equals(expression.Item);
+
+        // Assert
+        actual.Should().BeTrue("'equals' implementation must be reflexive");
+    }
+
+    [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
+    public void Equals_should_be_symetric(NonNull<BoundaryExpression> group, NonNull<FilterExpression> otherExpression)
+    {
+        // Act
+        bool groupEqualOtherExpression = group.Item.Equals(otherExpression.Item);
+        bool otherExpressionEqualGroup = otherExpression.Item.Equals(group);
+
+        // Assert
+        groupEqualOtherExpression.Should().Be(otherExpressionEqualGroup, "'equals' impelemntation must be symetric");
+    }
+
+    public static TheoryData<BoundaryExpression, object, bool, string> EqualsBehaviourCases
+        => new()
         {
-            // Act
-            bool actual = input.Equals(input);
-
-            // Assert
-            actual.Should().BeTrue("'equals' implementation should be reflexive");
-        }
-
-        [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
-        public void A_BoundaryExpression_instance_should_not_be_equal_to_null(BoundaryExpression input)
-        {
-            // Act
-            bool actual = input.Equals(null);
-
-            // Assert
-            actual.Should().BeFalse("a not null boundaryexpression is not equal to null");
-        }
-
-        [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
-        public void Two_BoundaryExpressions_instances_with_same_expression_and_included_should_be_equal(BoundaryExpression source)
-        {
-            // Arrange
-            BoundaryExpression first = new(source.Expression, source.Included);
-            BoundaryExpression other = new(source.Expression, source.Included);
-
-            // Act
-            bool actual = first.Equals(other);
-            int firstHashCode = first.GetHashCode();
-            int otherHashCode = other.GetHashCode();
-
-            // Assert
-            actual.Should().BeTrue();
-            firstHashCode.Should().Be(otherHashCode);
-        }
-
-        [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
-        public void Ctor_should_throw_ArgumentNullException_when_expression_is_null(bool included)
-        {
-            // Act
-            Action buildInstanceWithNullExpression = () => new BoundaryExpression(null, included);
-
-            // Assert
-            buildInstanceWithNullExpression.Should()
-                                           .ThrowExactly<ArgumentNullException>();
-        }
-
-        [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
-        public void Equals_should_be_reflexive(NonNull<BoundaryExpression> expression)
-        {
-            // Act
-            bool actual = expression.Item.Equals(expression.Item);
-
-            // Assert
-            actual.Should().BeTrue("'equals' implementation must be reflexive");
-        }
-
-        [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
-        public void Equals_should_be_symetric(NonNull<BoundaryExpression> group, NonNull<FilterExpression> otherExpression)
-        {
-            // Act
-            bool groupEqualOtherExpression = group.Item.Equals(otherExpression.Item);
-            bool otherExpressionEqualGroup = otherExpression.Item.Equals(group);
-
-            // Assert
-            groupEqualOtherExpression.Should().Be(otherExpressionEqualGroup, "'equals' impelemntation must be symetric");
-        }
-
-        public static TheoryData<BoundaryExpression, object, bool, string> EqualsBehaviourCases
-            => new()
             {
-                {
-                    new BoundaryExpression(new DateExpression(), true),
-                    new BoundaryExpression(new DateExpression(), true),
-                    true,
-                    $"Two instances with {nameof(DateExpression)} that are equal"
-                },
-                {
-                    new BoundaryExpression(new DateTimeExpression(new (), new (), new()), true),
-                    new BoundaryExpression(new DateTimeExpression(new (), new (), new()), true),
-                    true,
-                    $"Two instances with {nameof(DateExpression)} that are equal"
-                }
-            };
+                new BoundaryExpression(new DateExpression(), true),
+                new BoundaryExpression(new DateExpression(), true),
+                true,
+                $"Two instances with {nameof(DateExpression)} that are equal"
+            },
+            {
+                new BoundaryExpression(new DateTimeExpression(new (), new (), new()), true),
+                new BoundaryExpression(new DateTimeExpression(new (), new (), new()), true),
+                true,
+                $"Two instances with {nameof(DateExpression)} that are equal"
+            }
+        };
 
-        [Theory]
-        [MemberData(nameof(EqualsBehaviourCases))]
-        public void Equals_should_behave_as_expected(BoundaryExpression expression, object other, bool expected, string reason)
-        {
-            // Act
-            bool actual = expression.Equals(other);
+    [Theory]
+    [MemberData(nameof(EqualsBehaviourCases))]
+    public void Equals_should_behave_as_expected(BoundaryExpression expression, object other, bool expected, string reason)
+    {
+        // Act
+        bool actual = expression.Equals(other);
 
-            // Assert
-            actual.Should()
-                  .Be(expected, reason);
-        }
+        // Assert
+        actual.Should()
+            .Be(expected, reason);
     }
 }

--- a/test/DataFilters.UnitTests/Grammar/Syntax/BracketExpressionTests.cs
+++ b/test/DataFilters.UnitTests/Grammar/Syntax/BracketExpressionTests.cs
@@ -1,131 +1,130 @@
-﻿namespace DataFilters.UnitTests.Grammar.Syntax
+﻿namespace DataFilters.UnitTests.Grammar.Syntax;
+
+using System;
+using System.Linq;
+using DataFilters.Grammar.Syntax;
+using DataFilters.UnitTests.Helpers;
+using FluentAssertions;
+using FsCheck;
+using FsCheck.Fluent;
+using FsCheck.Xunit;
+using Xunit;
+using Xunit.Abstractions;
+
+public class BracketExpressionTests(ITestOutputHelper outputHelper)
 {
-    using System;
-    using System.Linq;
-    using DataFilters.Grammar.Syntax;
-    using DataFilters.UnitTests.Helpers;
-    using FluentAssertions;
-    using FsCheck;
-    using FsCheck.Fluent;
-    using FsCheck.Xunit;
-    using Xunit;
-    using Xunit.Abstractions;
+    [Fact]
+    public void IsFilterExpression() => typeof(BracketExpression).Should()
+        .BeAssignableTo<FilterExpression>().And
+        .Implement<IEquatable<BracketExpression>>().And
+        .Implement<IHaveComplexity>();
 
-    public class BracketExpressionTests(ITestOutputHelper outputHelper)
+    [Fact]
+    public void Ctor_Throws_ArgumentNullException_If_Value_Is_Null()
     {
-        [Fact]
-        public void IsFilterExpression() => typeof(BracketExpression).Should()
-            .BeAssignableTo<FilterExpression>().And
-            .Implement<IEquatable<BracketExpression>>().And
-            .Implement<IHaveComplexity>();
+        // Act
+        Action action = () => new BracketExpression(null);
 
-        [Fact]
-        public void Ctor_Throws_ArgumentNullException_If_Value_Is_Null()
+        // Assert
+        action.Should()
+            .ThrowExactly<ArgumentNullException>($"{nameof(BracketExpression)}.{nameof(BracketExpression.Values)} cannot be null");
+    }
+
+    public static TheoryData<BracketExpression, object, bool, string> EqualsCases
+        => new()
         {
-            // Act
-            Action action = () => new BracketExpression(null);
-
-            // Assert
-            action.Should()
-                .ThrowExactly<ArgumentNullException>($"{nameof(BracketExpression)}.{nameof(BracketExpression.Values)} cannot be null");
-        }
-
-        public static TheoryData<BracketExpression, object, bool, string> EqualsCases
-            => new()
             {
-                {
-                    new BracketExpression(new ConstantBracketValue("aBc")),
-                    new BracketExpression(new ConstantBracketValue("aBc")),
-                    true,
-                    $"Two {nameof(BracketExpression)} instances built with inputs that are equals"
-                },
-                {
-                    new BracketExpression(new ConstantBracketValue("aBc")),
-                    new BracketExpression(new ConstantBracketValue("aBc")),
-                    true,
-                    $"Two {nameof(BracketExpression)} instances built with inputs that are equals"
-                }
-            };
-
-        [Theory]
-        [MemberData(nameof(EqualsCases))]
-        public void Equals_should_behave_as_expected(BracketExpression expression, object obj, bool expected, string reason)
-        {
-            // Act
-            bool actual = expression.Equals(obj);
-
-            // Assert
-            actual.Should()
-                  .Be(expected, reason);
-        }
-
-        [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
-        public void Two_BracketExpression_instances_built_with_different_inputs_should_not_be_equal(NonEmptyArray<BracketValue> one,
-                                                                                                    NonEmptyArray<BracketValue> two)
-        {
-            // Arrange
-            BracketExpression first = new(one.Item);
-            BracketExpression second = new(two.Item);
-
-            first.Equals(second).ToProperty().When(one.Item.Equals(two.Item)).VerboseCheck(outputHelper);
-        }
-
-        [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
-        public void Complexity_should_depends_on_input(NonEmptyArray<BracketValue> values)
-        {
-            // Arrange
-            BracketExpression bracketExpression = new(values.Item);
-            double expected = values.Item.Select(value => value.Complexity)
-                                         .Aggregate((initial, next) => initial * next);
-
-            // Act
-            double complexity = bracketExpression.Complexity;
-
-            // Assert
-            complexity.Should().Be(expected);
-        }
-
-        public static TheoryData<BracketExpression, double> ComplexityCases
-            => new()
+                new BracketExpression(new ConstantBracketValue("aBc")),
+                new BracketExpression(new ConstantBracketValue("aBc")),
+                true,
+                $"Two {nameof(BracketExpression)} instances built with inputs that are equals"
+            },
             {
-                {
-                    new BracketExpression
-                    (
-                        new ConstantBracketValue("aa"),
-                        new RangeBracketValue('a', 'c')
-                    ),
-                    new ConstantBracketValue("aa").Complexity * new RangeBracketValue('a', 'c').Complexity
-                }
-            };
+                new BracketExpression(new ConstantBracketValue("aBc")),
+                new BracketExpression(new ConstantBracketValue("aBc")),
+                true,
+                $"Two {nameof(BracketExpression)} instances built with inputs that are equals"
+            }
+        };
 
-        [Theory]
-        [MemberData(nameof(ComplexityCases))]
-        public void Complexity_should_behave_as_expected(BracketExpression expression, double expected)
+    [Theory]
+    [MemberData(nameof(EqualsCases))]
+    public void Equals_should_behave_as_expected(BracketExpression expression, object obj, bool expected, string reason)
+    {
+        // Act
+        bool actual = expression.Equals(obj);
+
+        // Assert
+        actual.Should()
+            .Be(expected, reason);
+    }
+
+    [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
+    public void Two_BracketExpression_instances_built_with_different_inputs_should_not_be_equal(NonEmptyArray<BracketValue> one,
+        NonEmptyArray<BracketValue> two)
+    {
+        // Arrange
+        BracketExpression first = new(one.Item);
+        BracketExpression second = new(two.Item);
+
+        first.Equals(second).ToProperty().When(one.Item.Equals(two.Item)).VerboseCheck(outputHelper);
+    }
+
+    [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
+    public void Complexity_should_depends_on_input(NonEmptyArray<BracketValue> values)
+    {
+        // Arrange
+        BracketExpression bracketExpression = new(values.Item);
+        double expected = values.Item.Select(value => value.Complexity)
+            .Aggregate((initial, next) => initial * next);
+
+        // Act
+        double complexity = bracketExpression.Complexity;
+
+        // Assert
+        complexity.Should().Be(expected);
+    }
+
+    public static TheoryData<BracketExpression, double> ComplexityCases
+        => new()
         {
-            // Act
-            double actual = expression.Complexity;
+            {
+                new BracketExpression
+                (
+                    new ConstantBracketValue("aa"),
+                    new RangeBracketValue('a', 'c')
+                ),
+                new ConstantBracketValue("aa").Complexity * new RangeBracketValue('a', 'c').Complexity
+            }
+        };
 
-            // Assert
-            actual.Should()
-                  .Be(expected);
-        }
+    [Theory]
+    [MemberData(nameof(ComplexityCases))]
+    public void Complexity_should_behave_as_expected(BracketExpression expression, double expected)
+    {
+        // Act
+        double actual = expression.Complexity;
 
-        [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
-        public void Given_BracketRangeValue_IsEquivalentTo_should_be_equivalent_to_many_OrExpression_where_each_expression_contains_one_charater(NonNull<RangeBracketValue> rangeBracketValue)
-        {
-            // Arrange
-            BracketExpression rangeBracketExpression = new(rangeBracketValue.Item);
+        // Assert
+        actual.Should()
+            .Be(expected);
+    }
 
-            OneOfExpression oneOf = new(Enumerable.Range(rangeBracketValue.Item.Start,
-                                                          rangeBracketValue.Item.End - rangeBracketValue.Item.Start + 1)
-                                                   .Select(ascii => new StringValueExpression(((char)ascii).ToString()))
-                                                   .ToArray());
+    [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
+    public void Given_BracketRangeValue_IsEquivalentTo_should_be_equivalent_to_many_OrExpression_where_each_expression_contains_one_charater(NonNull<RangeBracketValue> rangeBracketValue)
+    {
+        // Arrange
+        BracketExpression rangeBracketExpression = new(rangeBracketValue.Item);
 
-            // Act
-            bool actual = rangeBracketExpression.IsEquivalentTo(oneOf);
+        OneOfExpression oneOf = new(Enumerable.Range(rangeBracketValue.Item.Start,
+                rangeBracketValue.Item.End - rangeBracketValue.Item.Start + 1)
+            .Select(ascii => new StringValueExpression(((char)ascii).ToString()))
+            .ToArray());
 
-            // Assert
-            actual.Should().BeTrue($"Range expression : {rangeBracketValue.Item}");
-        }
+        // Act
+        bool actual = rangeBracketExpression.IsEquivalentTo(oneOf);
+
+        // Assert
+        actual.Should().BeTrue($"Range expression : {rangeBracketValue.Item}");
     }
 }

--- a/test/DataFilters.UnitTests/Grammar/Syntax/ConstantBracketValueTests.cs
+++ b/test/DataFilters.UnitTests/Grammar/Syntax/ConstantBracketValueTests.cs
@@ -1,80 +1,79 @@
-﻿namespace DataFilters.UnitTests.Grammar.Syntax
+﻿namespace DataFilters.UnitTests.Grammar.Syntax;
+
+using System;
+using System.Linq;
+using DataFilters.Grammar.Syntax;
+using DataFilters.UnitTests.Helpers;
+using FluentAssertions;
+using FsCheck;
+using FsCheck.Fluent;
+using FsCheck.Xunit;
+
+public class ConstantBracketValueTests
 {
-    using System;
-    using System.Linq;
-    using DataFilters.Grammar.Syntax;
-    using DataFilters.UnitTests.Helpers;
-    using FluentAssertions;
-    using FsCheck;
-    using FsCheck.Fluent;
-    using FsCheck.Xunit;
-
-    public class ConstantBracketValueTests
+    [Property]
+    public void Value_should_be_set_by_the_parameter_of_the_constructor(NonNull<string> input)
     {
-        [Property]
-        public void Value_should_be_set_by_the_parameter_of_the_constructor(NonNull<string> input)
-        {
-            // Act
-            ConstantBracketValue constantBracketValue = new(input.Item);
+        // Act
+        ConstantBracketValue constantBracketValue = new(input.Item);
 
-            // Assert
-            constantBracketValue.Value.Should()
-                                      .Be(input.Item);
-        }
+        // Assert
+        constantBracketValue.Value.Should()
+            .Be(input.Item);
+    }
 
-        [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
-        public void Given_RangeBracketValue_Equals_should_returns_true_when_ConstantBracketValue_contains_all_letters_of_the_interval(NonNull<RangeBracketValue> rangeBracketValue)
-        {
-            // Arrange
-            ConstantBracketValue constantBracketValue = new(Enumerable.Range(rangeBracketValue.Item.Start, rangeBracketValue.Item.End - rangeBracketValue.Item.Start + 1)
-                                                                      .Select(ascii => ((char)ascii).ToString())
-                                                                      .Aggregate((accumulate, current) => $"{accumulate}{current}"));
+    [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
+    public void Given_RangeBracketValue_Equals_should_returns_true_when_ConstantBracketValue_contains_all_letters_of_the_interval(NonNull<RangeBracketValue> rangeBracketValue)
+    {
+        // Arrange
+        ConstantBracketValue constantBracketValue = new(Enumerable.Range(rangeBracketValue.Item.Start, rangeBracketValue.Item.End - rangeBracketValue.Item.Start + 1)
+            .Select(ascii => ((char)ascii).ToString())
+            .Aggregate((accumulate, current) => $"{accumulate}{current}"));
 
-            // Act
-            bool actual = constantBracketValue.Equals(rangeBracketValue.Item);
+        // Act
+        bool actual = constantBracketValue.Equals(rangeBracketValue.Item);
 
-            actual.Should().BeTrue($"Range expression : {rangeBracketValue} and Constant expression is {constantBracketValue.Value}");
-        }
+        actual.Should().BeTrue($"Range expression : {rangeBracketValue} and Constant expression is {constantBracketValue.Value}");
+    }
 
-        [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
-        public void Given_left_and_right_ConstantBracketValues_left_eq_right_should_be_returns_same_value_as_Equals(ConstantBracketValue left, ConstantBracketValue right)
-            => (left == right).When(left.Equals(right)).Label($"Left, Right : {(left, right)}");
+    [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
+    public void Given_left_and_right_ConstantBracketValues_left_eq_right_should_be_returns_same_value_as_Equals(ConstantBracketValue left, ConstantBracketValue right)
+        => (left == right).When(left.Equals(right)).Label($"Left, Right : {(left, right)}");
 
-        [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
-        public void Given_left_and_right_ConstantBracketValues_left_neq_right_should_be_returns_same_value_as_Equals(ConstantBracketValue left, ConstantBracketValue right)
-            => (left != right).When(!left.Equals(right)).Label($"Left, Right : {(left, right)}");
+    [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
+    public void Given_left_and_right_ConstantBracketValues_left_neq_right_should_be_returns_same_value_as_Equals(ConstantBracketValue left, ConstantBracketValue right)
+        => (left != right).When(!left.Equals(right)).Label($"Left, Right : {(left, right)}");
 
-        [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
-        public void Equals_should_be_reflexive(NonNull<ConstantBracketValue> expression)
-        {
-            // Act
-            bool actual = expression.Item.Equals(expression.Item);
+    [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
+    public void Equals_should_be_reflexive(NonNull<ConstantBracketValue> expression)
+    {
+        // Act
+        bool actual = expression.Item.Equals(expression.Item);
 
-            // Assert
-            actual.Should().BeTrue("'equals' implementation is reflexive");
-        }
+        // Assert
+        actual.Should().BeTrue("'equals' implementation is reflexive");
+    }
 
-        [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
-        public void Equals_should_be_symmetric(NonNull<ConstantBracketValue> expression, NonNull<BracketValue> otherExpression)
-        {
-            // Act
-            bool actual = expression.Item.Equals(otherExpression.Item) == otherExpression.Item.Equals(expression.Item);
+    [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
+    public void Equals_should_be_symmetric(NonNull<ConstantBracketValue> expression, NonNull<BracketValue> otherExpression)
+    {
+        // Act
+        bool actual = expression.Item.Equals(otherExpression.Item) == otherExpression.Item.Equals(expression.Item);
 
-            // Assert
-            actual.Should().BeTrue("'equals' implementation should be symetric");
-        }
+        // Assert
+        actual.Should().BeTrue("'equals' implementation should be symetric");
+    }
 
-        [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
-        public void Given_ConstantBracketValue_Complexity_should_be_equal_to_inner_expression_complexity(ConstantBracketValue value)
-        {
-            // Arrange
-            double expected = 1 + Math.Pow(2, value.Value.Length);
+    [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
+    public void Given_ConstantBracketValue_Complexity_should_be_equal_to_inner_expression_complexity(ConstantBracketValue value)
+    {
+        // Arrange
+        double expected = 1 + Math.Pow(2, value.Value.Length);
 
-            // Act
-            double actual = value.Complexity;
+        // Act
+        double actual = value.Complexity;
 
-            // Assert
-            actual.Should().Be(expected);
-        }
+        // Assert
+        actual.Should().Be(expected);
     }
 }

--- a/test/DataFilters.UnitTests/Grammar/Syntax/ContainsExpressionTests.cs
+++ b/test/DataFilters.UnitTests/Grammar/Syntax/ContainsExpressionTests.cs
@@ -2,234 +2,233 @@
 using System.Text;
 using DataFilters.Grammar.Parsing;
 
-namespace DataFilters.UnitTests.Grammar.Syntax
+namespace DataFilters.UnitTests.Grammar.Syntax;
+
+using System;
+using DataFilters.Grammar.Syntax;
+using DataFilters.UnitTests.Helpers;
+using FluentAssertions;
+using FsCheck;
+using FsCheck.Xunit;
+using Xunit;
+using Xunit.Abstractions;
+
+public class ContainsExpressionTests(ITestOutputHelper outputHelper)
 {
-    using System;
-    using DataFilters.Grammar.Syntax;
-    using DataFilters.UnitTests.Helpers;
-    using FluentAssertions;
-    using FsCheck;
-    using FsCheck.Xunit;
-    using Xunit;
-    using Xunit.Abstractions;
+    [Fact]
+    public void IsFilterExpression() => typeof(ContainsExpression).Should()
+        .BeAssignableTo<FilterExpression>().And
+        .Implement<IEquatable<ContainsExpression>>().And
+        .Implement<IHaveComplexity>().And
+        .Implement<IParseableString>();
 
-    public class ContainsExpressionTests(ITestOutputHelper outputHelper)
+    [Fact]
+    public void Given_string_argument_is_null_Constructor_should_thros_ArgumentNullException()
     {
-        [Fact]
-        public void IsFilterExpression() => typeof(ContainsExpression).Should()
-                                                                      .BeAssignableTo<FilterExpression>().And
-                                                                      .Implement<IEquatable<ContainsExpression>>().And
-                                                                      .Implement<IHaveComplexity>().And
-                                                                      .Implement<IParseableString>();
+        // Act
+        Action action = () => _ = new ContainsExpression((string)null);
 
-        [Fact]
-        public void Given_string_argument_is_null_Constructor_should_thros_ArgumentNullException()
+        // Assert
+        action.Should()
+            .ThrowExactly<ArgumentNullException>();
+    }
+
+    [Fact]
+    public void Given_TextExpression_is_null_Constructor_should_thros_ArgumentNullException()
+    {
+        // Act
+        Action action = () => _ = new ContainsExpression((TextExpression)null);
+
+        // Assert
+        action.Should()
+            .ThrowExactly<ArgumentNullException>();
+    }
+
+    [Fact]
+    public void Given_TextExpression_argument_is_null_Constructor_should_thros_ArgumentNullException()
+    {
+        // Act
+        Action action = () => _ = new ContainsExpression(string.Empty);
+
+        // Assert
+        action.Should()
+            .ThrowExactly<ArgumentOutOfRangeException>("The parameter of the constructor cannot be empty");
+    }
+
+    [Fact]
+    public void Ctor_DoesNot_Throws_ArgumentOutOfRangeException_When_Argument_Is_WhitespaceOnly()
+    {
+        // Act
+        Action action = () => _ = new ContainsExpression("  ");
+
+        // Assert
+        action.Should()
+            .NotThrow<ArgumentOutOfRangeException>("The parameter of the constructor can be whitespace only");
+        action.Should()
+            .NotThrow("The parameter of the constructor can be whitespace only");
+    }
+
+    public static TheoryData<ContainsExpression, object, bool, string> EqualsCases
+        => new()
         {
-            // Act
-            Action action = () => _ = new ContainsExpression((string)null);
-
-            // Assert
-            action.Should()
-                .ThrowExactly<ArgumentNullException>();
-        }
-
-        [Fact]
-        public void Given_TextExpression_is_null_Constructor_should_thros_ArgumentNullException()
-        {
-            // Act
-            Action action = () => _ = new ContainsExpression((TextExpression)null);
-
-            // Assert
-            action.Should()
-                .ThrowExactly<ArgumentNullException>();
-        }
-
-        [Fact]
-        public void Given_TextExpression_argument_is_null_Constructor_should_thros_ArgumentNullException()
-        {
-            // Act
-            Action action = () => _ = new ContainsExpression(string.Empty);
-
-            // Assert
-            action.Should()
-                .ThrowExactly<ArgumentOutOfRangeException>("The parameter of the constructor cannot be empty");
-        }
-
-        [Fact]
-        public void Ctor_DoesNot_Throws_ArgumentOutOfRangeException_When_Argument_Is_WhitespaceOnly()
-        {
-            // Act
-            Action action = () => _ = new ContainsExpression("  ");
-
-            // Assert
-            action.Should()
-                .NotThrow<ArgumentOutOfRangeException>("The parameter of the constructor can be whitespace only");
-            action.Should()
-                .NotThrow("The parameter of the constructor can be whitespace only");
-        }
-
-        public static TheoryData<ContainsExpression, object, bool, string> EqualsCases
-            => new()
             {
-                {
-                    new ContainsExpression("prop1"),
-                    new ContainsExpression("prop1"),
-                    true,
-                    "comparing two different instances with same property name"
-                },
-                {
-                    new ContainsExpression("prop1"),
-                    new ContainsExpression("prop2"),
-                    false,
-                    "comparing two different instances with different property name"
-                }
-            };
-
-        [Theory]
-        [MemberData(nameof(EqualsCases))]
-        public void ImplementsEqualsCorrectly(ContainsExpression first, object other, bool expected, string reason)
-        {
-            outputHelper.WriteLine($"First instance : {first}");
-            outputHelper.WriteLine($"Second instance : {other}");
-
-            // Act
-            bool actual = first.Equals(other);
-
-            // Assert
-            actual.Should()
-                .Be(expected, reason);
-        }
-
-        [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
-        public void Given_ContainsExpression_Complexity_eq_1U002E5(ContainsExpression contains)
-        {
-            // Act
-            double actual = contains.Complexity;
-
-            // Assert
-            actual.Should().Be(1.5);
-        }
-
-        [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
-        public void IsEquivalentTo_should_be_reflexive(ContainsExpression contains)
-            => contains.IsEquivalentTo(contains).Should().BeTrue();
-
-        [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
-        public void Given_TextExpression_as_input_EscapedParseableString_should_be_correct(NonNull<TextExpression> textExpressionGenerator)
-        {
-            // Arrange
-            TextExpression textExpression = textExpressionGenerator.Item;
-            ContainsExpression expression = new(textExpression);
-
-            string expected = $"*{textExpression.EscapedParseableString}*";
-
-            // Act
-            string actual = expression.EscapedParseableString;
-
-            // Assert
-            actual.Should()
-                  .Be(expected);
-        }
-
-        [Property]
-        public void Given_non_whitespace_string_as_input_Then_EscapedParseableString_should_be_correct(NonWhiteSpaceString textGenerator)
-        {
-            // Arrange
-            string text = textGenerator.Item;
-            ContainsExpression expression = new(text);
-
-            StringBuilder sb = new (text.Length * 2);
-            foreach (char chr in text)
+                new ContainsExpression("prop1"),
+                new ContainsExpression("prop1"),
+                true,
+                "comparing two different instances with same property name"
+            },
             {
-                if (FilterTokenizer.SpecialCharacters.Contains(chr))
-                {
-                    sb = sb.Append('\\');
-                }
-                sb = sb.Append(chr);
+                new ContainsExpression("prop1"),
+                new ContainsExpression("prop2"),
+                false,
+                "comparing two different instances with different property name"
             }
-            string expected = $"*{sb}*";
+        };
 
-            // Act
-            string actual = expression.EscapedParseableString;
+    [Theory]
+    [MemberData(nameof(EqualsCases))]
+    public void ImplementsEqualsCorrectly(ContainsExpression first, object other, bool expected, string reason)
+    {
+        outputHelper.WriteLine($"First instance : {first}");
+        outputHelper.WriteLine($"Second instance : {other}");
 
-            // Assert
-            actual.Should()
-                  .Be(expected);
-        }
+        // Act
+        bool actual = first.Equals(other);
 
-        [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
-        public void Equals_should_be_commutative(NonNull<ContainsExpression> firstGenerator, FilterExpression second)
+        // Assert
+        actual.Should()
+            .Be(expected, reason);
+    }
+
+    [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
+    public void Given_ContainsExpression_Complexity_eq_1U002E5(ContainsExpression contains)
+    {
+        // Act
+        double actual = contains.Complexity;
+
+        // Assert
+        actual.Should().Be(1.5);
+    }
+
+    [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
+    public void IsEquivalentTo_should_be_reflexive(ContainsExpression contains)
+        => contains.IsEquivalentTo(contains).Should().BeTrue();
+
+    [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
+    public void Given_TextExpression_as_input_EscapedParseableString_should_be_correct(NonNull<TextExpression> textExpressionGenerator)
+    {
+        // Arrange
+        TextExpression textExpression = textExpressionGenerator.Item;
+        ContainsExpression expression = new(textExpression);
+
+        string expected = $"*{textExpression.EscapedParseableString}*";
+
+        // Act
+        string actual = expression.EscapedParseableString;
+
+        // Assert
+        actual.Should()
+            .Be(expected);
+    }
+
+    [Property]
+    public void Given_non_whitespace_string_as_input_Then_EscapedParseableString_should_be_correct(NonWhiteSpaceString textGenerator)
+    {
+        // Arrange
+        string text = textGenerator.Item;
+        ContainsExpression expression = new(text);
+
+        StringBuilder sb = new (text.Length * 2);
+        foreach (char chr in text)
         {
-            // Arrange
-            ContainsExpression first = firstGenerator.Item;
-
-            // Act
-            bool firstEqualsSecond = first.Equals(second);
-            bool secondEqualsFirst = second.Equals(first);
-
-            // Assert
-            firstEqualsSecond.Should().Be(secondEqualsFirst, "'equals' implementation must be commutative");
-        }
-
-        [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
-        public void Equals_should_be_reflexive(NonNull<ContainsExpression> expression)
-        {
-            // Act
-            bool actual = expression.Item.Equals(expression.Item);
-
-            // Assert
-            actual.Should().BeTrue("'equals' implementation must be reflexive");
-        }
-
-        [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
-        public void Equals_should_be_symmetric(NonNull<ContainsExpression> expression, NonNull<FilterExpression> otherExpression)
-        {
-            // Act
-
-            bool expressionEqualsOther = expression.Item.Equals(otherExpression.Item);
-            bool otherEqualsExpression = otherExpression.Item.Equals(expression.Item);
-
-            // Assert
-            expressionEqualsOther.Should().Be(otherEqualsExpression, "'equals' implementation must be symmetric");
-        }
-
-        /// <summary>
-        /// Tests the constructor by copy of <see cref="TextExpression"/>.
-        /// </summary>
-        /// <param name="textExpressionGenerator"></param>
-        [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
-        public void Given_constructor_argument_is_TextExpression_Then_ContainsExpression_should_be_correct(NonNull<TextExpression> textExpressionGenerator)
-        {
-            // Arrange
-            TextExpression textExpression = textExpressionGenerator.Item;
-            outputHelper.WriteLine($"TextExpression : {textExpression.EscapedParseableString}");
-
-            // Act
-            ContainsExpression containsExpression = new (textExpression);
-
-            // Assert
-            containsExpression.EscapedParseableString.Should()
-                .Be($"*{textExpression.EscapedParseableString}*");
-        }
-
-        public static TheoryData<string, string> EscapedParseableStringCases
-            => new()
+            if (FilterTokenizer.SpecialCharacters.Contains(chr))
             {
-                { "Oi\fj8G]t:JK%H6m>+r{)[5\n6", "*Oi\fj8G\\]t\\:JK%H6m>+r\\{\\)\\[5\n6*" }
-            };
-
-        [Theory]
-        [MemberData(nameof(EscapedParseableStringCases))]
-        public void Given_input_as_string_Then_the_constructor_should_properly_escape_it(string input, string expected)
-        {
-            // Arrange
-            ContainsExpression expression = new(input);
-
-            // Act
-            string actual = expression.EscapedParseableString;
-
-            // Assert
-            actual.Should().Be(expected);
+                sb = sb.Append('\\');
+            }
+            sb = sb.Append(chr);
         }
+        string expected = $"*{sb}*";
+
+        // Act
+        string actual = expression.EscapedParseableString;
+
+        // Assert
+        actual.Should()
+            .Be(expected);
+    }
+
+    [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
+    public void Equals_should_be_commutative(NonNull<ContainsExpression> firstGenerator, FilterExpression second)
+    {
+        // Arrange
+        ContainsExpression first = firstGenerator.Item;
+
+        // Act
+        bool firstEqualsSecond = first.Equals(second);
+        bool secondEqualsFirst = second.Equals(first);
+
+        // Assert
+        firstEqualsSecond.Should().Be(secondEqualsFirst, "'equals' implementation must be commutative");
+    }
+
+    [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
+    public void Equals_should_be_reflexive(NonNull<ContainsExpression> expression)
+    {
+        // Act
+        bool actual = expression.Item.Equals(expression.Item);
+
+        // Assert
+        actual.Should().BeTrue("'equals' implementation must be reflexive");
+    }
+
+    [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
+    public void Equals_should_be_symmetric(NonNull<ContainsExpression> expression, NonNull<FilterExpression> otherExpression)
+    {
+        // Act
+
+        bool expressionEqualsOther = expression.Item.Equals(otherExpression.Item);
+        bool otherEqualsExpression = otherExpression.Item.Equals(expression.Item);
+
+        // Assert
+        expressionEqualsOther.Should().Be(otherEqualsExpression, "'equals' implementation must be symmetric");
+    }
+
+    /// <summary>
+    /// Tests the constructor by copy of <see cref="TextExpression"/>.
+    /// </summary>
+    /// <param name="textExpressionGenerator"></param>
+    [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
+    public void Given_constructor_argument_is_TextExpression_Then_ContainsExpression_should_be_correct(NonNull<TextExpression> textExpressionGenerator)
+    {
+        // Arrange
+        TextExpression textExpression = textExpressionGenerator.Item;
+        outputHelper.WriteLine($"TextExpression : {textExpression.EscapedParseableString}");
+
+        // Act
+        ContainsExpression containsExpression = new (textExpression);
+
+        // Assert
+        containsExpression.EscapedParseableString.Should()
+            .Be($"*{textExpression.EscapedParseableString}*");
+    }
+
+    public static TheoryData<string, string> EscapedParseableStringCases
+        => new()
+        {
+            { "Oi\fj8G]t:JK%H6m>+r{)[5\n6", "*Oi\fj8G\\]t\\:JK%H6m>+r\\{\\)\\[5\n6*" }
+        };
+
+    [Theory]
+    [MemberData(nameof(EscapedParseableStringCases))]
+    public void Given_input_as_string_Then_the_constructor_should_properly_escape_it(string input, string expected)
+    {
+        // Arrange
+        ContainsExpression expression = new(input);
+
+        // Act
+        string actual = expression.EscapedParseableString;
+
+        // Assert
+        actual.Should().Be(expected);
     }
 }

--- a/test/DataFilters.UnitTests/Grammar/Syntax/DateExpressionTests.cs
+++ b/test/DataFilters.UnitTests/Grammar/Syntax/DateExpressionTests.cs
@@ -1,115 +1,114 @@
-﻿namespace DataFilters.UnitTests.Grammar.Syntax
+﻿namespace DataFilters.UnitTests.Grammar.Syntax;
+
+using System;
+using DataFilters.Grammar.Syntax;
+using DataFilters.UnitTests.Helpers;
+using FluentAssertions;
+using FsCheck;
+using FsCheck.Fluent;
+using FsCheck.Xunit;
+using Xunit;
+
+public class DateExpressionTests
 {
-    using System;
-    using DataFilters.Grammar.Syntax;
-    using DataFilters.UnitTests.Helpers;
-    using FluentAssertions;
-    using FsCheck;
-    using FsCheck.Fluent;
-    using FsCheck.Xunit;
-    using Xunit;
+    [Fact]
+    public void IsFilterExpression() => typeof(DateExpression).Should()
+        .BeAssignableTo<FilterExpression>().And
+        .Implement<IEquatable<DateExpression>>().And
+        .Implement<IBoundaryExpression>();
 
-    public class DateExpressionTests
+    [Property]
+    public void Given_DateExpression_instance_instance_eq_instance_should_be_true(PositiveInt year, PositiveInt month, PositiveInt day)
     {
-        [Fact]
-        public void IsFilterExpression() => typeof(DateExpression).Should()
-                                            .BeAssignableTo<FilterExpression>().And
-                                            .Implement<IEquatable<DateExpression>>().And
-                                            .Implement<IBoundaryExpression>();
+        // Arrange
+        DateExpression instance = new(year.Item, month.Item, day.Item);
 
-        [Property]
-        public void Given_DateExpression_instance_instance_eq_instance_should_be_true(PositiveInt year, PositiveInt month, PositiveInt day)
+        // Act
+        bool actual = instance.Equals(instance);
+
+        // Assert
+        actual.Should()
+            .BeTrue();
+    }
+
+    [Property]
+    public void Given_DateExpression_instance_instance_eq_null_should_be_false(PositiveInt year, PositiveInt month, PositiveInt day)
+    {
+        // Arrange
+        DateExpression instance = new(year.Item, month.Item, day.Item);
+
+        // Act
+        bool actual = instance.Equals(null);
+
+        // Assert
+        actual.Should()
+            .BeFalse();
+    }
+
+    [Property]
+    public void Given_two_DateExpression_instances_first_and_other_with_same_data_first_eq_other_should_be_true(PositiveInt year, PositiveInt month, PositiveInt day)
+    {
+        // Arrange
+        DateExpression first = new(year.Item, month.Item, day.Item);
+        DateExpression other = new(year.Item, month.Item, day.Item);
+
+        // Act
+        bool actual = first.Equals(other);
+        int firstHashCode = first.GetHashCode();
+        int otherHashCode = other.GetHashCode();
+
+        // Assert
+        actual.Should().BeTrue();
+        firstHashCode.Should().Be(otherHashCode);
+    }
+
+    [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
+    public void Given_DateExpression_GetComplexity_should_return_1(NonNull<DateExpression> date)
+        => date.Item.Complexity.Should().Be(1);
+
+    [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
+    public void Equals_should_be_commutative(NonNull<DateExpression> first, FilterExpression second)
+        => (first.Item.Equals(second) == second.Equals(first.Item)).ToProperty();
+
+    [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
+    public void Equals_should_be_reflexive(NonNull<DateExpression> expression)
+        => expression.Item.Should().Be(expression.Item);
+
+    [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
+    public void Equals_should_be_symetric(NonNull<DateExpression> expression, NonNull<FilterExpression> otherExpression)
+        => expression.Item.Equals(otherExpression.Item).Should().Be(otherExpression.Item.Equals(expression.Item));
+
+    [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
+    public void IsEquivalent_should_be_commutative(NonNull<DateExpression> first, FilterExpression second)
+        => first.Item.IsEquivalentTo(second).Should().Be(second.IsEquivalentTo(first.Item));
+
+    [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
+    public void IsEquivalentTo_should_be_reflexive(NonNull<DateExpression> expression)
+        => expression.Item.IsEquivalentTo(expression.Item).Should().BeTrue();
+
+    [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
+    public void IsEquivalentTo_should_be_symetric(NonNull<DateExpression> expression, NonNull<FilterExpression> otherExpression)
+        => expression.Item.IsEquivalentTo(otherExpression.Item).Should().Be(otherExpression.Item.IsEquivalentTo(expression.Item));
+
+    [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
+    public void Given_left_and_right_operands_Equal_operator_should_return_same_result_as_using_Equals(NonNull<DateExpression> left, NonNull<DateExpression> right)
+        => (left.Item == right.Item).Should().Be(left.Item.Equals(right.Item));
+
+    [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
+    public void Given_left_and_right_operands_NotEquals_operator_should_return_opposite_result_of_Equals(NonNull<DateExpression> left, NonNull<DateExpression> right)
+        => (left.Item != right.Item).Should().Be(!left.Item.Equals(right.Item));
+
+    [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
+    public void Given_years_month_and_days_When_either_years_or_months_or_days_is_less_than_1_Then_constructor_should_throw_ArgumentOutOfRangeException(int years, int months, int days)
+    {
+        // Act
+        Action invokingConstructor = () => _ = new DateExpression(years, months, days);
+
+        // Assert
+        object __ = (years, months, days) switch
         {
-            // Arrange
-            DateExpression instance = new(year.Item, month.Item, day.Item);
-
-            // Act
-            bool actual = instance.Equals(instance);
-
-            // Assert
-            actual.Should()
-                  .BeTrue();
-        }
-
-        [Property]
-        public void Given_DateExpression_instance_instance_eq_null_should_be_false(PositiveInt year, PositiveInt month, PositiveInt day)
-        {
-            // Arrange
-            DateExpression instance = new(year.Item, month.Item, day.Item);
-
-            // Act
-            bool actual = instance.Equals(null);
-
-            // Assert
-            actual.Should()
-                  .BeFalse();
-        }
-
-        [Property]
-        public void Given_two_DateExpression_instances_first_and_other_with_same_data_first_eq_other_should_be_true(PositiveInt year, PositiveInt month, PositiveInt day)
-        {
-            // Arrange
-            DateExpression first = new(year.Item, month.Item, day.Item);
-            DateExpression other = new(year.Item, month.Item, day.Item);
-
-            // Act
-            bool actual = first.Equals(other);
-            int firstHashCode = first.GetHashCode();
-            int otherHashCode = other.GetHashCode();
-
-            // Assert
-            actual.Should().BeTrue();
-            firstHashCode.Should().Be(otherHashCode);
-        }
-
-        [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
-        public void Given_DateExpression_GetComplexity_should_return_1(NonNull<DateExpression> date)
-            => date.Item.Complexity.Should().Be(1);
-
-        [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
-        public void Equals_should_be_commutative(NonNull<DateExpression> first, FilterExpression second)
-            => (first.Item.Equals(second) == second.Equals(first.Item)).ToProperty();
-
-        [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
-        public void Equals_should_be_reflexive(NonNull<DateExpression> expression)
-            => expression.Item.Should().Be(expression.Item);
-
-        [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
-        public void Equals_should_be_symetric(NonNull<DateExpression> expression, NonNull<FilterExpression> otherExpression)
-            => expression.Item.Equals(otherExpression.Item).Should().Be(otherExpression.Item.Equals(expression.Item));
-
-        [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
-        public void IsEquivalent_should_be_commutative(NonNull<DateExpression> first, FilterExpression second)
-            => first.Item.IsEquivalentTo(second).Should().Be(second.IsEquivalentTo(first.Item));
-
-        [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
-        public void IsEquivalentTo_should_be_reflexive(NonNull<DateExpression> expression)
-            => expression.Item.IsEquivalentTo(expression.Item).Should().BeTrue();
-
-        [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
-        public void IsEquivalentTo_should_be_symetric(NonNull<DateExpression> expression, NonNull<FilterExpression> otherExpression)
-            => expression.Item.IsEquivalentTo(otherExpression.Item).Should().Be(otherExpression.Item.IsEquivalentTo(expression.Item));
-
-        [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
-        public void Given_left_and_right_operands_Equal_operator_should_return_same_result_as_using_Equals(NonNull<DateExpression> left, NonNull<DateExpression> right)
-            => (left.Item == right.Item).Should().Be(left.Item.Equals(right.Item));
-
-        [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
-        public void Given_left_and_right_operands_NotEquals_operator_should_return_opposite_result_of_Equals(NonNull<DateExpression> left, NonNull<DateExpression> right)
-            => (left.Item != right.Item).Should().Be(!left.Item.Equals(right.Item));
-
-        [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
-        public void Given_years_month_and_days_When_either_years_or_months_or_days_is_less_than_1_Then_constructor_should_throw_ArgumentOutOfRangeException(int years, int months, int days)
-        {
-            // Act
-            Action invokingConstructor = () => _ = new DateExpression(years, months, days);
-
-            // Assert
-            object __ = (years, months, days) switch
-            {
-                var (y, m, d) when y < 1 || m < 1 || d < 1 => invokingConstructor.Should().Throw<ArgumentOutOfRangeException>("because years, months and days must be greater than or equal to 1"),
-                _ => invokingConstructor.Should().NotThrow("because years, months and days are greater than or equal to 1")
-            };
-        }
+            var (y, m, d) when y < 1 || m < 1 || d < 1 => invokingConstructor.Should().Throw<ArgumentOutOfRangeException>("because years, months and days must be greater than or equal to 1"),
+            _ => invokingConstructor.Should().NotThrow("because years, months and days are greater than or equal to 1")
+        };
     }
 }

--- a/test/DataFilters.UnitTests/Grammar/Syntax/DateTimeExpressionTests.cs
+++ b/test/DataFilters.UnitTests/Grammar/Syntax/DateTimeExpressionTests.cs
@@ -1,230 +1,229 @@
-﻿namespace DataFilters.UnitTests.Grammar.Syntax
+﻿namespace DataFilters.UnitTests.Grammar.Syntax;
+
+using System;
+using DataFilters.Grammar.Syntax;
+using DataFilters.UnitTests.Helpers;
+using FluentAssertions;
+using FluentAssertions.Extensions;
+using FsCheck;
+using FsCheck.Xunit;
+using Xunit;
+using Xunit.Abstractions;
+using Xunit.Categories;
+
+[Feature(nameof(DataFilters.Grammar.Syntax))]
+public class DateTimeExpressionTests(ITestOutputHelper outputHelper)
 {
-    using System;
-    using DataFilters.Grammar.Syntax;
-    using DataFilters.UnitTests.Helpers;
-    using FluentAssertions;
-    using FluentAssertions.Extensions;
-    using FsCheck;
-    using FsCheck.Xunit;
-    using Xunit;
-    using Xunit.Abstractions;
-    using Xunit.Categories;
+    [Fact]
+    public void IsFilterExpression() => typeof(DateTimeExpression).Should()
+        .BeAssignableTo<FilterExpression>().And
+        .Implement<IEquatable<DateTimeExpression>>().And
+        .HaveConstructor(new[] { typeof(DateExpression), typeof(TimeExpression), typeof(OffsetExpression) }).And
+        .HaveConstructor(new[] { typeof(DateExpression), typeof(TimeExpression) }).And
+        .HaveConstructor(new[] { typeof(TimeExpression) }).And
+        .HaveConstructor(new[] { typeof(DateExpression) }).And
+        .HaveProperty<DateExpression>("Date").And
+        .HaveProperty<TimeExpression>("Time").And
+        .HaveProperty<OffsetExpression>("Offset");
 
-    [Feature(nameof(DataFilters.Grammar.Syntax))]
-    public class DateTimeExpressionTests(ITestOutputHelper outputHelper)
+    [Fact]
+    public void Given_date_and_time_parameters_are_null_Constructor_should_throws_ArgumentException()
     {
-        [Fact]
-        public void IsFilterExpression() => typeof(DateTimeExpression).Should()
-                                            .BeAssignableTo<FilterExpression>().And
-                                            .Implement<IEquatable<DateTimeExpression>>().And
-                                            .HaveConstructor(new[] { typeof(DateExpression), typeof(TimeExpression), typeof(OffsetExpression) }).And
-                                            .HaveConstructor(new[] { typeof(DateExpression), typeof(TimeExpression) }).And
-                                            .HaveConstructor(new[] { typeof(TimeExpression) }).And
-                                            .HaveConstructor(new[] { typeof(DateExpression) }).And
-                                            .HaveProperty<DateExpression>("Date").And
-                                            .HaveProperty<TimeExpression>("Time").And
-                                            .HaveProperty<OffsetExpression>("Offset");
+        // Act
+        Action ctor = () => new DateTimeExpression(null, null);
 
-        [Fact]
-        public void Given_date_and_time_parameters_are_null_Constructor_should_throws_ArgumentException()
+        // Assert
+        ctor.Should()
+            .ThrowExactly<ArgumentException>("both date and time are null");
+    }
+
+    [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
+    public void A_non_null_DateTimeExpression_instance_should_never_be_equal_to_null(DateTimeExpression instance)
+    {
+        // Act
+        bool actual = instance.Equals(null);
+
+        // Assert
+        actual.Should()
+            .BeFalse();
+    }
+
+    [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
+    public void Two_DateTimeExpression_instances_which_have_same_data_should_be_equal(DateExpression date, TimeExpression time, OffsetExpression offset)
+    {
+        // Arrange
+        DateTimeExpression first = new(date, time, offset);
+        DateTimeExpression other = new(date, time, offset);
+
+        // Act
+        bool actual = first.Equals(other);
+
+        // Assert
+        actual.Should()
+            .BeTrue();
+        first.GetHashCode().Should()
+            .Be(other.GetHashCode(), "Two instances that are equal should have same hashcode");
+    }
+
+    [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
+    public void A_DateTimeExpression_built_from_variables_obtained_from_deconstructing_a_DateTimeExpression_should_equal_the_original_DateTimeExpression_value(DateTimeExpression source)
+    {
+        outputHelper.WriteLine(message: $"DateTimeExpression is {source}");
+        (DateExpression date, TimeExpression time, OffsetExpression offset, _) = source;
+
+        // Act
+        DateTimeExpression clone = new(date, time, offset);
+
+        // Assert
+        clone.Should()
+            .Be(source);
+    }
+
+    [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
+    public void Given_DateTimeExpression_Complexity_Should_be_the_sum_of_complexity_of_each_member(NonNull<DateExpression> date, NonNull<TimeExpression> time, NonNull<OffsetExpression> offset)
+    {
+        // Arrange
+        DateTimeExpression dateTimeExpression = new(date.Item, time.Item, offset.Item);
+        double expected = date.Item.Complexity + time.Item.Complexity + offset.Item.Complexity;
+
+        // Act
+        double actual = dateTimeExpression.Complexity;
+
+        // Assert
+        actual.Should()
+            .BeGreaterThanOrEqualTo(3).And
+            .Be(expected);
+    }
+
+    [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
+    public void Given_DateTimeExpression_where_only_date_part_is_set_When_comparing_to_DateExpression_IsEquivalentTo_should_be_true(NonNull<DateExpression> dateExpression)
+    {
+        // Arrange
+        DateTimeExpression dateTimeExpression = new(dateExpression.Item);
+
+        // Act
+        bool actual = dateTimeExpression.IsEquivalentTo(dateExpression.Item);
+
+        // Assert
+        actual.Should().BeTrue();
+    }
+
+    [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
+    public void Given_DateTimeExpression_where_only_time_part_is_set_When_comparing_to_that_TimeExpression(NonNull<TimeExpression> timeExpression)
+    {
+        // Arrange
+        DateTimeExpression dateTimeExpression = new(timeExpression.Item);
+
+        // Act
+        bool actual = dateTimeExpression.IsEquivalentTo(timeExpression.Item);
+
+        // Assert
+        actual.Should().BeTrue();
+        dateTimeExpression.Complexity.Should().BeGreaterThan(timeExpression.Item.Complexity);
+    }
+
+    public static TheoryData<DateTimeExpression, object, bool, string> EqualsCases
+        => new()
         {
-            // Act
-            Action ctor = () => new DateTimeExpression(null, null);
-
-            // Assert
-            ctor.Should()
-                .ThrowExactly<ArgumentException>("both date and time are null");
-        }
-
-        [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
-        public void A_non_null_DateTimeExpression_instance_should_never_be_equal_to_null(DateTimeExpression instance)
-        {
-            // Act
-            bool actual = instance.Equals(null);
-
-            // Assert
-            actual.Should()
-                  .BeFalse();
-        }
-
-        [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
-        public void Two_DateTimeExpression_instances_which_have_same_data_should_be_equal(DateExpression date, TimeExpression time, OffsetExpression offset)
-        {
-            // Arrange
-            DateTimeExpression first = new(date, time, offset);
-            DateTimeExpression other = new(date, time, offset);
-
-            // Act
-            bool actual = first.Equals(other);
-
-            // Assert
-            actual.Should()
-                  .BeTrue();
-            first.GetHashCode().Should()
-                               .Be(other.GetHashCode(), "Two instances that are equal should have same hashcode");
-        }
-
-        [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
-        public void A_DateTimeExpression_built_from_variables_obtained_from_deconstructing_a_DateTimeExpression_should_equal_the_original_DateTimeExpression_value(DateTimeExpression source)
-        {
-            outputHelper.WriteLine(message: $"DateTimeExpression is {source}");
-            (DateExpression date, TimeExpression time, OffsetExpression offset, _) = source;
-
-            // Act
-            DateTimeExpression clone = new(date, time, offset);
-
-            // Assert
-            clone.Should()
-                 .Be(source);
-        }
-
-        [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
-        public void Given_DateTimeExpression_Complexity_Should_be_the_sum_of_complexity_of_each_member(NonNull<DateExpression> date, NonNull<TimeExpression> time, NonNull<OffsetExpression> offset)
-        {
-            // Arrange
-            DateTimeExpression dateTimeExpression = new(date.Item, time.Item, offset.Item);
-            double expected = date.Item.Complexity + time.Item.Complexity + offset.Item.Complexity;
-
-            // Act
-            double actual = dateTimeExpression.Complexity;
-
-            // Assert
-            actual.Should()
-                  .BeGreaterThanOrEqualTo(3).And
-                  .Be(expected);
-        }
-
-        [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
-        public void Given_DateTimeExpression_where_only_date_part_is_set_When_comparing_to_DateExpression_IsEquivalentTo_should_be_true(NonNull<DateExpression> dateExpression)
-        {
-            // Arrange
-            DateTimeExpression dateTimeExpression = new(dateExpression.Item);
-
-            // Act
-            bool actual = dateTimeExpression.IsEquivalentTo(dateExpression.Item);
-
-            // Assert
-            actual.Should().BeTrue();
-        }
-
-        [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
-        public void Given_DateTimeExpression_where_only_time_part_is_set_When_comparing_to_that_TimeExpression(NonNull<TimeExpression> timeExpression)
-        {
-            // Arrange
-            DateTimeExpression dateTimeExpression = new(timeExpression.Item);
-
-            // Act
-            bool actual = dateTimeExpression.IsEquivalentTo(timeExpression.Item);
-
-            // Assert
-            actual.Should().BeTrue();
-            dateTimeExpression.Complexity.Should().BeGreaterThan(timeExpression.Item.Complexity);
-        }
-
-        public static TheoryData<DateTimeExpression, object, bool, string> EqualsCases
-            => new()
             {
-                {
-                    new DateTimeExpression(new TimeExpression()),
-                    new TimeExpression(),
-                    true,
-                    $"{nameof(DateTimeExpression.Date)} and {nameof(DateTimeExpression.Date)} are null and TimeExpression are equal"
-                },
-                {
-                    new DateTimeExpression(new (), new (), new()),
-                    new DateTimeExpression(new (), new (), new()),
-                    true,
-                    $"Two instances with {nameof(DateTimeExpression)} that are equal"
-                },
-                {
-                    new DateTimeExpression(new(2090, 10, 10), new (03,00,40, 583), OffsetExpression.Zero),
-                    new DateTimeExpression(new(2090, 10, 10), new (03,00,40, 583), OffsetExpression.Zero),
-                    true,
-                    $"Two instances with {nameof(DateTimeExpression.Date)}, {nameof(DateTimeExpression.Time)}, {nameof(DateTimeExpression.Offset)} are equal and not null"
-                }
-            };
-
-        [Theory]
-        [MemberData(nameof(EqualsCases))]
-        public void Equals_should_work_as_expected(DateTimeExpression dateTime, object obj, bool expected, string reason)
-        {
-            // Act
-            bool actual = dateTime.Equals(obj);
-
-            // Assert
-            actual.Should()
-                  .Be(expected, reason);
-        }
-
-        [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
-        public void Equals_should_be_commutative(NonNull<DateTimeExpression> first, FilterExpression second)
-            => first.Item.Equals(second).Should().Be(second.Equals(first.Item));
-
-        [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
-        public void Equals_should_be_reflexive(NonNull<DateTimeExpression> expression)
-            => expression.Item.Should().Be(expression.Item);
-
-        [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
-        public void Equals_should_be_symetric(NonNull<DateTimeExpression> expression, NonNull<FilterExpression> otherExpression)
-            => expression.Item.Equals(otherExpression.Item).Should().Be(otherExpression.Item.Equals(expression.Item));
-
-        public static TheoryData<DateTimeExpression, object, object> EqualsTransitivityCases
-            => new()
+                new DateTimeExpression(new TimeExpression()),
+                new TimeExpression(),
+                true,
+                $"{nameof(DateTimeExpression.Date)} and {nameof(DateTimeExpression.Date)} are null and TimeExpression are equal"
+            },
             {
-                {
-                    new DateTimeExpression(1.January(2010)),
-                    new DateTimeExpression(1.January(2010)),
-                    new DateTimeExpression(1.January(2010))
-                },
-                {
-                    new DateTimeExpression(new TimeExpression(1)),
-                    new DateTimeExpression(new TimeExpression(minutes: 60)),
-                    new DateTimeExpression(new TimeExpression(seconds: 3600))
-                },
-                {
-                    new DateTimeExpression(new TimeExpression(1)),
-                    new DateTimeExpression(new TimeExpression(minutes: 60)),
-                    new DateTimeExpression(new TimeExpression(seconds: 3600))
-                }
-            };
+                new DateTimeExpression(new (), new (), new()),
+                new DateTimeExpression(new (), new (), new()),
+                true,
+                $"Two instances with {nameof(DateTimeExpression)} that are equal"
+            },
+            {
+                new DateTimeExpression(new(2090, 10, 10), new (03,00,40, 583), OffsetExpression.Zero),
+                new DateTimeExpression(new(2090, 10, 10), new (03,00,40, 583), OffsetExpression.Zero),
+                true,
+                $"Two instances with {nameof(DateTimeExpression.Date)}, {nameof(DateTimeExpression.Time)}, {nameof(DateTimeExpression.Offset)} are equal and not null"
+            }
+        };
 
-        [Theory]
-        [MemberData(nameof(EqualsTransitivityCases))]
-        public void Equals_should_be_transitive(DateTimeExpression first, object second, object third)
+    [Theory]
+    [MemberData(nameof(EqualsCases))]
+    public void Equals_should_work_as_expected(DateTimeExpression dateTime, object obj, bool expected, string reason)
+    {
+        // Act
+        bool actual = dateTime.Equals(obj);
+
+        // Assert
+        actual.Should()
+            .Be(expected, reason);
+    }
+
+    [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
+    public void Equals_should_be_commutative(NonNull<DateTimeExpression> first, FilterExpression second)
+        => first.Item.Equals(second).Should().Be(second.Equals(first.Item));
+
+    [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
+    public void Equals_should_be_reflexive(NonNull<DateTimeExpression> expression)
+        => expression.Item.Should().Be(expression.Item);
+
+    [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
+    public void Equals_should_be_symetric(NonNull<DateTimeExpression> expression, NonNull<FilterExpression> otherExpression)
+        => expression.Item.Equals(otherExpression.Item).Should().Be(otherExpression.Item.Equals(expression.Item));
+
+    public static TheoryData<DateTimeExpression, object, object> EqualsTransitivityCases
+        => new()
         {
-            // Arrange
-            bool firstEqualsSecond = first.Equals(second);
-            bool secondEqualsThird = second.Equals(third);
+            {
+                new DateTimeExpression(1.January(2010)),
+                new DateTimeExpression(1.January(2010)),
+                new DateTimeExpression(1.January(2010))
+            },
+            {
+                new DateTimeExpression(new TimeExpression(1)),
+                new DateTimeExpression(new TimeExpression(minutes: 60)),
+                new DateTimeExpression(new TimeExpression(seconds: 3600))
+            },
+            {
+                new DateTimeExpression(new TimeExpression(1)),
+                new DateTimeExpression(new TimeExpression(minutes: 60)),
+                new DateTimeExpression(new TimeExpression(seconds: 3600))
+            }
+        };
 
-            // Act
-            bool actual = first.Equals(third);
+    [Theory]
+    [MemberData(nameof(EqualsTransitivityCases))]
+    public void Equals_should_be_transitive(DateTimeExpression first, object second, object third)
+    {
+        // Arrange
+        bool firstEqualsSecond = first.Equals(second);
+        bool secondEqualsThird = second.Equals(third);
 
-            // Assert
-            actual.Should()
-                  .Be(firstEqualsSecond && secondEqualsThird);
-        }
+        // Act
+        bool actual = first.Equals(third);
 
-        [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
-        public void Given_left_and_right_operands_Equal_operator_should_return_same_result_as_using_Equals(NonNull<DateTimeExpression> left, NonNull<DateTimeExpression> right)
-        {
-            // Act
-            bool actual = left.Item == right.Item;
+        // Assert
+        actual.Should()
+            .Be(firstEqualsSecond && secondEqualsThird);
+    }
 
-            // Assert
-            actual.Should()
-                  .Be(left.Item.Equals(right.Item));
-        }
+    [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
+    public void Given_left_and_right_operands_Equal_operator_should_return_same_result_as_using_Equals(NonNull<DateTimeExpression> left, NonNull<DateTimeExpression> right)
+    {
+        // Act
+        bool actual = left.Item == right.Item;
 
-        [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
-        public void Given_left_and_right_operands_NotEqual_operator_should_return_opposite_result_of_Equal_operator(NonNull<DateTimeExpression> left, NonNull<DateTimeExpression> right)
-        {
-            // Act
-            bool actual = left.Item != right.Item;
+        // Assert
+        actual.Should()
+            .Be(left.Item.Equals(right.Item));
+    }
 
-            // Assert
-            actual.Should()
-                  .Be(!left.Item.Equals(right.Item));
-        }
+    [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
+    public void Given_left_and_right_operands_NotEqual_operator_should_return_opposite_result_of_Equal_operator(NonNull<DateTimeExpression> left, NonNull<DateTimeExpression> right)
+    {
+        // Act
+        bool actual = left.Item != right.Item;
+
+        // Assert
+        actual.Should()
+            .Be(!left.Item.Equals(right.Item));
     }
 }

--- a/test/DataFilters.UnitTests/Grammar/Syntax/DurationExpressionTests.cs
+++ b/test/DataFilters.UnitTests/Grammar/Syntax/DurationExpressionTests.cs
@@ -1,184 +1,183 @@
-namespace DataFilters.UnitTests.Grammar.Syntax
+namespace DataFilters.UnitTests.Grammar.Syntax;
+
+using System;
+using DataFilters.Grammar.Syntax;
+using DataFilters.UnitTests.Helpers;
+using FluentAssertions;
+using FsCheck;
+using FsCheck.Xunit;
+using Xunit;
+using Xunit.Abstractions;
+using Xunit.Categories;
+
+[UnitTest]
+public class DurationExpressionTests(ITestOutputHelper outputHelper)
 {
-    using System;
-    using DataFilters.Grammar.Syntax;
-    using DataFilters.UnitTests.Helpers;
-    using FluentAssertions;
-    using FsCheck;
-    using FsCheck.Xunit;
-    using Xunit;
-    using Xunit.Abstractions;
-    using Xunit.Categories;
+    [Fact]
+    public void IsFilterExpression() => typeof(DurationExpression).Should()
+        .BeDerivedFrom<FilterExpression>();
 
-    [UnitTest]
-    public class DurationExpressionTests(ITestOutputHelper outputHelper)
+    [Property]
+    public void Throws_ArgumentOutOfRangeException_when_any_ctor_input_is_negative(int years, int months, int weeks, int days, int hours, int minutes, int seconds)
     {
-        [Fact]
-        public void IsFilterExpression() => typeof(DurationExpression).Should()
-                                                                      .BeDerivedFrom<FilterExpression>();
+        Action invokingConstructor = () => _ = new DurationExpression(years, months, weeks, days, hours, minutes, seconds);
 
-        [Property]
-        public void Throws_ArgumentOutOfRangeException_when_any_ctor_input_is_negative(int years, int months, int weeks, int days, int hours, int minutes, int seconds)
+        object __ = (years, months, weeks, days, hours, minutes, seconds) switch
         {
-            Action invokingConstructor = () => _ = new DurationExpression(years, months, weeks, days, hours, minutes, seconds);
+            var tuple when tuple.years < 0
+                           || tuple.months < 0
+                           || tuple.weeks < 0
+                           || tuple.days < 0
+                           || tuple.hours < 0
+                           || tuple.minutes < 0
+                           || tuple.seconds < 0 => invokingConstructor.Should().ThrowExactly<ArgumentOutOfRangeException>(),
+            _ => invokingConstructor.Should().NotThrow()
+        };
+    }
 
-            object __ = (years, months, weeks, days, hours, minutes, seconds) switch
-            {
-                var tuple when tuple.years < 0
-                               || tuple.months < 0
-                               || tuple.weeks < 0
-                               || tuple.days < 0
-                               || tuple.hours < 0
-                               || tuple.minutes < 0
-                               || tuple.seconds < 0 => invokingConstructor.Should().ThrowExactly<ArgumentOutOfRangeException>(),
-                _ => invokingConstructor.Should().NotThrow()
-            };
-        }
+    [Property]
+    public void Set_properties_accordingly(PositiveInt years, PositiveInt months, PositiveInt weeks, PositiveInt days, PositiveInt hours, PositiveInt minutes, PositiveInt seconds)
+    {
+        DurationExpression duration = new(years.Item, months.Item, weeks.Item, days.Item, hours.Item, minutes.Item, seconds.Item);
 
-        [Property]
-        public void Set_properties_accordingly(PositiveInt years, PositiveInt months, PositiveInt weeks, PositiveInt days, PositiveInt hours, PositiveInt minutes, PositiveInt seconds)
+        duration.Years.Should().Be(years.Item);
+        duration.Months.Should().Be(months.Item);
+        duration.Days.Should().Be(days.Item);
+        duration.Hours.Should().Be(hours.Item);
+        duration.Minutes.Should().Be(minutes.Item);
+        duration.Seconds.Should().Be(seconds.Item);
+    }
+
+    [Property]
+    public void Equals_depends_on_values_only(PositiveInt years, PositiveInt months, PositiveInt weeks, PositiveInt days, PositiveInt hours, PositiveInt minutes, PositiveInt seconds)
+    {
+        DurationExpression first = new(years.Item, months.Item, weeks.Item, days.Item, hours.Item, minutes.Item, seconds.Item);
+        DurationExpression other = new(years.Item, months.Item, weeks.Item, days.Item, hours.Item, minutes.Item, seconds.Item);
+
+        // Act
+        bool actual = first.Equals(other);
+        int firstHashCode = first.GetHashCode();
+        int otherHashCode = other.GetHashCode();
+
+        // Assert
+        actual.Should().BeTrue();
+        firstHashCode.Should().Be(otherHashCode);
+    }
+
+    [Property]
+    public void Two_durations_that_are_equal_are_equivalent(PositiveInt years, PositiveInt months, PositiveInt weeks, PositiveInt days, PositiveInt hours, PositiveInt minutes, PositiveInt seconds)
+    {
+        DurationExpression first = new(years.Item, months.Item, weeks.Item, days.Item, hours.Item, minutes.Item, seconds.Item);
+        DurationExpression other = new(years.Item, months.Item, weeks.Item, days.Item, hours.Item, minutes.Item, seconds.Item);
+
+        // Act
+        bool firstEqualsOther = first.Equals(other);
+        bool firstIsEquivalentToOther = first.IsEquivalentTo(other);
+
+        // Assert
+        firstEqualsOther.Should().BeTrue();
+        firstIsEquivalentToOther.Should().BeTrue();
+    }
+
+    [Property]
+    public void Two_durations_are_equivalent_when_they_represent_same_timespan()
+    {
+        // Arrange
+        DurationExpression first = new(hours: 24);
+        DurationExpression other = new(days: 1);
+
+        // Act
+        bool firstEqualsOther = first.Equals(other);
+        bool firstIsEquivalentToOther = first.IsEquivalentTo(other);
+
+        // Assert
+        firstEqualsOther.Should().BeFalse("two durations initialized with timespans that are not in the same unit of time");
+        firstIsEquivalentToOther.Should().BeTrue("two durations initialized from timespans that are equal should be equivalent");
+    }
+
+    [Property]
+    public void Equals_to_null_always_returns_false(PositiveInt years, PositiveInt months, PositiveInt weeks, PositiveInt days, PositiveInt hours, PositiveInt minutes, PositiveInt seconds)
+    {
+        // Arrange
+        DurationExpression duration = new(years.Item, months.Item, weeks.Item, days.Item, hours.Item, minutes.Item, seconds.Item);
+
+        // Act
+        bool durationEqualsToNull = duration.Equals(null);
+
+        // Assert
+        durationEqualsToNull.Should().BeFalse();
+    }
+
+    [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
+    public void Equals_should_be_commutative(NonNull<DurationExpression> first, FilterExpression second)
+        => first.Item.Equals(second).Should().Be(second.Equals(first.Item));
+
+    [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
+    public void Equals_should_be_reflexive(NonNull<DurationExpression> expression)
+        => expression.Item.Equals(expression.Item).Should().BeTrue();
+
+    [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
+    public void Equals_should_be_symetric(NonNull<DurationExpression> expression, NonNull<FilterExpression> otherExpression)
+        => expression.Item.Equals(otherExpression.Item).Should().Be(otherExpression.Item.Equals(expression.Item));
+
+    [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
+    public void Given_DurationExpression_GetComplexity_should_return_1(DurationExpression duration)
+        => duration.Complexity.Should().Be(1);
+
+    [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
+    public void IsEquivalentTo_should_be_transitive(DurationExpression duration, NonNull<FilterExpression> other, NonNull<FilterExpression> third)
+    {
+        // Arrange
+        outputHelper.WriteLine($"Duration : {duration}");
+        outputHelper.WriteLine($"Other : {other.Item.EscapedParseableString}");
+        outputHelper.WriteLine($"Third : {third.Item.EscapedParseableString}");
+
+        bool first = duration.IsEquivalentTo(other.Item);
+        bool second = other.Item.IsEquivalentTo(third.Item);
+
+        // Act 
+        bool actual = duration.IsEquivalentTo(third.Item);
+
+        // Assert
+        if (first && second)
         {
-            DurationExpression duration = new(years.Item, months.Item, weeks.Item, days.Item, hours.Item, minutes.Item, seconds.Item);
-
-            duration.Years.Should().Be(years.Item);
-            duration.Months.Should().Be(months.Item);
-            duration.Days.Should().Be(days.Item);
-            duration.Hours.Should().Be(hours.Item);
-            duration.Minutes.Should().Be(minutes.Item);
-            duration.Seconds.Should().Be(seconds.Item);
-        }
-
-        [Property]
-        public void Equals_depends_on_values_only(PositiveInt years, PositiveInt months, PositiveInt weeks, PositiveInt days, PositiveInt hours, PositiveInt minutes, PositiveInt seconds)
-        {
-            DurationExpression first = new(years.Item, months.Item, weeks.Item, days.Item, hours.Item, minutes.Item, seconds.Item);
-            DurationExpression other = new(years.Item, months.Item, weeks.Item, days.Item, hours.Item, minutes.Item, seconds.Item);
-
-            // Act
-            bool actual = first.Equals(other);
-            int firstHashCode = first.GetHashCode();
-            int otherHashCode = other.GetHashCode();
-
-            // Assert
             actual.Should().BeTrue();
-            firstHashCode.Should().Be(otherHashCode);
         }
+    }
 
-        [Property]
-        public void Two_durations_that_are_equal_are_equivalent(PositiveInt years, PositiveInt months, PositiveInt weeks, PositiveInt days, PositiveInt hours, PositiveInt minutes, PositiveInt seconds)
+    public static TheoryData<DurationExpression, FilterExpression, FilterExpression, (bool expected, string reason)> IsEquivalentToCases
+        => new()
         {
-            DurationExpression first = new(years.Item, months.Item, weeks.Item, days.Item, hours.Item, minutes.Item, seconds.Item);
-            DurationExpression other = new(years.Item, months.Item, weeks.Item, days.Item, hours.Item, minutes.Item, seconds.Item);
-
-            // Act
-            bool firstEqualsOther = first.Equals(other);
-            bool firstIsEquivalentToOther = first.IsEquivalentTo(other);
-
-            // Assert
-            firstEqualsOther.Should().BeTrue();
-            firstIsEquivalentToOther.Should().BeTrue();
-        }
-
-        [Property]
-        public void Two_durations_are_equivalent_when_they_represent_same_timespan()
-        {
-            // Arrange
-            DurationExpression first = new(hours: 24);
-            DurationExpression other = new(days: 1);
-
-            // Act
-            bool firstEqualsOther = first.Equals(other);
-            bool firstIsEquivalentToOther = first.IsEquivalentTo(other);
-
-            // Assert
-            firstEqualsOther.Should().BeFalse("two durations initialized with timespans that are not in the same unit of time");
-            firstIsEquivalentToOther.Should().BeTrue("two durations initialized from timespans that are equal should be equivalent");
-        }
-
-        [Property]
-        public void Equals_to_null_always_returns_false(PositiveInt years, PositiveInt months, PositiveInt weeks, PositiveInt days, PositiveInt hours, PositiveInt minutes, PositiveInt seconds)
-        {
-            // Arrange
-            DurationExpression duration = new(years.Item, months.Item, weeks.Item, days.Item, hours.Item, minutes.Item, seconds.Item);
-
-            // Act
-            bool durationEqualsToNull = duration.Equals(null);
-
-            // Assert
-            durationEqualsToNull.Should().BeFalse();
-        }
-
-        [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
-        public void Equals_should_be_commutative(NonNull<DurationExpression> first, FilterExpression second)
-            => first.Item.Equals(second).Should().Be(second.Equals(first.Item));
-
-        [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
-        public void Equals_should_be_reflexive(NonNull<DurationExpression> expression)
-            => expression.Item.Equals(expression.Item).Should().BeTrue();
-
-        [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
-        public void Equals_should_be_symetric(NonNull<DurationExpression> expression, NonNull<FilterExpression> otherExpression)
-            => expression.Item.Equals(otherExpression.Item).Should().Be(otherExpression.Item.Equals(expression.Item));
-
-        [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
-        public void Given_DurationExpression_GetComplexity_should_return_1(DurationExpression duration)
-            => duration.Complexity.Should().Be(1);
-
-        [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
-        public void IsEquivalentTo_should_be_transitive(DurationExpression duration, NonNull<FilterExpression> other, NonNull<FilterExpression> third)
-        {
-            // Arrange
-            outputHelper.WriteLine($"Duration : {duration}");
-            outputHelper.WriteLine($"Other : {other.Item.EscapedParseableString}");
-            outputHelper.WriteLine($"Third : {third.Item.EscapedParseableString}");
-
-            bool first = duration.IsEquivalentTo(other.Item);
-            bool second = other.Item.IsEquivalentTo(third.Item);
-
-            // Act 
-            bool actual = duration.IsEquivalentTo(third.Item);
-
-            // Assert
-            if (first && second)
             {
-                actual.Should().BeTrue();
+                new DurationExpression(),
+                new StartsWithExpression("a"),
+                new StartsWithExpression("a"),
+                (
+                    expected: false,
+                    reason: "A is not equivalent to B and B is equivalent to C => A is not equivalent to C"
+                )
             }
-        }
+        };
 
-        public static TheoryData<DurationExpression, FilterExpression, FilterExpression, (bool expected, string reason)> IsEquivalentToCases
-            => new()
-            {
-                {
-                    new DurationExpression(),
-                    new StartsWithExpression("a"),
-                    new StartsWithExpression("a"),
-                    (
-                        expected: false,
-                        reason: "A is not equivalent to B and B is equivalent to C => A is not equivalent to C"
-                    )
-                }
-            };
+    [Theory]
+    [MemberData(nameof(IsEquivalentToCases))]
+    public void IsEquivalent_should_behave_as_expected(DurationExpression duration, FilterExpression other, FilterExpression third, (bool expected, string reason) expectation)
+    {
+        // Arrange
+        outputHelper.WriteLine($"Duration : {duration}");
+        outputHelper.WriteLine($"Other : {other.EscapedParseableString}");
+        outputHelper.WriteLine($"Third : {third.EscapedParseableString}");
 
-        [Theory]
-        [MemberData(nameof(IsEquivalentToCases))]
-        public void IsEquivalent_should_behave_as_expected(DurationExpression duration, FilterExpression other, FilterExpression third, (bool expected, string reason) expectation)
-        {
-            // Arrange
-            outputHelper.WriteLine($"Duration : {duration}");
-            outputHelper.WriteLine($"Other : {other.EscapedParseableString}");
-            outputHelper.WriteLine($"Third : {third.EscapedParseableString}");
+        bool durationIsEquivalentToOther = duration.IsEquivalentTo(other);
+        bool otherIsEquivalentToThird = other.IsEquivalentTo(third);
 
-            bool durationIsEquivalentToOther = duration.IsEquivalentTo(other);
-            bool otherIsEquivalentToThird = other.IsEquivalentTo(third);
+        outputHelper.WriteLine($"{duration} is equivalent to {other} : {durationIsEquivalentToOther}");
+        outputHelper.WriteLine($"{other} is equivalent to {third} : {otherIsEquivalentToThird}");
 
-            outputHelper.WriteLine($"{duration} is equivalent to {other} : {durationIsEquivalentToOther}");
-            outputHelper.WriteLine($"{other} is equivalent to {third} : {otherIsEquivalentToThird}");
+        // Act
+        bool actual = duration.IsEquivalentTo(third);
 
-            // Act
-            bool actual = duration.IsEquivalentTo(third);
-
-            // Assert
-            actual.Should().Be(expectation.expected, expectation.reason);
-        }
+        // Assert
+        actual.Should().Be(expectation.expected, expectation.reason);
     }
 }

--- a/test/DataFilters.UnitTests/Grammar/Syntax/EndsWithExpressionTests.cs
+++ b/test/DataFilters.UnitTests/Grammar/Syntax/EndsWithExpressionTests.cs
@@ -1,156 +1,155 @@
-﻿namespace DataFilters.UnitTests.Grammar.Syntax
+﻿namespace DataFilters.UnitTests.Grammar.Syntax;
+
+using System;
+using DataFilters.Grammar.Syntax;
+using DataFilters.UnitTests.Helpers;
+using FluentAssertions;
+using FsCheck;
+using FsCheck.Xunit;
+using Xunit;
+using Xunit.Abstractions;
+using Xunit.Categories;
+
+[UnitTest]
+public class EndsWithExpressionTests(ITestOutputHelper outputHelper)
 {
-    using System;
-    using DataFilters.Grammar.Syntax;
-    using DataFilters.UnitTests.Helpers;
-    using FluentAssertions;
-    using FsCheck;
-    using FsCheck.Xunit;
-    using Xunit;
-    using Xunit.Abstractions;
-    using Xunit.Categories;
+    [Fact]
+    public void IsFilterExpression() => typeof(EndsWithExpression).Should()
+        .BeAssignableTo<FilterExpression>().And
+        .Implement<IEquatable<EndsWithExpression>>().And
+        .Implement<IParseableString>();
 
-    [UnitTest]
-    public class EndsWithExpressionTests(ITestOutputHelper outputHelper)
+    [Fact]
+    public void Given_string_input_is_null_Constructor_should_throws_ArgumentNullException()
     {
-        [Fact]
-        public void IsFilterExpression() => typeof(EndsWithExpression).Should()
-                                                                      .BeAssignableTo<FilterExpression>().And
-                                                                      .Implement<IEquatable<EndsWithExpression>>().And
-                                                                      .Implement<IParseableString>();
+        // Act
+        Action action = () => new EndsWithExpression((string)null);
 
-        [Fact]
-        public void Given_string_input_is_null_Constructor_should_throws_ArgumentNullException()
+        // Assert
+        action.Should()
+            .ThrowExactly<ArgumentNullException>($"The value of {nameof(EndsWithExpression)}'s constructor cannot be null");
+    }
+
+    [Fact]
+    public void Given_TextExpression_input_is_null_Constructor_should_throws_ArgumentNullException()
+    {
+        // Act
+        Action action = () => new EndsWithExpression((TextExpression)null);
+
+        // Assert
+        action.Should()
+            .ThrowExactly<ArgumentNullException>($"The value of {nameof(EndsWithExpression)}'s constructor cannot be null");
+    }
+
+    [Fact]
+    public void Given_string_input_is_an_empty_Constructor_should_throws_ArgumentOutOfRangeException()
+    {
+        // Act
+        Action action = () => new EndsWithExpression(string.Empty);
+
+        // Assert
+        action.Should()
+            .ThrowExactly<ArgumentOutOfRangeException>($"The value of {nameof(EndsWithExpression)}'s constructor cannot be empty");
+    }
+
+    public static TheoryData<EndsWithExpression, object, bool, string> EqualsCases
+        => new()
         {
-            // Act
-            Action action = () => new EndsWithExpression((string)null);
-
-            // Assert
-            action.Should()
-                .ThrowExactly<ArgumentNullException>($"The value of {nameof(EndsWithExpression)}'s constructor cannot be null");
-        }
-
-        [Fact]
-        public void Given_TextExpression_input_is_null_Constructor_should_throws_ArgumentNullException()
-        {
-            // Act
-            Action action = () => new EndsWithExpression((TextExpression)null);
-
-            // Assert
-            action.Should()
-                .ThrowExactly<ArgumentNullException>($"The value of {nameof(EndsWithExpression)}'s constructor cannot be null");
-        }
-
-        [Fact]
-        public void Given_string_input_is_an_empty_Constructor_should_throws_ArgumentOutOfRangeException()
-        {
-            // Act
-            Action action = () => new EndsWithExpression(string.Empty);
-
-            // Assert
-            action.Should()
-                .ThrowExactly<ArgumentOutOfRangeException>($"The value of {nameof(EndsWithExpression)}'s constructor cannot be empty");
-        }
-
-        public static TheoryData<EndsWithExpression, object, bool, string> EqualsCases
-            => new()
             {
-                {
-                    new EndsWithExpression("prop1"),
-                    new EndsWithExpression("prop1"),
-                    true,
-                    "comparing two different instances with same property name"
-                },
-                {
-                    new EndsWithExpression("prop1"),
-                    new EndsWithExpression("prop2"),
-                    false,
-                    "comparing two different instances with different property name"
-                }
-            };
-
-        [Theory]
-        [MemberData(nameof(EqualsCases))]
-        public void ImplementsEqualsCorrectly(EndsWithExpression current, object other, bool expected, string reason)
-        {
-            outputHelper.WriteLine($"First instance : {current}");
-            outputHelper.WriteLine($"Second instance : {other}");
-
-            // Act
-            bool actual = current.Equals(other);
-            int actualHashCode = current.GetHashCode();
-
-            // Assert
-            actual.Should()
-                .Be(expected, reason);
-
-            object _ = expected switch
+                new EndsWithExpression("prop1"),
+                new EndsWithExpression("prop1"),
+                true,
+                "comparing two different instances with same property name"
+            },
             {
-                true => actualHashCode.Should()
-                    .Be(other?.GetHashCode(), reason),
-                _ => true
-            };
-        }
+                new EndsWithExpression("prop1"),
+                new EndsWithExpression("prop2"),
+                false,
+                "comparing two different instances with different property name"
+            }
+        };
 
-        [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
-        public void Given_EndsWithExpression_Complexity_should_return_1U002E5(EndsWithExpression endsWith)
-            => endsWith.Complexity.Should().Be(1.5);
+    [Theory]
+    [MemberData(nameof(EqualsCases))]
+    public void ImplementsEqualsCorrectly(EndsWithExpression current, object other, bool expected, string reason)
+    {
+        outputHelper.WriteLine($"First instance : {current}");
+        outputHelper.WriteLine($"Second instance : {other}");
 
-        [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
-        public void Given_TextExpression_as_input_EscapedParseableString_should_be_correct(NonNull<TextExpression> text)
+        // Act
+        bool actual = current.Equals(other);
+        int actualHashCode = current.GetHashCode();
+
+        // Assert
+        actual.Should()
+            .Be(expected, reason);
+
+        object _ = expected switch
         {
-            // Arrange
-            EndsWithExpression expression = new(text.Item);
-            string expected = $"*{text.Item.EscapedParseableString}";
+            true => actualHashCode.Should()
+                .Be(other?.GetHashCode(), reason),
+            _ => true
+        };
+    }
 
-            // Act
-            string actual = expression.EscapedParseableString;
+    [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
+    public void Given_EndsWithExpression_Complexity_should_return_1U002E5(EndsWithExpression endsWith)
+        => endsWith.Complexity.Should().Be(1.5);
 
-            // Assert
-            actual.Should()
-                  .Be(expected);
-        }
+    [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
+    public void Given_TextExpression_as_input_EscapedParseableString_should_be_correct(NonNull<TextExpression> text)
+    {
+        // Arrange
+        EndsWithExpression expression = new(text.Item);
+        string expected = $"*{text.Item.EscapedParseableString}";
 
-        [Property]
-        public void Given_non_whitespace_string_as_input_as_input_EscapedParseableString_should_be_correct(NonWhiteSpaceString text)
-        {
-            // Arrange
-            EndsWithExpression expression = new(text.Item);
-            StringValueExpression stringValueExpression = new(text.Item);
-            string expected = $"*{stringValueExpression.EscapedParseableString}";
+        // Act
+        string actual = expression.EscapedParseableString;
 
-            // Act
-            string actual = expression.EscapedParseableString;
+        // Assert
+        actual.Should()
+            .Be(expected);
+    }
 
-            // Assert
-            actual.Should()
-                  .Be(expected);
-        }
+    [Property]
+    public void Given_non_whitespace_string_as_input_as_input_EscapedParseableString_should_be_correct(NonWhiteSpaceString text)
+    {
+        // Arrange
+        EndsWithExpression expression = new(text.Item);
+        StringValueExpression stringValueExpression = new(text.Item);
+        string expected = $"*{stringValueExpression.EscapedParseableString}";
 
-        [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
-        public void Equals_should_be_commutative(NonNull<EndsWithExpression> first, FilterExpression second)
-            => first.Item.Equals(second).Should().Be(second.Equals(first.Item));
+        // Act
+        string actual = expression.EscapedParseableString;
 
-        [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
-        public void Equals_should_be_reflexive(NonNull<EndsWithExpression> expression)
-            => expression.Item.Equals(expression.Item).Should().BeTrue();
+        // Assert
+        actual.Should()
+            .Be(expected);
+    }
 
-        [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
-        public void Equals_should_be_symetric(NonNull<EndsWithExpression> expression, NonNull<FilterExpression> otherExpression)
-            => expression.Item.Equals(otherExpression.Item).Should().Be(otherExpression.Item.Equals(expression.Item));
+    [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
+    public void Equals_should_be_commutative(NonNull<EndsWithExpression> first, FilterExpression second)
+        => first.Item.Equals(second).Should().Be(second.Equals(first.Item));
 
-        [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
-        public void Given_EndsWithExpression_When_adding_AsteriskExpression_should_returns_ContainsExpression(NonNull<EndsWithExpression> endsWith)
-        {
-            // Arrange
-            ContainsExpression expected = new(endsWith.Item.Value);
+    [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
+    public void Equals_should_be_reflexive(NonNull<EndsWithExpression> expression)
+        => expression.Item.Equals(expression.Item).Should().BeTrue();
 
-            // Act
-            ContainsExpression actual = endsWith.Item + AsteriskExpression.Instance;
+    [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
+    public void Equals_should_be_symetric(NonNull<EndsWithExpression> expression, NonNull<FilterExpression> otherExpression)
+        => expression.Item.Equals(otherExpression.Item).Should().Be(otherExpression.Item.Equals(expression.Item));
 
-            // Assert
-            actual.Should()
-                  .Be(expected);
-        }
+    [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
+    public void Given_EndsWithExpression_When_adding_AsteriskExpression_should_returns_ContainsExpression(NonNull<EndsWithExpression> endsWith)
+    {
+        // Arrange
+        ContainsExpression expected = new(endsWith.Item.Value);
+
+        // Act
+        ContainsExpression actual = endsWith.Item + AsteriskExpression.Instance;
+
+        // Assert
+        actual.Should()
+            .Be(expected);
     }
 }

--- a/test/DataFilters.UnitTests/Grammar/Syntax/GroupExpressionTests.cs
+++ b/test/DataFilters.UnitTests/Grammar/Syntax/GroupExpressionTests.cs
@@ -1,315 +1,314 @@
-﻿namespace DataFilters.UnitTests.Grammar.Syntax
+﻿namespace DataFilters.UnitTests.Grammar.Syntax;
+
+using System;
+using DataFilters.Grammar.Syntax;
+using DataFilters.UnitTests.Helpers;
+using FluentAssertions;
+using FsCheck;
+using FsCheck.Xunit;
+using Xunit;
+using Xunit.Abstractions;
+
+public class GroupExpressionTests(ITestOutputHelper outputHelper)
 {
-    using System;
-    using DataFilters.Grammar.Syntax;
-    using DataFilters.UnitTests.Helpers;
-    using FluentAssertions;
-    using FsCheck;
-    using FsCheck.Xunit;
-    using Xunit;
-    using Xunit.Abstractions;
+    [Fact]
+    public void IsFilterExpression() => typeof(GroupExpression).Should()
+        .BeAssignableTo<FilterExpression>().And
+        .Implement<IEquatable<GroupExpression>>().And
+        .Implement<IHaveComplexity>().And
+        .Implement<IParseableString>();
 
-    public class GroupExpressionTests(ITestOutputHelper outputHelper)
+    [Fact]
+    public void Ctor_Throws_ArgumentNullException_When_Argument_Is_Null()
     {
-        [Fact]
-        public void IsFilterExpression() => typeof(GroupExpression).Should()
-                                                                   .BeAssignableTo<FilterExpression>().And
-                                                                   .Implement<IEquatable<GroupExpression>>().And
-                                                                   .Implement<IHaveComplexity>().And
-                                                                   .Implement<IParseableString>();
+        // Act
+        Action action = () => _ = new GroupExpression(null);
 
-        [Fact]
-        public void Ctor_Throws_ArgumentNullException_When_Argument_Is_Null()
+        // Assert
+        action.Should()
+            .ThrowExactly<ArgumentNullException>($"The parameter of  {nameof(GroupExpression)}'s constructor cannot be null");
+    }
+
+    [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
+    public void Given_current_instance_is_not_null_and_other_is_null_Equals_should_return_false(NonNull<GroupExpression> group)
+    {
+        // Act
+        bool actual = group.Item.Equals(null);
+
+        // Assert
+        actual.Should()
+            .BeFalse();
+    }
+
+    [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
+    public void Equals_should_be_reflexive(NonNull<GroupExpression> group)
+        => group.Item.Equals(group.Item).Should().BeTrue();
+
+    [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
+    public void Equals_should_be_symmetric(NonNull<GroupExpression> group, NonNull<FilterExpression> otherExpression)
+        => group.Item.Equals(otherExpression.Item).Should().Be(otherExpression.Item.Equals(group.Item));
+
+    [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
+    public void Given_GroupExpression_Complexity_should_be_linear_to_inner_expression_complexity(GroupExpression group) => group.Complexity.Should().Be(0.1 + group.Expression.Complexity);
+
+    [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
+    public void Given_GroupExpression_which_contains_an_arbitrary_expression_When_comparing_to_that_arbitrary_expression_IsEquivalent_should_return_true(NonNull<FilterExpression> filterExpression)
+    {
+        // Arrange
+        GroupExpression group = new(filterExpression.Item);
+
+        // Act
+        bool actual = group.IsEquivalentTo(filterExpression.Item);
+
+        // Assert
+        actual.Should().BeTrue();
+    }
+
+    [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
+    public void Given_GroupExpression_which_contains_an_arbitrary_expression_When_comparing_to_that_arbitrary_expression_IsEquivalentTo_should_return_true(NonNull<FilterExpression> filterExpression)
+    {
+        // Arrange
+        GroupExpression group = new(filterExpression.Item);
+
+        // Act
+        bool actual = group.IsEquivalentTo(filterExpression.Item);
+
+        // Assert
+        actual.Should().BeTrue();
+    }
+
+    [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
+    public void Given_GroupExpression_which_contains_an_arbitrary_expression_When_wrapping_that_group_inside_a_group_expression_Should_not_change_its_meaning(NonNull<GroupExpression> expression)
+    {
+        // Arrange
+        GroupExpression group = new(expression.Item);
+
+        // Act
+        bool isEquivalent = group.IsEquivalentTo(expression.Item);
+
+        // Assert
+        isEquivalent.Should().BeTrue();
+    }
+
+    [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
+    public void Given_two_GroupExpression_instances_that_wrap_equivalent_expressions_IsEquivalent_should_be_true(NonNull<FilterExpression> filterExpression)
+    {
+        // Arrange
+        GroupExpression first = new(filterExpression.Item);
+        GroupExpression other = new(filterExpression.Item);
+
+        // Act
+        bool actual = first.IsEquivalentTo(other);
+
+        // Assert
+        actual.Should().BeTrue();
+    }
+
+    public static TheoryData<GroupExpression, object, bool, string> EqualsCases
+        => new()
         {
-            // Act
-            Action action = () => _ = new GroupExpression(null);
+            {
+                new GroupExpression(new StartsWithExpression("prop1")),
+                new GroupExpression(new StartsWithExpression("prop1")),
+                true,
+                "comparing two different instances with same property name"
+            },
+            {
+                new GroupExpression(new StartsWithExpression("prop1")),
+                new GroupExpression(new StartsWithExpression("prop2")),
+                false,
+                "comparing two different instances with different inner expressions"
+            },
+            {
+                new GroupExpression(new DateTimeExpression(new(2090, 10, 10), new (03,00,40, 583), OffsetExpression.Zero)),
+                new GroupExpression(new DateTimeExpression(new(2090, 10, 10), new (03,00,40, 583), OffsetExpression.Zero)),
+                true,
+                "Two instances with inner expressions that are equal"
+            },
+            {
+                new GroupExpression(new NumericValueExpression("0")),
+                new GroupExpression(new StringValueExpression("0")),
+                true,
+                "Two instances with inner expressions that are equal"
+            }
+        };
 
-            // Assert
-            action.Should()
-                .ThrowExactly<ArgumentNullException>($"The parameter of  {nameof(GroupExpression)}'s constructor cannot be null");
-        }
+    [Theory]
+    [MemberData(nameof(EqualsCases))]
+    public void Equals_should_behave_as_expected(GroupExpression expression, object obj, bool expected, string reason)
+    {
+        // Act
+        bool actual = expression.Equals(obj);
 
-        [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
-        public void Given_current_instance_is_not_null_and_other_is_null_Equals_should_return_false(NonNull<GroupExpression> group)
+        // Assert
+        actual.Should()
+            .Be(expected, reason);
+    }
+
+    [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
+    public void Given_GroupExpression_wraps_an_arbitrary_FilterExpression_When_that_group_is_wrapped_inside_a_group_expression_Should_not_change_its_meaning(NonNull<FilterExpression> filterExpression)
+    {
+        // Arrange
+        GroupExpression group = new(filterExpression.Item);
+        GroupExpression extraGroup = new(group);
+
+        // Act
+        bool isEquivalent = group.IsEquivalentTo(extraGroup);
+
+        // Assert
+        isEquivalent.Should().BeTrue();
+    }
+
+    [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
+    public void Given_any_BinaryExpression_When_that_expression_is_wrapped_inside_a_group_expression_Should_not_change_its_meaning(NonNull<BinaryFilterExpression> filterExpression)
+    {
+        // Arrange
+        GroupExpression group = new(filterExpression.Item);
+
+        // Act
+        bool isEquivalent = group.IsEquivalentTo(filterExpression.Item);
+
+        // Assert
+        isEquivalent.Should().BeTrue();
+    }
+
+    [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
+    public void IsEquivalent_should_be_reflexive(GroupExpression group)
+        => group.IsEquivalentTo(group).Should().BeTrue();
+
+    [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
+    public void IsEquivalent_should_be_symmetric(GroupExpression group, NonNull<FilterExpression> other)
+    {
+        outputHelper.WriteLine($"Group : {group}");
+        outputHelper.WriteLine($"Other : {other}");
+
+        group.IsEquivalentTo(other.Item).Should().Be(other.Item.IsEquivalentTo(group));
+    }
+
+    [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
+    public void IsEquivalent_should_be_transitive(GroupExpression group, NonNull<FilterExpression> other, NonNull<FilterExpression> third)
+    {
+        // Arrange
+        outputHelper.WriteLine($"Group : {group}");
+        outputHelper.WriteLine($"Other : {other.Item.EscapedParseableString}");
+        outputHelper.WriteLine($"Third : {third.Item.EscapedParseableString}");
+
+        bool first = group.IsEquivalentTo(other.Item);
+        bool second = other.Item.IsEquivalentTo(third.Item);
+
+        // Act
+        bool actual = group.IsEquivalentTo(third.Item);
+
+        // Assert
+        if (first && second)
         {
-            // Act
-            bool actual = group.Item.Equals(null);
-
-            // Assert
-            actual.Should()
-                  .BeFalse();
-        }
-
-        [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
-        public void Equals_should_be_reflexive(NonNull<GroupExpression> group)
-            => group.Item.Equals(group.Item).Should().BeTrue();
-
-        [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
-        public void Equals_should_be_symmetric(NonNull<GroupExpression> group, NonNull<FilterExpression> otherExpression)
-            => group.Item.Equals(otherExpression.Item).Should().Be(otherExpression.Item.Equals(group.Item));
-
-        [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
-        public void Given_GroupExpression_Complexity_should_be_linear_to_inner_expression_complexity(GroupExpression group) => group.Complexity.Should().Be(0.1 + group.Expression.Complexity);
-
-        [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
-        public void Given_GroupExpression_which_contains_an_arbitrary_expression_When_comparing_to_that_arbitrary_expression_IsEquivalent_should_return_true(NonNull<FilterExpression> filterExpression)
-        {
-            // Arrange
-            GroupExpression group = new(filterExpression.Item);
-
-            // Act
-            bool actual = group.IsEquivalentTo(filterExpression.Item);
-
-            // Assert
             actual.Should().BeTrue();
         }
+    }
 
-        [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
-        public void Given_GroupExpression_which_contains_an_arbitrary_expression_When_comparing_to_that_arbitrary_expression_IsEquivalentTo_should_return_true(NonNull<FilterExpression> filterExpression)
+    [Property(Arbitrary = [typeof(ExpressionsGenerators)], Replay = "(13485810522331674394,9508666507375819251")]
+    public void Given_a_non_null_filter_expression_When_wrapped_inside_a_group_expression_Should_not_change_its_meaning(NonNull<FilterExpression> filterExpressionGenerator, PositiveInt count)
+    {
+        // Arrange
+        int depth = count.Item / 2;
+        FilterExpression filterExpression = filterExpressionGenerator.Item;
+        GroupExpression initialGroup = new(filterExpression);
+        GroupExpression otherGroup = new(filterExpression);
+
+        for (int i = 0; i < depth; i++)
         {
-            // Arrange
-            GroupExpression group = new(filterExpression.Item);
-
-            // Act
-            bool actual = group.IsEquivalentTo(filterExpression.Item);
-
-            // Assert
-            actual.Should().BeTrue();
+            otherGroup = new GroupExpression(otherGroup);
         }
 
-        [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
-        public void Given_GroupExpression_which_contains_an_arbitrary_expression_When_wrapping_that_group_inside_a_group_expression_Should_not_change_its_meaning(NonNull<GroupExpression> expression)
+        // Act
+        bool isEquivalent = initialGroup.IsEquivalentTo(otherGroup);
+
+        // Assert
+        outputHelper.WriteLine($"{nameof(initialGroup)}: {initialGroup:d}");
+        outputHelper.WriteLine($"{nameof(otherGroup)}: {otherGroup:d}");
+        isEquivalent.Should().BeTrue();
+    }
+
+    [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
+    public void Given_a_two_groups_that_wraps_the_same_expression_Then_they_should_be_equal(NonNull<FilterExpression> filterExpressionGenerator, PositiveInt count)
+    {
+        // Arrange
+        int depth = count.Item / 2;
+        FilterExpression filterExpression = filterExpressionGenerator.Item;
+        GroupExpression initialGroup = new(filterExpression);
+        GroupExpression otherGroup = new(filterExpression);
+
+        for (int i = 0; i < depth; i++)
         {
-            // Arrange
-            GroupExpression group = new(expression.Item);
-
-            // Act
-            bool isEquivalent = group.IsEquivalentTo(expression.Item);
-
-            // Assert
-            isEquivalent.Should().BeTrue();
+            initialGroup = new GroupExpression(initialGroup);
+            otherGroup = new GroupExpression(otherGroup);
         }
 
-        [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
-        public void Given_two_GroupExpression_instances_that_wrap_equivalent_expressions_IsEquivalent_should_be_true(NonNull<FilterExpression> filterExpression)
+        // Act
+        bool isEquivalent = initialGroup.IsEquivalentTo(otherGroup);
+
+        // Assert
+        isEquivalent.Should().BeTrue();
+    }
+
+    [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
+    public void Given_a_non_null_FilterExpression_that_is_wrapped_inside_a_GroupExpression_instance_When_calling_Simplify_Then_the_resulting_FilterExpression_should_be_equivalent_to_the_starting_FilterExpression(NonNull<FilterExpression> filterExpressionGenerator)
+    {
+        // Arrange
+        FilterExpression expected = filterExpressionGenerator.Item;
+        GroupExpression group = new(expected);
+
+        // Act
+        FilterExpression actual = group.Simplify();
+
+        // Assert
+        actual.Should().NotBeOfType<GroupExpression>();
+        actual.IsEquivalentTo(expected).Should().BeTrue();
+    }
+
+    public static TheoryData<GroupExpression, FilterExpression> SimplifyCases
+        => new TheoryData<GroupExpression, FilterExpression>()
         {
-            // Arrange
-            GroupExpression first = new(filterExpression.Item);
-            GroupExpression other = new(filterExpression.Item);
-
-            // Act
-            bool actual = first.IsEquivalentTo(other);
-
-            // Assert
-            actual.Should().BeTrue();
-        }
-
-        public static TheoryData<GroupExpression, object, bool, string> EqualsCases
-            => new()
             {
-                {
-                    new GroupExpression(new StartsWithExpression("prop1")),
-                    new GroupExpression(new StartsWithExpression("prop1")),
-                    true,
-                    "comparing two different instances with same property name"
-                },
-                {
-                    new GroupExpression(new StartsWithExpression("prop1")),
-                    new GroupExpression(new StartsWithExpression("prop2")),
-                    false,
-                    "comparing two different instances with different inner expressions"
-                },
-                {
-                    new GroupExpression(new DateTimeExpression(new(2090, 10, 10), new (03,00,40, 583), OffsetExpression.Zero)),
-                    new GroupExpression(new DateTimeExpression(new(2090, 10, 10), new (03,00,40, 583), OffsetExpression.Zero)),
-                    true,
-                    "Two instances with inner expressions that are equal"
-                },
-                {
-                    new GroupExpression(new NumericValueExpression("0")),
-                    new GroupExpression(new StringValueExpression("0")),
-                    true,
-                    "Two instances with inner expressions that are equal"
-                }
-            };
-
-        [Theory]
-        [MemberData(nameof(EqualsCases))]
-        public void Equals_should_behave_as_expected(GroupExpression expression, object obj, bool expected, string reason)
-        {
-            // Act
-            bool actual = expression.Equals(obj);
-
-            // Assert
-            actual.Should()
-                  .Be(expected, reason);
-        }
-
-        [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
-        public void Given_GroupExpression_wraps_an_arbitrary_FilterExpression_When_that_group_is_wrapped_inside_a_group_expression_Should_not_change_its_meaning(NonNull<FilterExpression> filterExpression)
-        {
-            // Arrange
-            GroupExpression group = new(filterExpression.Item);
-            GroupExpression extraGroup = new(group);
-
-            // Act
-            bool isEquivalent = group.IsEquivalentTo(extraGroup);
-
-            // Assert
-            isEquivalent.Should().BeTrue();
-        }
-
-        [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
-        public void Given_any_BinaryExpression_When_that_expression_is_wrapped_inside_a_group_expression_Should_not_change_its_meaning(NonNull<BinaryFilterExpression> filterExpression)
-        {
-            // Arrange
-            GroupExpression group = new(filterExpression.Item);
-
-            // Act
-            bool isEquivalent = group.IsEquivalentTo(filterExpression.Item);
-
-            // Assert
-            isEquivalent.Should().BeTrue();
-        }
-
-        [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
-        public void IsEquivalent_should_be_reflexive(GroupExpression group)
-            => group.IsEquivalentTo(group).Should().BeTrue();
-
-        [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
-        public void IsEquivalent_should_be_symmetric(GroupExpression group, NonNull<FilterExpression> other)
-        {
-            outputHelper.WriteLine($"Group : {group}");
-            outputHelper.WriteLine($"Other : {other}");
-
-            group.IsEquivalentTo(other.Item).Should().Be(other.Item.IsEquivalentTo(group));
-        }
-
-        [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
-        public void IsEquivalent_should_be_transitive(GroupExpression group, NonNull<FilterExpression> other, NonNull<FilterExpression> third)
-        {
-            // Arrange
-            outputHelper.WriteLine($"Group : {group}");
-            outputHelper.WriteLine($"Other : {other.Item.EscapedParseableString}");
-            outputHelper.WriteLine($"Third : {third.Item.EscapedParseableString}");
-
-            bool first = group.IsEquivalentTo(other.Item);
-            bool second = other.Item.IsEquivalentTo(third.Item);
-
-            // Act
-            bool actual = group.IsEquivalentTo(third.Item);
-
-            // Assert
-            if (first && second)
+                new GroupExpression(new StringValueExpression("prop")),
+                new StringValueExpression("prop")
+            },
             {
-                actual.Should().BeTrue();
+                new GroupExpression(new OrExpression(new StringValueExpression("prop"), new StringValueExpression("prop"))),
+                new StringValueExpression("prop")
             }
-        }
+        };
 
-        [Property(Arbitrary = [typeof(ExpressionsGenerators)], Replay = "(13485810522331674394,9508666507375819251")]
-        public void Given_a_non_null_filter_expression_When_wrapped_inside_a_group_expression_Should_not_change_its_meaning(NonNull<FilterExpression> filterExpressionGenerator, PositiveInt count)
-        {
-            // Arrange
-            int depth = count.Item / 2;
-            FilterExpression filterExpression = filterExpressionGenerator.Item;
-            GroupExpression initialGroup = new(filterExpression);
-            GroupExpression otherGroup = new(filterExpression);
-
-            for (int i = 0; i < depth; i++)
-            {
-                otherGroup = new GroupExpression(otherGroup);
-            }
-
-            // Act
-            bool isEquivalent = initialGroup.IsEquivalentTo(otherGroup);
-
-            // Assert
-            outputHelper.WriteLine($"{nameof(initialGroup)}: {initialGroup:d}");
-            outputHelper.WriteLine($"{nameof(otherGroup)}: {otherGroup:d}");
-            isEquivalent.Should().BeTrue();
-        }
-
-        [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
-        public void Given_a_two_groups_that_wraps_the_same_expression_Then_they_should_be_equal(NonNull<FilterExpression> filterExpressionGenerator, PositiveInt count)
-        {
-            // Arrange
-            int depth = count.Item / 2;
-            FilterExpression filterExpression = filterExpressionGenerator.Item;
-            GroupExpression initialGroup = new(filterExpression);
-            GroupExpression otherGroup = new(filterExpression);
-
-            for (int i = 0; i < depth; i++)
-            {
-                initialGroup = new GroupExpression(initialGroup);
-                otherGroup = new GroupExpression(otherGroup);
-            }
-
-            // Act
-            bool isEquivalent = initialGroup.IsEquivalentTo(otherGroup);
-
-            // Assert
-            isEquivalent.Should().BeTrue();
-        }
-
-        [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
-        public void Given_a_non_null_FilterExpression_that_is_wrapped_inside_a_GroupExpression_instance_When_calling_Simplify_Then_the_resulting_FilterExpression_should_be_equivalent_to_the_starting_FilterExpression(NonNull<FilterExpression> filterExpressionGenerator)
-        {
-            // Arrange
-            FilterExpression expected = filterExpressionGenerator.Item;
-            GroupExpression group = new(expected);
-
-            // Act
-            FilterExpression actual = group.Simplify();
-
-            // Assert
-            actual.Should().NotBeOfType<GroupExpression>();
-            actual.IsEquivalentTo(expected).Should().BeTrue();
-        }
-
-        public static TheoryData<GroupExpression, FilterExpression> SimplifyCases
-            => new TheoryData<GroupExpression, FilterExpression>()
-            {
-                {
-                    new GroupExpression(new StringValueExpression("prop")),
-                    new StringValueExpression("prop")
-                },
-                {
-                    new GroupExpression(new OrExpression(new StringValueExpression("prop"), new StringValueExpression("prop"))),
-                    new StringValueExpression("prop")
-                }
-            };
-
-        [Theory]
-        [MemberData(nameof(SimplifyCases))]
-        public void Given_GroupExpression_When_calling_Simplify_Then_should_return_expected_outcome(GroupExpression input, FilterExpression expected)
-        {
-            // Act
-            FilterExpression actual = input.Simplify();
+    [Theory]
+    [MemberData(nameof(SimplifyCases))]
+    public void Given_GroupExpression_When_calling_Simplify_Then_should_return_expected_outcome(GroupExpression input, FilterExpression expected)
+    {
+        // Act
+        FilterExpression actual = input.Simplify();
             
-            // Assert
-            actual.Should().Be(expected);
-        }
+        // Assert
+        actual.Should().Be(expected);
+    }
 
-        public static TheoryData<GroupExpression, FilterExpression, bool, string> IsEquivalentToCases
-            => new()
-            {
-                {
-                    new GroupExpression(new IntervalExpression(new BoundaryExpression(new NumericValueExpression("-1"), true), new BoundaryExpression(new NumericValueExpression("-1"), true))),
-                    new GroupExpression(new IntervalExpression(new BoundaryExpression(new NumericValueExpression("-1"), true), new BoundaryExpression(new NumericValueExpression("-1"), true))),
-                    true,
-                    "left and right are expressions with exactly same values"
-                }
-            };
-        
-        [Theory]
-        [MemberData(nameof(IsEquivalentToCases))]
-        public void Given_left_is_a_GroupExpression_and_right_is_an_expression_Then_IsEquivalent_should_returns_expected_result(GroupExpression left, FilterExpression right, bool expected, string reason)
+    public static TheoryData<GroupExpression, FilterExpression, bool, string> IsEquivalentToCases
+        => new()
         {
-            // Act
-            bool actual = left.IsEquivalentTo(right);
+            {
+                new GroupExpression(new IntervalExpression(new BoundaryExpression(new NumericValueExpression("-1"), true), new BoundaryExpression(new NumericValueExpression("-1"), true))),
+                new GroupExpression(new IntervalExpression(new BoundaryExpression(new NumericValueExpression("-1"), true), new BoundaryExpression(new NumericValueExpression("-1"), true))),
+                true,
+                "left and right are expressions with exactly same values"
+            }
+        };
+        
+    [Theory]
+    [MemberData(nameof(IsEquivalentToCases))]
+    public void Given_left_is_a_GroupExpression_and_right_is_an_expression_Then_IsEquivalent_should_returns_expected_result(GroupExpression left, FilterExpression right, bool expected, string reason)
+    {
+        // Act
+        bool actual = left.IsEquivalentTo(right);
  
-            // Assert
-            actual.Should().Be(expected, reason);
-        }
+        // Assert
+        actual.Should().Be(expected, reason);
     }
 }

--- a/test/DataFilters.UnitTests/Grammar/Syntax/IntervalExpressionTests.cs
+++ b/test/DataFilters.UnitTests/Grammar/Syntax/IntervalExpressionTests.cs
@@ -1,426 +1,425 @@
-﻿namespace DataFilters.UnitTests.Grammar.Syntax
+﻿namespace DataFilters.UnitTests.Grammar.Syntax;
+
+using System;
+using DataFilters.Grammar.Exceptions;
+using DataFilters.Grammar.Syntax;
+using DataFilters.UnitTests.Helpers;
+using FluentAssertions;
+using FluentAssertions.Extensions;
+using FsCheck;
+using FsCheck.Xunit;
+using Xunit;
+using Xunit.Abstractions;
+
+public class IntervalExpressionTests(ITestOutputHelper outputHelper)
 {
-    using System;
-    using DataFilters.Grammar.Exceptions;
-    using DataFilters.Grammar.Syntax;
-    using DataFilters.UnitTests.Helpers;
-    using FluentAssertions;
-    using FluentAssertions.Extensions;
-    using FsCheck;
-    using FsCheck.Xunit;
-    using Xunit;
-    using Xunit.Abstractions;
+    [Fact]
+    public void IsFilterExpression() => typeof(IntervalExpression).Should()
+        .BeAssignableTo<FilterExpression>().And
+        .Implement<IEquatable<IntervalExpression>>().And
+        .Implement<ISimplifiable>();
 
-    public class IntervalExpressionTests(ITestOutputHelper outputHelper)
+    [Fact]
+    public void Given_min_and_max_are_null_Ctor_should_throws_IncorrectBoundaryException()
     {
-        [Fact]
-        public void IsFilterExpression() => typeof(IntervalExpression).Should()
-                                                                   .BeAssignableTo<FilterExpression>().And
-                                                                   .Implement<IEquatable<IntervalExpression>>().And
-                                                                   .Implement<ISimplifiable>();
+        // Act
+        Action action = () => new IntervalExpression(null, null);
 
-        [Fact]
-        public void Given_min_and_max_are_null_Ctor_should_throws_IncorrectBoundaryException()
+        // Assert
+        action.Should()
+            .ThrowExactly<IncorrectBoundaryException>($"Either {nameof(IntervalExpression.Min)}/{nameof(IntervalExpression.Max)} must not be null");
+    }
+
+    public static TheoryData<BoundaryExpression, BoundaryExpression, string> IncorrectBoundariesCases
+        => new()
         {
-            // Act
-            Action action = () => new IntervalExpression(null, null);
+            {
+                new BoundaryExpression(AsteriskExpression.Instance, included: true),
+                new BoundaryExpression(AsteriskExpression.Instance, included: true),
+                $"min and max cannot both be {nameof(AsteriskExpression)} instances"
+            },
+            {
+                new BoundaryExpression(AsteriskExpression.Instance, included : true),
+                null,
+                $"max cannot be null when min is {nameof(AsteriskExpression)} instance"
+            }
+        };
 
-            // Assert
-            action.Should()
-                .ThrowExactly<IncorrectBoundaryException>($"Either {nameof(IntervalExpression.Min)}/{nameof(IntervalExpression.Max)} must not be null");
+    [Theory]
+    [MemberData(nameof(IncorrectBoundariesCases))]
+    public void Given_incorrect_boundaries_Ctor_should_throws_IncorrectBoundaryException(BoundaryExpression min, BoundaryExpression max, string reason)
+    {
+        // Act
+        Action action = () => new IntervalExpression(min, max);
+
+        // Assert
+        action.Should()
+            .ThrowExactly<IncorrectBoundaryException>(reason);
+    }
+
+    public static TheoryData<BoundaryExpression, BoundaryExpression, string> BoundariesTypeMismatchCases
+        => new()
+        {
+            {
+                new BoundaryExpression(new DateExpression(), included: true), new BoundaryExpression(new NumericValueExpression("10"), included: true),
+                $"min holds {nameof(DateExpression)} and max holds {nameof(ConstantValueExpression)}"
+            },
+            {
+                new BoundaryExpression(new NumericValueExpression("10"), included : true), new BoundaryExpression(new DateExpression(), included : true),
+                $"min holds {nameof(ConstantValueExpression)} and max holds {nameof(DateExpression)}"
+            },
+            {
+                new BoundaryExpression(new TimeExpression(), included: true),
+                new BoundaryExpression(new DateExpression(), included: true),
+                $"min holds  { nameof(TimeExpression) } and max holds { nameof(DateExpression) }"
+            }
+        };
+
+    [Theory]
+    [MemberData(nameof(BoundariesTypeMismatchCases))]
+    public void Given_boundaries_that_are_not_compatible_Ctor_should_throws_BoundaryTypeMismatchException(BoundaryExpression min, BoundaryExpression max, string reason)
+    {
+        // Act
+        Action action = () => _ = new IntervalExpression(min, max);
+
+        // Assert
+        action.Should()
+            .ThrowExactly<BoundariesTypeMismatchException>(reason)
+            .Where(ex => !string.IsNullOrWhiteSpace(ex.ParamName));
+    }
+
+    public static TheoryData<BoundaryExpression, BoundaryExpression> ValidCtorCases
+        => new()
+        {
+            {
+                new BoundaryExpression(new DateExpression(), included: false),
+                new BoundaryExpression(new TimeExpression(), included: false)
+            },
+            {
+                new BoundaryExpression(AsteriskExpression.Instance, included: false),
+                new BoundaryExpression(new TimeExpression(), included: false)
+            },
+            {
+                new BoundaryExpression(new TimeExpression(), included: false),
+                new BoundaryExpression(AsteriskExpression.Instance, included: false)
+            }
+        };
+
+    [Theory]
+    [MemberData(nameof(ValidCtorCases))]
+    public void Given_valid_min_and_max_boundaries_Ctor_should_not_throws(BoundaryExpression min, BoundaryExpression max)
+    {
+        // Act
+        Action ctor = () => new IntervalExpression(min, max);
+
+        ctor.Should()
+            .NotThrow();
+    }
+
+    public static TheoryData<BoundaryExpression, BoundaryExpression, IntervalExpression, string> CtorLogicCases
+    {
+        get
+        {
+            TheoryData<BoundaryExpression, BoundaryExpression, IntervalExpression, string> cases = [];
+            DateTime dateTime = 12.March(2019);
+
+            cases.Add
+            (
+                new BoundaryExpression(new DateTimeExpression(dateTime), included: true),
+                new BoundaryExpression(new TimeExpression(hours: 10), included: true),
+                new IntervalExpression(min: new BoundaryExpression(new DateTimeExpression(dateTime), included: true),
+                    max: new BoundaryExpression(new DateTimeExpression(dateTime.Add(10.Hours())), included: true)),
+                "max date part should be deduced from min date part when max date part is not specified"
+            );
+
+            return cases;
         }
+    }
 
-        public static TheoryData<BoundaryExpression, BoundaryExpression, string> IncorrectBoundariesCases
-            => new()
+    [Theory]
+    [MemberData(nameof(CtorLogicCases))]
+    public void Given_min_and_max_bounds_Constructor_logic_should_work_as_expected(BoundaryExpression min, BoundaryExpression max, IntervalExpression expected, string reason)
+    {
+        // Act
+        IntervalExpression actual = new(min, max);
+
+        // Assert
+        actual.Should()
+            .Be(expected, reason);
+    }
+
+    public static TheoryData<IntervalExpression, object, bool, string> EqualCases
+    {
+        get
+        {
+            TheoryData<IntervalExpression, object, bool, string> cases = new()
             {
                 {
-                    new BoundaryExpression(AsteriskExpression.Instance, included: true),
-                    new BoundaryExpression(AsteriskExpression.Instance, included: true),
-                    $"min and max cannot both be {nameof(AsteriskExpression)} instances"
+                    new IntervalExpression(min: new BoundaryExpression(new NumericValueExpression("10"), included : true)),
+                    new IntervalExpression(min: new BoundaryExpression(new NumericValueExpression("10"), included : true)),
+                    true,
+                    $"comparing two {nameof(IntervalExpression)} instances with same min and max"
                 },
                 {
-                    new BoundaryExpression(AsteriskExpression.Instance, included : true),
+                    new IntervalExpression(min: new BoundaryExpression(new NumericValueExpression("10"), included : true)),
+                    new IntervalExpression(min: new BoundaryExpression(new NumericValueExpression("10"), included : false)),
+                    false,
+                    $"comparing two {nameof(IntervalExpression)} instances with same min and max but not same {nameof(BoundaryExpression.Included)}"
+                },
+                {
+                    new IntervalExpression(min: new BoundaryExpression(new NumericValueExpression("10"), included : true)),
                     null,
-                    $"max cannot be null when min is {nameof(AsteriskExpression)} instance"
-                }
+                    false,
+                    "comparing to null"
+                },
+                {
+                    new IntervalExpression(max: new BoundaryExpression(new NumericValueExpression("10"), included : true)),
+                    new IntervalExpression(max: new BoundaryExpression(new NumericValueExpression("10"), included : true)),
+                    true,
+                    $"comparing two {nameof(IntervalExpression)} instances with same min and max"
+                },
+                {
+                    new IntervalExpression(max: new BoundaryExpression( new DateTimeExpression(new DateExpression()), included : true)),
+                    new IntervalExpression(max: new BoundaryExpression( new DateTimeExpression(new DateExpression()), included : true)),
+                    true,
+                    $"comparing two {nameof(IntervalExpression)} instances with same {nameof(DateTimeExpression)} min and max"
+                },
             };
 
-        [Theory]
-        [MemberData(nameof(IncorrectBoundariesCases))]
-        public void Given_incorrect_boundaries_Ctor_should_throws_IncorrectBoundaryException(BoundaryExpression min, BoundaryExpression max, string reason)
-        {
-            // Act
-            Action action = () => new IntervalExpression(min, max);
-
-            // Assert
-            action.Should()
-                .ThrowExactly<IncorrectBoundaryException>(reason);
-        }
-
-        public static TheoryData<BoundaryExpression, BoundaryExpression, string> BoundariesTypeMismatchCases
-            => new()
             {
-                {
-                    new BoundaryExpression(new DateExpression(), included: true), new BoundaryExpression(new NumericValueExpression("10"), included: true),
-                    $"min holds {nameof(DateExpression)} and max holds {nameof(ConstantValueExpression)}"
-                },
-                {
-                    new BoundaryExpression(new NumericValueExpression("10"), included : true), new BoundaryExpression(new DateExpression(), included : true),
-                    $"min holds {nameof(ConstantValueExpression)} and max holds {nameof(DateExpression)}"
-                },
-                {
-                    new BoundaryExpression(new TimeExpression(), included: true),
-                    new BoundaryExpression(new DateExpression(), included: true),
-                    $"min holds  { nameof(TimeExpression) } and max holds { nameof(DateExpression) }"
-                }
-            };
-
-        [Theory]
-        [MemberData(nameof(BoundariesTypeMismatchCases))]
-        public void Given_boundaries_that_are_not_compatible_Ctor_should_throws_BoundaryTypeMismatchException(BoundaryExpression min, BoundaryExpression max, string reason)
-        {
-            // Act
-            Action action = () => _ = new IntervalExpression(min, max);
-
-            // Assert
-            action.Should()
-                .ThrowExactly<BoundariesTypeMismatchException>(reason)
-                .Where(ex => !string.IsNullOrWhiteSpace(ex.ParamName));
-        }
-
-        public static TheoryData<BoundaryExpression, BoundaryExpression> ValidCtorCases
-            => new()
-            {
-                {
-                    new BoundaryExpression(new DateExpression(), included: false),
-                    new BoundaryExpression(new TimeExpression(), included: false)
-                },
-                {
-                    new BoundaryExpression(AsteriskExpression.Instance, included: false),
-                    new BoundaryExpression(new TimeExpression(), included: false)
-                },
-                {
-                    new BoundaryExpression(new TimeExpression(), included: false),
-                    new BoundaryExpression(AsteriskExpression.Instance, included: false)
-                }
-            };
-
-        [Theory]
-        [MemberData(nameof(ValidCtorCases))]
-        public void Given_valid_min_and_max_boundaries_Ctor_should_not_throws(BoundaryExpression min, BoundaryExpression max)
-        {
-            // Act
-            Action ctor = () => new IntervalExpression(min, max);
-
-            ctor.Should()
-                .NotThrow();
-        }
-
-        public static TheoryData<BoundaryExpression, BoundaryExpression, IntervalExpression, string> CtorLogicCases
-        {
-            get
-            {
-                TheoryData<BoundaryExpression, BoundaryExpression, IntervalExpression, string> cases = [];
-                DateTime dateTime = 12.March(2019);
-
+                IntervalExpression interval = new(min: new BoundaryExpression(new DateTimeExpression(new DateExpression(2012, 10, 19), new TimeExpression(15, 03, 45), OffsetExpression.Zero), included: false),
+                    max: new BoundaryExpression(new DateTimeExpression(new DateExpression(2012, 10, 19), new TimeExpression(15, 03, 45), new(hours: 1)), included: false));
                 cases.Add
                 (
-                    new BoundaryExpression(new DateTimeExpression(dateTime), included: true),
-                    new BoundaryExpression(new TimeExpression(hours: 10), included: true),
-                    new IntervalExpression(min: new BoundaryExpression(new DateTimeExpression(dateTime), included: true),
-                                           max: new BoundaryExpression(new DateTimeExpression(dateTime.Add(10.Hours())), included: true)),
-                    "max date part should be deduced from min date part when max date part is not specified"
-                );
-
-                return cases;
-            }
-        }
-
-        [Theory]
-        [MemberData(nameof(CtorLogicCases))]
-        public void Given_min_and_max_bounds_Constructor_logic_should_work_as_expected(BoundaryExpression min, BoundaryExpression max, IntervalExpression expected, string reason)
-        {
-            // Act
-            IntervalExpression actual = new(min, max);
-
-            // Assert
-            actual.Should()
-                  .Be(expected, reason);
-        }
-
-        public static TheoryData<IntervalExpression, object, bool, string> EqualCases
-        {
-            get
-            {
-                TheoryData<IntervalExpression, object, bool, string> cases = new()
-                {
-                    {
-                        new IntervalExpression(min: new BoundaryExpression(new NumericValueExpression("10"), included : true)),
-                        new IntervalExpression(min: new BoundaryExpression(new NumericValueExpression("10"), included : true)),
-                        true,
-                        $"comparing two {nameof(IntervalExpression)} instances with same min and max"
-                    },
-                    {
-                        new IntervalExpression(min: new BoundaryExpression(new NumericValueExpression("10"), included : true)),
-                        new IntervalExpression(min: new BoundaryExpression(new NumericValueExpression("10"), included : false)),
-                        false,
-                        $"comparing two {nameof(IntervalExpression)} instances with same min and max but not same {nameof(BoundaryExpression.Included)}"
-                    },
-                    {
-                        new IntervalExpression(min: new BoundaryExpression(new NumericValueExpression("10"), included : true)),
-                        null,
-                        false,
-                        "comparing to null"
-                    },
-                    {
-                        new IntervalExpression(max: new BoundaryExpression(new NumericValueExpression("10"), included : true)),
-                        new IntervalExpression(max: new BoundaryExpression(new NumericValueExpression("10"), included : true)),
-                        true,
-                        $"comparing two {nameof(IntervalExpression)} instances with same min and max"
-                    },
-                    {
-                        new IntervalExpression(max: new BoundaryExpression( new DateTimeExpression(new DateExpression()), included : true)),
-                        new IntervalExpression(max: new BoundaryExpression( new DateTimeExpression(new DateExpression()), included : true)),
-                        true,
-                        $"comparing two {nameof(IntervalExpression)} instances with same {nameof(DateTimeExpression)} min and max"
-                    },
-                };
-
-                {
-                    IntervalExpression interval = new(min: new BoundaryExpression(new DateTimeExpression(new DateExpression(2012, 10, 19), new TimeExpression(15, 03, 45), OffsetExpression.Zero), included: false),
-                                                max: new BoundaryExpression(new DateTimeExpression(new DateExpression(2012, 10, 19), new TimeExpression(15, 03, 45), new(hours: 1)), included: false));
-                    cases.Add
-                    (
-                        interval,
-                        interval,
-                        true,
-                        "Comparing two ranges"
-                    );
-                }
-
-                cases.Add(
-                    new IntervalExpression(new BoundaryExpression(new DateTimeExpression(new(1973, 09, 02), new(18, 50, 17, 403), OffsetExpression.Zero), true),
-                                           new BoundaryExpression(new DateExpression(1944, 09, 06), true)),
-                    new IntervalExpression(new BoundaryExpression(new DateTimeExpression(new(1973, 09, 02), new(18, 50, 17, 403), OffsetExpression.Zero), true),
-                                           new BoundaryExpression(new DateExpression(1944, 09, 06), true)),
+                    interval,
+                    interval,
                     true,
-                    "Two intervals with same data"
+                    "Comparing two ranges"
                 );
-
-                return cases;
             }
+
+            cases.Add(
+                new IntervalExpression(new BoundaryExpression(new DateTimeExpression(new(1973, 09, 02), new(18, 50, 17, 403), OffsetExpression.Zero), true),
+                    new BoundaryExpression(new DateExpression(1944, 09, 06), true)),
+                new IntervalExpression(new BoundaryExpression(new DateTimeExpression(new(1973, 09, 02), new(18, 50, 17, 403), OffsetExpression.Zero), true),
+                    new BoundaryExpression(new DateExpression(1944, 09, 06), true)),
+                true,
+                "Two intervals with same data"
+            );
+
+            return cases;
         }
-
-        [Theory]
-        [MemberData(nameof(EqualCases))]
-        public void Equals_should_work_as_expected(IntervalExpression first, object other, bool expected, string reason)
-        {
-            outputHelper.WriteLine($"First instance : {first}");
-            outputHelper.WriteLine($"Second instance : {other}");
-
-            // Act
-            bool actual = first.Equals(other);
-
-            // Assert
-            actual.Should()
-                .Be(expected, reason);
-        }
-
-        [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
-        public void Given_min_bound_is_DateTimeExpression_When_min_does_not_hold_TimeExpression_Constructor_should_converts_Min_to_DateExpression(DateExpression date, bool included)
-        {
-            // Arrange
-            DateTimeExpression dateTimeExpression = new(date);
-            BoundaryExpression minBoundary = new(dateTimeExpression, included);
-
-            // Act
-            IntervalExpression sut = new(minBoundary);
-
-            // Assert
-            sut.Min.Expression.Should().Be(date);
-        }
-
-        [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
-        public void Given_Min_boundary_is_a_DateTimeExpression_with_only_time_specified_Ctor_should_convert_min_boundary_to_only_holds_the_specified_TimeExpression(NonNull<TimeExpression> time, bool included)
-        {
-            // Arrange
-            DateTimeExpression dateTimeExpression = new(time.Item);
-
-            // Act
-            IntervalExpression interval = new(min: new BoundaryExpression(dateTimeExpression, included));
-
-            // Assert
-            interval.Min.Expression.Should()
-                                   .BeOfType<TimeExpression>()
-                                   .Which.Should().Be(time.Item);
-        }
-
-        [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
-        public void Given_Min_boundary_is_a_DateTimeExpression_with_only_date_specified_Ctor_should_convert_min_boundary_to_only_holds_the_specified_DateExpression(NonNull<DateExpression> date, bool included)
-        {
-            // Arrange
-            DateTimeExpression dateTimeExpression = new(date.Item);
-
-            // Act
-            IntervalExpression interval = new(min: new BoundaryExpression(dateTimeExpression, included));
-
-            // Assert
-            interval.Min.Expression.Should()
-                                   .BeOfType<DateExpression>()
-                                   .Which.Should().Be(date.Item);
-        }
-
-        [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
-        public void Ctor_should_converts_Max_DateTimeExpression_to_TimeExpression_when_DateExpression_is_not_provided(PositiveInt hours,
-                                                                                                                      PositiveInt minutes,
-                                                                                                                      PositiveInt seconds,
-                                                                                                                      PositiveInt milliseconds,
-                                                                                                                      bool included)
-        {
-            // Arrange
-            TimeExpression time = new(hours.Item, minutes.Item, seconds.Item, milliseconds.Item);
-            DateTimeExpression dateTimeExpression = new(time);
-
-            // Act
-            IntervalExpression interval = new(max: new BoundaryExpression(dateTimeExpression, included));
-            (IBoundaryExpression expression, _) = interval.Max;
-
-            // Assert
-            expression.Should()
-                      .Be(time);
-        }
-
-        [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
-        public void Given_a_ConstantExpression_that_is_equal_to_min_and_min_and_max_are_equal_and_min_and_max_are_included_IsEquivalent_should_return_true_when_comparing_with_ConstantExpression(NumericValueExpression constant)
-        {
-            CreateIsEquivalentPropeprty(constant, constant, minIncluded: true, maxIsIncluded: true);
-        }
-
-        [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
-        public void IsEquivalent_should_be_reflexive(NonNull<IntervalExpression> interval)
-        {
-            // Arrange
-            IntervalExpression source = interval.Item;
-
-            // Act
-            bool actual = source.IsEquivalentTo(source);
-
-            // Assert
-            actual.Should().BeTrue();
-        }
-
-        [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
-        public void Given_a_DateExpression_that_is_equal_to_min_and_min_and_max_are_equal_and_min_and_max_are_included_IsEquivalent_should_return_true_when_comparing_with_DateExpression(DateExpression date)
-        {
-            CreateIsEquivalentPropeprty(date, date, minIncluded: true, maxIsIncluded: true);
-        }
-
-        [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
-        public void Given_a_DateTimeExpression_that_is_equal_to_min_and_min_and_max_are_equal_and_min_and_max_are_included_IsEquivalent_should_return_true_when_comparing_with_DateTimeExpression(DateTimeExpression dateTime)
-        {
-            CreateIsEquivalentPropeprty(dateTime, dateTime, minIncluded: true, maxIsIncluded: true);
-        }
-
-        [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
-        public void Given_a_DateTimeExpression_that_is_equal_to_min_and_min_and_max_are_equal_and_min_and_max_are_included_IsEquivalent_should_return_true_when_comparing_with_TimeExpression(TimeExpression dateTime)
-        {
-            CreateIsEquivalentPropeprty(dateTime, dateTime, minIncluded: true, maxIsIncluded: true);
-        }
-
-        private static void CreateIsEquivalentPropeprty(FilterExpression filterExpression, IBoundaryExpression boundaryExpression, bool minIncluded, bool maxIsIncluded)
-        {
-            // Arrange
-            IntervalExpression range = new(new BoundaryExpression(boundaryExpression, minIncluded), new BoundaryExpression(boundaryExpression, maxIsIncluded));
-
-            // Act 
-            bool actual = range.IsEquivalentTo(filterExpression);
-
-            // Assert
-            actual.Should().BeTrue();
-        }
-
-        [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
-        public void Given_RangeExpression_GetComplexity_should_return_sum_of_min_and_max_complexity(NonNull<IntervalExpression> rangeExpressionGenerator)
-        {
-            // Arrange
-            IntervalExpression rangeExpression = rangeExpressionGenerator.Item;
-
-            // Act
-            double actualComplexity = rangeExpression.Complexity;
-
-            // Assert
-            object _ = (rangeExpression.Min, rangeExpression.Max) switch
-            {
-                ({ Expression: { } minExpression }, { Expression: { } maxExpression }) => actualComplexity.Should().Be(minExpression.Complexity + maxExpression.Complexity),
-                ({ Expression: { } minExpression }, null) => actualComplexity.Should().Be(minExpression.Complexity),
-                (null, { Expression: { } maxExpression }) => actualComplexity.Should().Be(maxExpression.Complexity),
-                _ => actualComplexity.Should().Be(0),
-            };
-        }
-
-        public static TheoryData<IntervalExpression, FilterExpression, string> SimplifyCases
-            => new()
-            {
-                {
-                    new IntervalExpression(new (new NumericValueExpression("10"), true), new (new NumericValueExpression("10"), true)),
-                    new NumericValueExpression("10"),
-                    "Lower and upper bound are equal"
-                },
-                {
-                    new IntervalExpression(new (new NumericValueExpression("10"), true), new (new NumericValueExpression("12"), true)),
-                    new IntervalExpression(new (new NumericValueExpression("10"), true), new (new NumericValueExpression("12"), true)),
-                    "Lower and upper bound are not equals and not equivalent"
-                },
-                {
-                    new IntervalExpression(new (new TimeExpression(1), true), new (new TimeExpression(minutes: 60), true)),
-                    new TimeExpression(1),
-                    "Lower and upper bound are equivalent"
-                },
-                {
-                    new IntervalExpression(new (new NumericValueExpression("-32"), true), new (new NumericValueExpression("-32"), true)),
-                    new NumericValueExpression("-32"),
-                    "Lower and upper bound are equal"
-                }
-            };
-
-        [Theory]
-        [MemberData(nameof(SimplifyCases))]
-        public void Given_IntervalExpression_Simplify_should_return_expected_expression(IntervalExpression rangeExpression, FilterExpression expected, string reason)
-        {
-            outputHelper.WriteLine($"Range expression : {rangeExpression}");
-
-            // Act
-            FilterExpression actual = rangeExpression.Simplify();
-
-            // Assert
-            actual.Should()
-                  .Be(expected, reason);
-        }
-
-        [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
-        public void An_IntervalExpression_instance_built_from_data_from_a_previously_deconstructed_instance_should_be_equal(IntervalExpression expected)
-        {
-            // Arrange
-            (BoundaryExpression min, BoundaryExpression max) = expected;
-
-            // Act
-            IntervalExpression actual = new(min, max);
-
-            // Assert
-            actual.Should()
-                  .Be(expected);
-        }
-
-        [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
-        public void Equals_should_be_commutative(NonNull<IntervalExpression> first, FilterExpression second)
-            => first.Item.Equals(second).Should().Be(second.Equals(first.Item));
-
-        [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
-        public void Equals_should_be_reflexive(NonNull<IntervalExpression> expression)
-            => expression.Item.Should().Be(expression.Item);
-
-        [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
-        public void Equals_should_be_symetric(NonNull<IntervalExpression> expression, NonNull<FilterExpression> otherExpression)
-            => expression.Item.Equals(otherExpression.Item).Should().Be(otherExpression.Item.Equals(expression.Item));
     }
+
+    [Theory]
+    [MemberData(nameof(EqualCases))]
+    public void Equals_should_work_as_expected(IntervalExpression first, object other, bool expected, string reason)
+    {
+        outputHelper.WriteLine($"First instance : {first}");
+        outputHelper.WriteLine($"Second instance : {other}");
+
+        // Act
+        bool actual = first.Equals(other);
+
+        // Assert
+        actual.Should()
+            .Be(expected, reason);
+    }
+
+    [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
+    public void Given_min_bound_is_DateTimeExpression_When_min_does_not_hold_TimeExpression_Constructor_should_converts_Min_to_DateExpression(DateExpression date, bool included)
+    {
+        // Arrange
+        DateTimeExpression dateTimeExpression = new(date);
+        BoundaryExpression minBoundary = new(dateTimeExpression, included);
+
+        // Act
+        IntervalExpression sut = new(minBoundary);
+
+        // Assert
+        sut.Min.Expression.Should().Be(date);
+    }
+
+    [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
+    public void Given_Min_boundary_is_a_DateTimeExpression_with_only_time_specified_Ctor_should_convert_min_boundary_to_only_holds_the_specified_TimeExpression(NonNull<TimeExpression> time, bool included)
+    {
+        // Arrange
+        DateTimeExpression dateTimeExpression = new(time.Item);
+
+        // Act
+        IntervalExpression interval = new(min: new BoundaryExpression(dateTimeExpression, included));
+
+        // Assert
+        interval.Min.Expression.Should()
+            .BeOfType<TimeExpression>()
+            .Which.Should().Be(time.Item);
+    }
+
+    [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
+    public void Given_Min_boundary_is_a_DateTimeExpression_with_only_date_specified_Ctor_should_convert_min_boundary_to_only_holds_the_specified_DateExpression(NonNull<DateExpression> date, bool included)
+    {
+        // Arrange
+        DateTimeExpression dateTimeExpression = new(date.Item);
+
+        // Act
+        IntervalExpression interval = new(min: new BoundaryExpression(dateTimeExpression, included));
+
+        // Assert
+        interval.Min.Expression.Should()
+            .BeOfType<DateExpression>()
+            .Which.Should().Be(date.Item);
+    }
+
+    [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
+    public void Ctor_should_converts_Max_DateTimeExpression_to_TimeExpression_when_DateExpression_is_not_provided(PositiveInt hours,
+        PositiveInt minutes,
+        PositiveInt seconds,
+        PositiveInt milliseconds,
+        bool included)
+    {
+        // Arrange
+        TimeExpression time = new(hours.Item, minutes.Item, seconds.Item, milliseconds.Item);
+        DateTimeExpression dateTimeExpression = new(time);
+
+        // Act
+        IntervalExpression interval = new(max: new BoundaryExpression(dateTimeExpression, included));
+        (IBoundaryExpression expression, _) = interval.Max;
+
+        // Assert
+        expression.Should()
+            .Be(time);
+    }
+
+    [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
+    public void Given_a_ConstantExpression_that_is_equal_to_min_and_min_and_max_are_equal_and_min_and_max_are_included_IsEquivalent_should_return_true_when_comparing_with_ConstantExpression(NumericValueExpression constant)
+    {
+        CreateIsEquivalentPropeprty(constant, constant, minIncluded: true, maxIsIncluded: true);
+    }
+
+    [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
+    public void IsEquivalent_should_be_reflexive(NonNull<IntervalExpression> interval)
+    {
+        // Arrange
+        IntervalExpression source = interval.Item;
+
+        // Act
+        bool actual = source.IsEquivalentTo(source);
+
+        // Assert
+        actual.Should().BeTrue();
+    }
+
+    [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
+    public void Given_a_DateExpression_that_is_equal_to_min_and_min_and_max_are_equal_and_min_and_max_are_included_IsEquivalent_should_return_true_when_comparing_with_DateExpression(DateExpression date)
+    {
+        CreateIsEquivalentPropeprty(date, date, minIncluded: true, maxIsIncluded: true);
+    }
+
+    [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
+    public void Given_a_DateTimeExpression_that_is_equal_to_min_and_min_and_max_are_equal_and_min_and_max_are_included_IsEquivalent_should_return_true_when_comparing_with_DateTimeExpression(DateTimeExpression dateTime)
+    {
+        CreateIsEquivalentPropeprty(dateTime, dateTime, minIncluded: true, maxIsIncluded: true);
+    }
+
+    [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
+    public void Given_a_DateTimeExpression_that_is_equal_to_min_and_min_and_max_are_equal_and_min_and_max_are_included_IsEquivalent_should_return_true_when_comparing_with_TimeExpression(TimeExpression dateTime)
+    {
+        CreateIsEquivalentPropeprty(dateTime, dateTime, minIncluded: true, maxIsIncluded: true);
+    }
+
+    private static void CreateIsEquivalentPropeprty(FilterExpression filterExpression, IBoundaryExpression boundaryExpression, bool minIncluded, bool maxIsIncluded)
+    {
+        // Arrange
+        IntervalExpression range = new(new BoundaryExpression(boundaryExpression, minIncluded), new BoundaryExpression(boundaryExpression, maxIsIncluded));
+
+        // Act 
+        bool actual = range.IsEquivalentTo(filterExpression);
+
+        // Assert
+        actual.Should().BeTrue();
+    }
+
+    [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
+    public void Given_RangeExpression_GetComplexity_should_return_sum_of_min_and_max_complexity(NonNull<IntervalExpression> rangeExpressionGenerator)
+    {
+        // Arrange
+        IntervalExpression rangeExpression = rangeExpressionGenerator.Item;
+
+        // Act
+        double actualComplexity = rangeExpression.Complexity;
+
+        // Assert
+        object _ = (rangeExpression.Min, rangeExpression.Max) switch
+        {
+            ({ Expression: { } minExpression }, { Expression: { } maxExpression }) => actualComplexity.Should().Be(minExpression.Complexity + maxExpression.Complexity),
+            ({ Expression: { } minExpression }, null) => actualComplexity.Should().Be(minExpression.Complexity),
+            (null, { Expression: { } maxExpression }) => actualComplexity.Should().Be(maxExpression.Complexity),
+            _ => actualComplexity.Should().Be(0),
+        };
+    }
+
+    public static TheoryData<IntervalExpression, FilterExpression, string> SimplifyCases
+        => new()
+        {
+            {
+                new IntervalExpression(new (new NumericValueExpression("10"), true), new (new NumericValueExpression("10"), true)),
+                new NumericValueExpression("10"),
+                "Lower and upper bound are equal"
+            },
+            {
+                new IntervalExpression(new (new NumericValueExpression("10"), true), new (new NumericValueExpression("12"), true)),
+                new IntervalExpression(new (new NumericValueExpression("10"), true), new (new NumericValueExpression("12"), true)),
+                "Lower and upper bound are not equals and not equivalent"
+            },
+            {
+                new IntervalExpression(new (new TimeExpression(1), true), new (new TimeExpression(minutes: 60), true)),
+                new TimeExpression(1),
+                "Lower and upper bound are equivalent"
+            },
+            {
+                new IntervalExpression(new (new NumericValueExpression("-32"), true), new (new NumericValueExpression("-32"), true)),
+                new NumericValueExpression("-32"),
+                "Lower and upper bound are equal"
+            }
+        };
+
+    [Theory]
+    [MemberData(nameof(SimplifyCases))]
+    public void Given_IntervalExpression_Simplify_should_return_expected_expression(IntervalExpression rangeExpression, FilterExpression expected, string reason)
+    {
+        outputHelper.WriteLine($"Range expression : {rangeExpression}");
+
+        // Act
+        FilterExpression actual = rangeExpression.Simplify();
+
+        // Assert
+        actual.Should()
+            .Be(expected, reason);
+    }
+
+    [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
+    public void An_IntervalExpression_instance_built_from_data_from_a_previously_deconstructed_instance_should_be_equal(IntervalExpression expected)
+    {
+        // Arrange
+        (BoundaryExpression min, BoundaryExpression max) = expected;
+
+        // Act
+        IntervalExpression actual = new(min, max);
+
+        // Assert
+        actual.Should()
+            .Be(expected);
+    }
+
+    [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
+    public void Equals_should_be_commutative(NonNull<IntervalExpression> first, FilterExpression second)
+        => first.Item.Equals(second).Should().Be(second.Equals(first.Item));
+
+    [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
+    public void Equals_should_be_reflexive(NonNull<IntervalExpression> expression)
+        => expression.Item.Should().Be(expression.Item);
+
+    [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
+    public void Equals_should_be_symetric(NonNull<IntervalExpression> expression, NonNull<FilterExpression> otherExpression)
+        => expression.Item.Equals(otherExpression.Item).Should().Be(otherExpression.Item.Equals(expression.Item));
 }

--- a/test/DataFilters.UnitTests/Grammar/Syntax/NotExpressionTests.cs
+++ b/test/DataFilters.UnitTests/Grammar/Syntax/NotExpressionTests.cs
@@ -1,199 +1,198 @@
-﻿namespace DataFilters.UnitTests.Grammar.Syntax
+﻿namespace DataFilters.UnitTests.Grammar.Syntax;
+
+using System;
+using DataFilters.Grammar.Parsing;
+using DataFilters.Grammar.Syntax;
+using DataFilters.UnitTests.Helpers;
+using FluentAssertions;
+using FsCheck;
+using FsCheck.Fluent;
+using FsCheck.Xunit;
+using Superpower;
+using Superpower.Model;
+using Xunit;
+
+public class NotExpressionTests
 {
-    using System;
-    using DataFilters.Grammar.Parsing;
-    using DataFilters.Grammar.Syntax;
-    using DataFilters.UnitTests.Helpers;
-    using FluentAssertions;
-    using FsCheck;
-    using FsCheck.Fluent;
-    using FsCheck.Xunit;
-    using Superpower;
-    using Superpower.Model;
-    using Xunit;
+    [Fact]
+    public void IsFilterExpression() => typeof(NotExpression).Should()
+        .BeAssignableTo<FilterExpression>().And
+        .Implement<IEquatable<NotExpression>>().And
+        .HaveConstructor(new[] { typeof(FilterExpression) }).And
+        .HaveProperty<FilterExpression>("Expression");
 
-    public class NotExpressionTests
+    [Fact]
+    public void Ctor_should_throws_ArgumentNullException_when_argument_is_null()
     {
-        [Fact]
-        public void IsFilterExpression() => typeof(NotExpression).Should()
-                                                                 .BeAssignableTo<FilterExpression>().And
-                                                                 .Implement<IEquatable<NotExpression>>().And
-                                                                 .HaveConstructor(new[] { typeof(FilterExpression) }).And
-                                                                 .HaveProperty<FilterExpression>("Expression");
+        // Act
+        Action action = () => _ = new NotExpression(null);
 
-        [Fact]
-        public void Ctor_should_throws_ArgumentNullException_when_argument_is_null()
-        {
-            // Act
-            Action action = () => _ = new NotExpression(null);
-
-            // Assert
-            action.Should()
-                .ThrowExactly<ArgumentNullException>($"The parameter of  {nameof(NotExpression)}'s constructor cannot be null");
-        }
-
-        public static TheoryData<string, NotExpression> ParsingCases
-            => new()
-            {
-                { "!!5", new NotExpression(new NotExpression(new NumericValueExpression("5"))) }
-            };
-
-        [Theory]
-        [MemberData(nameof(ParsingCases))]
-        public void Should_parse_to_NotExpression(string input, NotExpression expected)
-        {
-            // Arrange
-            FilterTokenizer tokenizer = new();
-            TokenList<FilterToken> tokens = tokenizer.Tokenize(input);
-
-            // Act
-            NotExpression actual = FilterTokenParser.Not.Parse(tokens);
-
-            // Assert
-            actual.Should().Be(expected);
-        }
-
-        [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
-        public void Given_NotExpression_GetComplexity_should_return_same_complexity_as_embedded_expression(NonNull<NotExpression> notExpression)
-            => notExpression.Item.Complexity.Should().Be(notExpression.Item.Expression.Complexity);
-
-        [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
-        public void Given_NotExpression_Equals_should_be_reflexive(NonNull<NotExpression> notExpression)
-            => notExpression.Item.Should().Be(notExpression.Item);
-
-        [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
-        public void Given_NotExpression_and_a_filter_expression_that_is_not_null_Equals_should_be_symetric(NonNull<NotExpression> notExpression, NonNull<FilterExpression> filterExpression)
-            => notExpression.Item.Equals(filterExpression.Item).Should().Be(filterExpression.Item.Equals(notExpression.Item));
-
-        [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
-        public void Given_two_instances_holding_same_Expressions_Equals_should_return_true(NonNull<FilterExpression> expression)
-        {
-            // Arrange
-            NotExpression first = new(expression.Item);
-            NotExpression other = new(expression.Item);
-
-            // Act
-            bool actual = first.Equals(other);
-            int firstHashCode = first.GetHashCode();
-            int otherHashCode = other.GetHashCode();
-
-            // Assert
-            actual.Should().BeTrue();
-            firstHashCode.Should().Be(otherHashCode);
-        }
-
-        [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
-        public void Given_argument_is_AndExpression_Constructor_should_wrap_it_inside_a_GroupExpression(NonNull<BinaryFilterExpression> expression)
-        {
-            // Act
-            NotExpression not = new(expression.Item);
-
-            // Assert
-            not.Expression.Should()
-                          .BeOfType<GroupExpression>("the parameter is a BinaryFilterExpression");
-        }
-
-        public static TheoryData<NotExpression, string> EscapedParseableStringCases
-            => new()
-            {
-                {
-                    new NotExpression(
-                        new OrExpression(new DateTimeExpression(new TimeExpression(2, 53, 39, 827)),
-                                                  new DateTimeExpression(new DateExpression(1901,06,17),
-                                                                         new TimeExpression(09, 13,44, 17),
-                                                                         OffsetExpression.Zero))
-                        ),
-
-                    "!(T02:53:39.827|1901-06-17T09:13:44.17Z)"
-                },
-                {
-                    new NotExpression(
-                       new OrExpression(new TimeExpression(2, 53, 39, 827),
-                                                  new DateTimeExpression(new DateExpression(1901,06,17),
-                                                                         new TimeExpression(09, 13,44, 17),
-                                                                         OffsetExpression.Zero))
-                        ),
-
-                    "!(02:53:39.827|1901-06-17T09:13:44.17Z)"
-                }
-            };
-
-        [Theory]
-        [MemberData(nameof(EscapedParseableStringCases))]
-        public void Given_NotExpression_EscapedParseableString_should_match_expected(NotExpression expression, string expected)
-        {
-            // Act
-            string actual = expression.EscapedParseableString;
-
-            // Assert
-            actual.Should()
-                  .Be(expected);
-        }
-
-        public static TheoryData<NotExpression, object, bool, string> EqualsCases
-            => new()
-            {
-                {
-                     new NotExpression(
-                        new OrExpression(new DateTimeExpression(new TimeExpression(2, 53, 39, 827)),
-                                                  new DateTimeExpression(new DateExpression(1901,06,17),
-                                                                         new TimeExpression(09, 13,44, 17),
-                                                                         OffsetExpression.Zero))
-                        ),
-                      new NotExpression(
-                        new OrExpression(new TimeExpression(2, 53, 39, 827),
-                                                  new DateTimeExpression(new DateExpression(1901,06,17),
-                                                                         new TimeExpression(09, 13,44, 17),
-                                                                         OffsetExpression.Zero))
-                        ),
-                    true,
-                    $"{nameof(DateTimeExpression.Date)} and {nameof(DateTimeExpression.Date)} are null and TimeExpression are equal"
-                },
-                {
-                    new NotExpression(new NotExpression(new NumericValueExpression("5"))),
-                    new NotExpression(new NotExpression(new NumericValueExpression("5"))),
-                    true,
-                    $"Two {nameof(NotExpression)} instances that contains equal inner expressions"
-                }
-            };
-
-        [Theory]
-        [MemberData(nameof(EqualsCases))]
-        public void Equals_should_work_as_expected(NotExpression expression, object obj, bool expected, string reason)
-        {
-            // Act
-            bool actual = expression.Equals(obj);
-
-            // Assert
-            actual.Should()
-                  .Be(expected, reason);
-        }
-
-        [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
-        public void Equals_should_be_commutative(NonNull<NotExpression> first, FilterExpression second)
-            => (first.Item.Equals(second) == second.Equals(first.Item)).ToProperty();
-
-        [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
-        public void Equals_should_be_reflexive(NonNull<NotExpression> expression)
-            => expression.Item.Equals(expression.Item).ToProperty();
-
-        [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
-        public void Equals_should_be_symetric(NonNull<NotExpression> expression, NonNull<FilterExpression> otherExpression)
-            => expression.Item.Equals(otherExpression.Item).Should().Be(otherExpression.Item.Equals(expression.Item));
-
-        [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
-        public void Given_NotExpression_Simplify_should_return_the_expected_expression(FilterExpression innerExpression)
-        {
-            // Act
-            NotExpression notExpression = new(innerExpression);
-            double complexityBeforeSimplification = notExpression.Complexity;
-
-            // Act
-            FilterExpression simplifiedExpression = notExpression.Simplify();
-
-            // Assert
-            notExpression.IsEquivalentTo(simplifiedExpression);
-        }
-
+        // Assert
+        action.Should()
+            .ThrowExactly<ArgumentNullException>($"The parameter of  {nameof(NotExpression)}'s constructor cannot be null");
     }
+
+    public static TheoryData<string, NotExpression> ParsingCases
+        => new()
+        {
+            { "!!5", new NotExpression(new NotExpression(new NumericValueExpression("5"))) }
+        };
+
+    [Theory]
+    [MemberData(nameof(ParsingCases))]
+    public void Should_parse_to_NotExpression(string input, NotExpression expected)
+    {
+        // Arrange
+        FilterTokenizer tokenizer = new();
+        TokenList<FilterToken> tokens = tokenizer.Tokenize(input);
+
+        // Act
+        NotExpression actual = FilterTokenParser.Not.Parse(tokens);
+
+        // Assert
+        actual.Should().Be(expected);
+    }
+
+    [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
+    public void Given_NotExpression_GetComplexity_should_return_same_complexity_as_embedded_expression(NonNull<NotExpression> notExpression)
+        => notExpression.Item.Complexity.Should().Be(notExpression.Item.Expression.Complexity);
+
+    [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
+    public void Given_NotExpression_Equals_should_be_reflexive(NonNull<NotExpression> notExpression)
+        => notExpression.Item.Should().Be(notExpression.Item);
+
+    [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
+    public void Given_NotExpression_and_a_filter_expression_that_is_not_null_Equals_should_be_symetric(NonNull<NotExpression> notExpression, NonNull<FilterExpression> filterExpression)
+        => notExpression.Item.Equals(filterExpression.Item).Should().Be(filterExpression.Item.Equals(notExpression.Item));
+
+    [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
+    public void Given_two_instances_holding_same_Expressions_Equals_should_return_true(NonNull<FilterExpression> expression)
+    {
+        // Arrange
+        NotExpression first = new(expression.Item);
+        NotExpression other = new(expression.Item);
+
+        // Act
+        bool actual = first.Equals(other);
+        int firstHashCode = first.GetHashCode();
+        int otherHashCode = other.GetHashCode();
+
+        // Assert
+        actual.Should().BeTrue();
+        firstHashCode.Should().Be(otherHashCode);
+    }
+
+    [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
+    public void Given_argument_is_AndExpression_Constructor_should_wrap_it_inside_a_GroupExpression(NonNull<BinaryFilterExpression> expression)
+    {
+        // Act
+        NotExpression not = new(expression.Item);
+
+        // Assert
+        not.Expression.Should()
+            .BeOfType<GroupExpression>("the parameter is a BinaryFilterExpression");
+    }
+
+    public static TheoryData<NotExpression, string> EscapedParseableStringCases
+        => new()
+        {
+            {
+                new NotExpression(
+                    new OrExpression(new DateTimeExpression(new TimeExpression(2, 53, 39, 827)),
+                        new DateTimeExpression(new DateExpression(1901,06,17),
+                            new TimeExpression(09, 13,44, 17),
+                            OffsetExpression.Zero))
+                ),
+
+                "!(T02:53:39.827|1901-06-17T09:13:44.17Z)"
+            },
+            {
+                new NotExpression(
+                    new OrExpression(new TimeExpression(2, 53, 39, 827),
+                        new DateTimeExpression(new DateExpression(1901,06,17),
+                            new TimeExpression(09, 13,44, 17),
+                            OffsetExpression.Zero))
+                ),
+
+                "!(02:53:39.827|1901-06-17T09:13:44.17Z)"
+            }
+        };
+
+    [Theory]
+    [MemberData(nameof(EscapedParseableStringCases))]
+    public void Given_NotExpression_EscapedParseableString_should_match_expected(NotExpression expression, string expected)
+    {
+        // Act
+        string actual = expression.EscapedParseableString;
+
+        // Assert
+        actual.Should()
+            .Be(expected);
+    }
+
+    public static TheoryData<NotExpression, object, bool, string> EqualsCases
+        => new()
+        {
+            {
+                new NotExpression(
+                    new OrExpression(new DateTimeExpression(new TimeExpression(2, 53, 39, 827)),
+                        new DateTimeExpression(new DateExpression(1901,06,17),
+                            new TimeExpression(09, 13,44, 17),
+                            OffsetExpression.Zero))
+                ),
+                new NotExpression(
+                    new OrExpression(new TimeExpression(2, 53, 39, 827),
+                        new DateTimeExpression(new DateExpression(1901,06,17),
+                            new TimeExpression(09, 13,44, 17),
+                            OffsetExpression.Zero))
+                ),
+                true,
+                $"{nameof(DateTimeExpression.Date)} and {nameof(DateTimeExpression.Date)} are null and TimeExpression are equal"
+            },
+            {
+                new NotExpression(new NotExpression(new NumericValueExpression("5"))),
+                new NotExpression(new NotExpression(new NumericValueExpression("5"))),
+                true,
+                $"Two {nameof(NotExpression)} instances that contains equal inner expressions"
+            }
+        };
+
+    [Theory]
+    [MemberData(nameof(EqualsCases))]
+    public void Equals_should_work_as_expected(NotExpression expression, object obj, bool expected, string reason)
+    {
+        // Act
+        bool actual = expression.Equals(obj);
+
+        // Assert
+        actual.Should()
+            .Be(expected, reason);
+    }
+
+    [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
+    public void Equals_should_be_commutative(NonNull<NotExpression> first, FilterExpression second)
+        => (first.Item.Equals(second) == second.Equals(first.Item)).ToProperty();
+
+    [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
+    public void Equals_should_be_reflexive(NonNull<NotExpression> expression)
+        => expression.Item.Equals(expression.Item).ToProperty();
+
+    [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
+    public void Equals_should_be_symetric(NonNull<NotExpression> expression, NonNull<FilterExpression> otherExpression)
+        => expression.Item.Equals(otherExpression.Item).Should().Be(otherExpression.Item.Equals(expression.Item));
+
+    [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
+    public void Given_NotExpression_Simplify_should_return_the_expected_expression(FilterExpression innerExpression)
+    {
+        // Act
+        NotExpression notExpression = new(innerExpression);
+        double complexityBeforeSimplification = notExpression.Complexity;
+
+        // Act
+        FilterExpression simplifiedExpression = notExpression.Simplify();
+
+        // Assert
+        notExpression.IsEquivalentTo(simplifiedExpression);
+    }
+
 }

--- a/test/DataFilters.UnitTests/Grammar/Syntax/OffsetExpressionTests.cs
+++ b/test/DataFilters.UnitTests/Grammar/Syntax/OffsetExpressionTests.cs
@@ -1,66 +1,65 @@
-﻿namespace DataFilters.UnitTests.Grammar.Syntax
+﻿namespace DataFilters.UnitTests.Grammar.Syntax;
+
+using DataFilters.Grammar.Syntax;
+using DataFilters.UnitTests.Helpers;
+
+using FluentAssertions;
+
+using FsCheck;
+using FsCheck.Fluent;
+using FsCheck.Xunit;
+
+using Xunit;
+using Xunit.Categories;
+
+[UnitTest]
+public class OffsetExpressionTests
 {
-    using DataFilters.Grammar.Syntax;
-    using DataFilters.UnitTests.Helpers;
-
-    using FluentAssertions;
-
-    using FsCheck;
-    using FsCheck.Fluent;
-    using FsCheck.Xunit;
-
-    using Xunit;
-    using Xunit.Categories;
-
-    [UnitTest]
-    public class OffsetExpressionTests
+    [Theory]
+    [InlineData(NumericSign.Minus, 0, 0, "Z")]
+    [InlineData(NumericSign.Plus, 0, 0, "Z")]
+    [InlineData(NumericSign.Minus, 1, 0, "-01:00")]
+    [InlineData(NumericSign.Plus, 2, 0, "+02:00")]
+    [InlineData(NumericSign.Minus, 2, 0, "-02:00")]
+    public void Given_input_EscapedParseableString_should_be_correct(NumericSign sign, uint hours, uint minutes, string expected)
     {
-        [Theory]
-        [InlineData(NumericSign.Minus, 0, 0, "Z")]
-        [InlineData(NumericSign.Plus, 0, 0, "Z")]
-        [InlineData(NumericSign.Minus, 1, 0, "-01:00")]
-        [InlineData(NumericSign.Plus, 2, 0, "+02:00")]
-        [InlineData(NumericSign.Minus, 2, 0, "-02:00")]
-        public void Given_input_EscapedParseableString_should_be_correct(NumericSign sign, uint hours, uint minutes, string expected)
-        {
-            // Arrange
-            OffsetExpression offset = new(sign, hours, minutes);
+        // Arrange
+        OffsetExpression offset = new(sign, hours, minutes);
 
-            // Act
-            string actual = offset.EscapedParseableString;
+        // Act
+        string actual = offset.EscapedParseableString;
 
-            // Assert
-            actual.Should()
-                  .Be(expected);
-        }
+        // Assert
+        actual.Should()
+            .Be(expected);
+    }
 
-        [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
-        public void Given_an_OffsetExpression_instance_Equals_should_be_reflective(NonNull<OffsetExpression> offset) => offset.Item.Equals(offset.Item).ToProperty();
+    [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
+    public void Given_an_OffsetExpression_instance_Equals_should_be_reflective(NonNull<OffsetExpression> offset) => offset.Item.Equals(offset.Item).ToProperty();
 
-        [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
-        public void Equals_should_be_commutative(NonNull<OffsetExpression> first, FilterExpression second)
-            => first.Item.Equals(second).Should().Be(second.Equals(first.Item));
+    [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
+    public void Equals_should_be_commutative(NonNull<OffsetExpression> first, FilterExpression second)
+        => first.Item.Equals(second).Should().Be(second.Equals(first.Item));
 
-        [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
-        public void Equals_should_be_reflexive(NonNull<OffsetExpression> expression)
-            => expression.Item.Should().Be(expression.Item);
+    [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
+    public void Equals_should_be_reflexive(NonNull<OffsetExpression> expression)
+        => expression.Item.Should().Be(expression.Item);
 
-        [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
-        public void Equals_should_be_symetric(NonNull<OffsetExpression> expression, NonNull<FilterExpression> otherExpression)
-            => expression.Item.Equals(otherExpression.Item).Should().Be(otherExpression.Item.Equals(expression.Item));
+    [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
+    public void Equals_should_be_symetric(NonNull<OffsetExpression> expression, NonNull<FilterExpression> otherExpression)
+        => expression.Item.Equals(otherExpression.Item).Should().Be(otherExpression.Item.Equals(expression.Item));
 
-        [Property]
-        public void Given_offset_is_Zero_When_comparing_same_offset_should_not_take_into_account_the_numeric_sign(NumericSign sign)
-        {
-            // Arrange
-            OffsetExpression zero = OffsetExpression.Zero;
-            OffsetExpression zeroWithNegativeSign = new(sign, (uint)zero.Hours, (uint)zero.Minutes);
+    [Property]
+    public void Given_offset_is_Zero_When_comparing_same_offset_should_not_take_into_account_the_numeric_sign(NumericSign sign)
+    {
+        // Arrange
+        OffsetExpression zero = OffsetExpression.Zero;
+        OffsetExpression zeroWithNegativeSign = new(sign, (uint)zero.Hours, (uint)zero.Minutes);
 
-            // Act
-            bool actual = zero == zeroWithNegativeSign;
+        // Act
+        bool actual = zero == zeroWithNegativeSign;
 
-            // Assert
-            actual.Should().BeTrue();
-        }
+        // Assert
+        actual.Should().BeTrue();
     }
 }

--- a/test/DataFilters.UnitTests/Grammar/Syntax/OneOfExpressionTests.cs
+++ b/test/DataFilters.UnitTests/Grammar/Syntax/OneOfExpressionTests.cs
@@ -1,329 +1,328 @@
-﻿namespace DataFilters.UnitTests.Grammar.Syntax
+﻿namespace DataFilters.UnitTests.Grammar.Syntax;
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using DataFilters.Grammar.Syntax;
+using DataFilters.UnitTests.Helpers;
+using FluentAssertions;
+using FsCheck;
+using FsCheck.Xunit;
+using Xunit;
+using Xunit.Abstractions;
+
+public class OneOfExpressionTests(ITestOutputHelper outputHelper)
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Linq;
-    using DataFilters.Grammar.Syntax;
-    using DataFilters.UnitTests.Helpers;
-    using FluentAssertions;
-    using FsCheck;
-    using FsCheck.Xunit;
-    using Xunit;
-    using Xunit.Abstractions;
+    [Fact]
+    public void IsFilterExpression() => typeof(OneOfExpression).Should()
+        .BeAssignableTo<FilterExpression>().And
+        .Implement<IEquatable<OneOfExpression>>().And
+        .HaveConstructor(new[] { typeof(FilterExpression[]) }).And
+        .HaveProperty<IReadOnlyList<FilterExpression>>(nameof(OneOfExpression.Values));
 
-    public class OneOfExpressionTests(ITestOutputHelper outputHelper)
+    [Fact]
+    public void Ctor_Throws_ArgumentNullException_When_Argument_Is_Null()
     {
-        [Fact]
-        public void IsFilterExpression() => typeof(OneOfExpression).Should()
-                                                                   .BeAssignableTo<FilterExpression>().And
-                                                                   .Implement<IEquatable<OneOfExpression>>().And
-                                                                   .HaveConstructor(new[] { typeof(FilterExpression[]) }).And
-                                                                   .HaveProperty<IReadOnlyList<FilterExpression>>(nameof(OneOfExpression.Values));
+        // Act
+        Action action = () => _ = new OneOfExpression(null);
 
-        [Fact]
-        public void Ctor_Throws_ArgumentNullException_When_Argument_Is_Null()
+        // Assert
+        action.Should()
+            .ThrowExactly<ArgumentNullException>($"The parameter {nameof(OneOfExpression)}'s constructor cannot be null");
+    }
+
+    [Fact]
+    public void Constructor_throws_InvalidOperationException_when_values_is_empty()
+    {
+        // Act
+        Action ctorWithEmptyArray = () => _ = new OneOfExpression([]);
+
+        // Assert
+        ctorWithEmptyArray.Should()
+            .ThrowExactly<InvalidOperationException>($"The parameter {nameof(OneOfExpression)}'s constructor cannot be a empty array");
+    }
+
+    public static TheoryData<OneOfExpression, object, bool, string> EqualsCases
+        => new()
         {
-            // Act
-            Action action = () => _ = new OneOfExpression(null);
-
-            // Assert
-            action.Should()
-                .ThrowExactly<ArgumentNullException>($"The parameter {nameof(OneOfExpression)}'s constructor cannot be null");
-        }
-
-        [Fact]
-        public void Constructor_throws_InvalidOperationException_when_values_is_empty()
-        {
-            // Act
-            Action ctorWithEmptyArray = () => _ = new OneOfExpression([]);
-
-            // Assert
-            ctorWithEmptyArray.Should()
-                              .ThrowExactly<InvalidOperationException>($"The parameter {nameof(OneOfExpression)}'s constructor cannot be a empty array");
-        }
-
-        public static TheoryData<OneOfExpression, object, bool, string> EqualsCases
-            => new()
             {
-                {
-                    new OneOfExpression(new StringValueExpression("prop1"), new StringValueExpression("prop2")),
-                    new OneOfExpression(new StringValueExpression("prop1"), new StringValueExpression("prop2")),
-                    true,
-                    "comparing two different instances with same data in same order"
-                },
-                {
-                    new OneOfExpression(new StringValueExpression("prop1"), new StringValueExpression("prop2")),
-                    new OneOfExpression(new StringValueExpression("prop2"), new StringValueExpression("prop1")),
-                    false,
-                    "comparing two different instances with same data but the order does not matter"
-                },
-                {
-                    new OneOfExpression(new StringValueExpression("prop1"), new StringValueExpression("prop2")),
-                    new OneOfExpression(new StringValueExpression("prop1"), new StringValueExpression("prop3")),
-                    false,
-                    "comparing two different instances with different data"
-                }
-            };
-
-        [Theory]
-        [MemberData(nameof(EqualsCases))]
-        public void ImplementsEqualsCorrectly(OneOfExpression first, object other, bool expected, string reason)
-        {
-            outputHelper.WriteLine($"First instance : {first}");
-            outputHelper.WriteLine($"Second instance : {other}");
-
-            // Act
-            bool actual = first.Equals(other);
-            int actualHashCode = first.GetHashCode();
-
-            // Assert
-            actual.Should()
-                  .Be(expected, reason);
-
-            object _ = expected switch
+                new OneOfExpression(new StringValueExpression("prop1"), new StringValueExpression("prop2")),
+                new OneOfExpression(new StringValueExpression("prop1"), new StringValueExpression("prop2")),
+                true,
+                "comparing two different instances with same data in same order"
+            },
             {
-                true => actualHashCode.Should()
-                                      .Be(other?.GetHashCode(), reason),
-                _ => true
-            };
-        }
-
-        public static TheoryData<OneOfExpression, FilterExpression, bool, string> IsEquivalentToCases
-            => new()
+                new OneOfExpression(new StringValueExpression("prop1"), new StringValueExpression("prop2")),
+                new OneOfExpression(new StringValueExpression("prop2"), new StringValueExpression("prop1")),
+                false,
+                "comparing two different instances with same data but the order does not matter"
+            },
             {
-                {
-                    new OneOfExpression(new StringValueExpression("prop1"), new StringValueExpression("prop2")),
-                    new OneOfExpression(new StringValueExpression("prop1"), new StringValueExpression("prop2")),
-                    true,
-                    "comparing two different instances with same data in same order"
-                },
-                {
-                    new OneOfExpression(new StringValueExpression("prop1"), new StringValueExpression("prop2")),
-                    new OneOfExpression(new StringValueExpression("prop2"), new StringValueExpression("prop1")),
-                    true,
-                    "comparing two different instances with same data but the order does not matter"
-                },
-                {
-                    new OneOfExpression(new StringValueExpression("prop1"), new StringValueExpression("prop2")),
-                    new OneOfExpression(new StringValueExpression("prop1"), new StringValueExpression("prop3")),
-                    false,
-                    "comparing two different instances with different data"
-                },
-                {
-                    new OneOfExpression(new StringValueExpression("prop1"), new StringValueExpression("prop2")),
-                    new OneOfExpression(new StringValueExpression("prop1"), new StringValueExpression("prop2"), new StringValueExpression("prop3")),
-                    false,
-                    "the other instance contains all data of the first instance and one item that is not in the current instance"
-                },
-                {
-                    new OneOfExpression(new StringValueExpression("prop1"), new StringValueExpression("prop1"), new StringValueExpression("prop2")),
-                    new OneOfExpression(new StringValueExpression("prop1"), new StringValueExpression("prop2")),
-                    true,
-                    $"a {nameof(OneOfExpression)} instance that holds duplicates is equivalent a {nameof(OneOfExpression)} with no duplicate"
-                },
-                {
-                    new OneOfExpression(new StringValueExpression("prop1"), new StringValueExpression("prop2")),
-                    new OrExpression(new StringValueExpression("prop1"), new StringValueExpression("prop2")),
-                    true,
-                    $"a {nameof(OneOfExpression)} instance that holds two distinct value is equivalent to an {nameof(OrExpression)} with the same values"
-                },
-                {
-                    new OneOfExpression(new IntervalExpression(new BoundaryExpression(new NumericValueExpression("-1"), true),
-                                                                new BoundaryExpression(new NumericValueExpression("-1"), true)),
-                                               new IntervalExpression(new BoundaryExpression(new NumericValueExpression("-1"), true),
-                                                                new BoundaryExpression(new NumericValueExpression("-1"), true))),
-                    new NumericValueExpression("-1"),
-                    true,
-                    $"a {nameof(OneOfExpression)} instance that holds two distinct value is equivalent to its simplified version"
-                }
-            };
+                new OneOfExpression(new StringValueExpression("prop1"), new StringValueExpression("prop2")),
+                new OneOfExpression(new StringValueExpression("prop1"), new StringValueExpression("prop3")),
+                false,
+                "comparing two different instances with different data"
+            }
+        };
 
-        [Theory]
-        [MemberData(nameof(IsEquivalentToCases))]
-        public void Implements_IsEquivalentTo_Properly(OneOfExpression first, FilterExpression other, bool expected, string reason)
+    [Theory]
+    [MemberData(nameof(EqualsCases))]
+    public void ImplementsEqualsCorrectly(OneOfExpression first, object other, bool expected, string reason)
+    {
+        outputHelper.WriteLine($"First instance : {first}");
+        outputHelper.WriteLine($"Second instance : {other}");
+
+        // Act
+        bool actual = first.Equals(other);
+        int actualHashCode = first.GetHashCode();
+
+        // Assert
+        actual.Should()
+            .Be(expected, reason);
+
+        object _ = expected switch
         {
-            // Act
-            bool actual = first.IsEquivalentTo(other);
+            true => actualHashCode.Should()
+                .Be(other?.GetHashCode(), reason),
+            _ => true
+        };
+    }
 
-            // Assert
-            actual.Should()
-                  .Be(expected, reason);
-        }
-
-        [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
-        public void Given_ConstantExpression_equals_left_and_left_equals_right_expression_IsEquivalentTo_should_be_true(StringValueExpression filterExpression, PositiveInt n)
-            => Given_OneOfExpression_contains_the_same_expression_repeated_many_time_When_comparing_to_that_expression_IsEquivalentTo_should_return_true(filterExpression, n.Item);
-
-        [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
-        public void Given_DateExpression_equals_left_and_left_equals_right_expression_IsEquivalentTo_should_be_true(DateExpression filterExpression, PositiveInt n)
-            => Given_OneOfExpression_contains_the_same_expression_repeated_many_time_When_comparing_to_that_expression_IsEquivalentTo_should_return_true(filterExpression, n.Item);
-
-        [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
-        public void Given_DateTimeExpression_equals_left_and_left_equals_right_expression_IsEquivalentTo_should_be_true(DateTimeExpression filterExpression, PositiveInt n)
-            => Given_OneOfExpression_contains_the_same_expression_repeated_many_time_When_comparing_to_that_expression_IsEquivalentTo_should_return_true(filterExpression, n.Item);
-
-        [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
-        public void Given_AsteriskExpression_equals_left_and_left_equals_right_expression_IsEquivalentTo_should_be_true(PositiveInt n)
-            => Given_OneOfExpression_contains_the_same_expression_repeated_many_time_When_comparing_to_that_expression_IsEquivalentTo_should_return_true(AsteriskExpression.Instance, n.Item);
-
-        private static void Given_OneOfExpression_contains_the_same_expression_repeated_many_time_When_comparing_to_that_expression_IsEquivalentTo_should_return_true(FilterExpression filterExpression, int n)
+    public static TheoryData<OneOfExpression, FilterExpression, bool, string> IsEquivalentToCases
+        => new()
         {
-            // Arrange
-            IEnumerable<FilterExpression> filterExpressions = Enumerable.Repeat(filterExpression, n);
-
-            OneOfExpression oneOfExpression = new(filterExpressions.ToArray());
-
-            // Act
-            bool actual = oneOfExpression.IsEquivalentTo(filterExpression);
-
-            // Assert
-            actual.Should().BeTrue();
-        }
-
-        [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
-        public void Given_OneOfExpression_Complexity_should_return_sum_of_inner_expressions(NonEmptyArray<FilterExpression> expressions)
-        {
-            // Arrange
-            OneOfExpression oneOfExpression = new(expressions.Item);
-            double expected = oneOfExpression.Values.Sum(expr => expr.Complexity);
-
-            // Act
-            double actual = oneOfExpression.Complexity;
-
-            // Assert
-            actual.Should().Be(expected);
-        }
-
-        [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
-        public void Given_OneOfExpression_with_same_values_repeated_more_than_once_Simplify_should_filter_out_duplicated_values(NonEmptyArray<FilterExpression> expressions)
-        {
-            // Arrange
-            OneOfExpression oneOf = new(expressions.Item);
-
-            double complexityBeforeCallingSimplify = oneOf.Complexity;
-
-            // Act
-            FilterExpression simplifiedExpression = oneOf.Simplify();
-
-            // Assert
-            simplifiedExpression.Complexity.Should().BeLessThanOrEqualTo(complexityBeforeCallingSimplify);
-        }
-
-        public static TheoryData<OneOfExpression, FilterExpression> SimplifyCases
-            => new()
             {
-                {
-                    new OneOfExpression(new StringValueExpression("val1"), new StringValueExpression("val2")),
-                    new OrExpression(new StringValueExpression("val1"), new StringValueExpression("val2"))
-                },
-                {
-                    new OneOfExpression(new StringValueExpression("val1"), new StringValueExpression("val1")),
-                    new StringValueExpression("val1")
-                },
-                {
-                    new OneOfExpression(new StringValueExpression("val1"), new OrExpression(new StringValueExpression("val1"), new StringValueExpression("val1"))),
-                    new StringValueExpression("val1")
-                },
-                {
-                    new OneOfExpression(new IntervalExpression(new BoundaryExpression(new NumericValueExpression("-1"), true),
-                                                                new BoundaryExpression(new NumericValueExpression("-1"), true)),
-                                               new IntervalExpression(new BoundaryExpression(new NumericValueExpression("-1"), true),
-                                                                new BoundaryExpression(new NumericValueExpression("-1"), true))),
-                    new NumericValueExpression("-1")
-                },
-                {
-                    new OneOfExpression(null, new GroupExpression(new AndExpression(new StringValueExpression("a"), new StringValueExpression("b"))), null),
-                    new AndExpression(new StringValueExpression("a"), new StringValueExpression("b"))
-                },
-                {
-                    new OneOfExpression(new ContainsExpression("A"), new ContainsExpression("A"), new ContainsExpression("A")),
-                    new ContainsExpression("A")
-                }
-            };
+                new OneOfExpression(new StringValueExpression("prop1"), new StringValueExpression("prop2")),
+                new OneOfExpression(new StringValueExpression("prop1"), new StringValueExpression("prop2")),
+                true,
+                "comparing two different instances with same data in same order"
+            },
+            {
+                new OneOfExpression(new StringValueExpression("prop1"), new StringValueExpression("prop2")),
+                new OneOfExpression(new StringValueExpression("prop2"), new StringValueExpression("prop1")),
+                true,
+                "comparing two different instances with same data but the order does not matter"
+            },
+            {
+                new OneOfExpression(new StringValueExpression("prop1"), new StringValueExpression("prop2")),
+                new OneOfExpression(new StringValueExpression("prop1"), new StringValueExpression("prop3")),
+                false,
+                "comparing two different instances with different data"
+            },
+            {
+                new OneOfExpression(new StringValueExpression("prop1"), new StringValueExpression("prop2")),
+                new OneOfExpression(new StringValueExpression("prop1"), new StringValueExpression("prop2"), new StringValueExpression("prop3")),
+                false,
+                "the other instance contains all data of the first instance and one item that is not in the current instance"
+            },
+            {
+                new OneOfExpression(new StringValueExpression("prop1"), new StringValueExpression("prop1"), new StringValueExpression("prop2")),
+                new OneOfExpression(new StringValueExpression("prop1"), new StringValueExpression("prop2")),
+                true,
+                $"a {nameof(OneOfExpression)} instance that holds duplicates is equivalent a {nameof(OneOfExpression)} with no duplicate"
+            },
+            {
+                new OneOfExpression(new StringValueExpression("prop1"), new StringValueExpression("prop2")),
+                new OrExpression(new StringValueExpression("prop1"), new StringValueExpression("prop2")),
+                true,
+                $"a {nameof(OneOfExpression)} instance that holds two distinct value is equivalent to an {nameof(OrExpression)} with the same values"
+            },
+            {
+                new OneOfExpression(new IntervalExpression(new BoundaryExpression(new NumericValueExpression("-1"), true),
+                        new BoundaryExpression(new NumericValueExpression("-1"), true)),
+                    new IntervalExpression(new BoundaryExpression(new NumericValueExpression("-1"), true),
+                        new BoundaryExpression(new NumericValueExpression("-1"), true))),
+                new NumericValueExpression("-1"),
+                true,
+                $"a {nameof(OneOfExpression)} instance that holds two distinct value is equivalent to its simplified version"
+            }
+        };
 
-        [Theory]
-        [MemberData(nameof(SimplifyCases))]
-        public void Given_OneOfExpression_Simplify_should_output_expected_expression(OneOfExpression input, FilterExpression expected)
+    [Theory]
+    [MemberData(nameof(IsEquivalentToCases))]
+    public void Implements_IsEquivalentTo_Properly(OneOfExpression first, FilterExpression other, bool expected, string reason)
+    {
+        // Act
+        bool actual = first.IsEquivalentTo(other);
+
+        // Assert
+        actual.Should()
+            .Be(expected, reason);
+    }
+
+    [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
+    public void Given_ConstantExpression_equals_left_and_left_equals_right_expression_IsEquivalentTo_should_be_true(StringValueExpression filterExpression, PositiveInt n)
+        => Given_OneOfExpression_contains_the_same_expression_repeated_many_time_When_comparing_to_that_expression_IsEquivalentTo_should_return_true(filterExpression, n.Item);
+
+    [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
+    public void Given_DateExpression_equals_left_and_left_equals_right_expression_IsEquivalentTo_should_be_true(DateExpression filterExpression, PositiveInt n)
+        => Given_OneOfExpression_contains_the_same_expression_repeated_many_time_When_comparing_to_that_expression_IsEquivalentTo_should_return_true(filterExpression, n.Item);
+
+    [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
+    public void Given_DateTimeExpression_equals_left_and_left_equals_right_expression_IsEquivalentTo_should_be_true(DateTimeExpression filterExpression, PositiveInt n)
+        => Given_OneOfExpression_contains_the_same_expression_repeated_many_time_When_comparing_to_that_expression_IsEquivalentTo_should_return_true(filterExpression, n.Item);
+
+    [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
+    public void Given_AsteriskExpression_equals_left_and_left_equals_right_expression_IsEquivalentTo_should_be_true(PositiveInt n)
+        => Given_OneOfExpression_contains_the_same_expression_repeated_many_time_When_comparing_to_that_expression_IsEquivalentTo_should_return_true(AsteriskExpression.Instance, n.Item);
+
+    private static void Given_OneOfExpression_contains_the_same_expression_repeated_many_time_When_comparing_to_that_expression_IsEquivalentTo_should_return_true(FilterExpression filterExpression, int n)
+    {
+        // Arrange
+        IEnumerable<FilterExpression> filterExpressions = Enumerable.Repeat(filterExpression, n);
+
+        OneOfExpression oneOfExpression = new(filterExpressions.ToArray());
+
+        // Act
+        bool actual = oneOfExpression.IsEquivalentTo(filterExpression);
+
+        // Assert
+        actual.Should().BeTrue();
+    }
+
+    [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
+    public void Given_OneOfExpression_Complexity_should_return_sum_of_inner_expressions(NonEmptyArray<FilterExpression> expressions)
+    {
+        // Arrange
+        OneOfExpression oneOfExpression = new(expressions.Item);
+        double expected = oneOfExpression.Values.Sum(expr => expr.Complexity);
+
+        // Act
+        double actual = oneOfExpression.Complexity;
+
+        // Assert
+        actual.Should().Be(expected);
+    }
+
+    [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
+    public void Given_OneOfExpression_with_same_values_repeated_more_than_once_Simplify_should_filter_out_duplicated_values(NonEmptyArray<FilterExpression> expressions)
+    {
+        // Arrange
+        OneOfExpression oneOf = new(expressions.Item);
+
+        double complexityBeforeCallingSimplify = oneOf.Complexity;
+
+        // Act
+        FilterExpression simplifiedExpression = oneOf.Simplify();
+
+        // Assert
+        simplifiedExpression.Complexity.Should().BeLessThanOrEqualTo(complexityBeforeCallingSimplify);
+    }
+
+    public static TheoryData<OneOfExpression, FilterExpression> SimplifyCases
+        => new()
         {
-            // Act
-            FilterExpression actual = input.Simplify();
+            {
+                new OneOfExpression(new StringValueExpression("val1"), new StringValueExpression("val2")),
+                new OrExpression(new StringValueExpression("val1"), new StringValueExpression("val2"))
+            },
+            {
+                new OneOfExpression(new StringValueExpression("val1"), new StringValueExpression("val1")),
+                new StringValueExpression("val1")
+            },
+            {
+                new OneOfExpression(new StringValueExpression("val1"), new OrExpression(new StringValueExpression("val1"), new StringValueExpression("val1"))),
+                new StringValueExpression("val1")
+            },
+            {
+                new OneOfExpression(new IntervalExpression(new BoundaryExpression(new NumericValueExpression("-1"), true),
+                        new BoundaryExpression(new NumericValueExpression("-1"), true)),
+                    new IntervalExpression(new BoundaryExpression(new NumericValueExpression("-1"), true),
+                        new BoundaryExpression(new NumericValueExpression("-1"), true))),
+                new NumericValueExpression("-1")
+            },
+            {
+                new OneOfExpression(null, new GroupExpression(new AndExpression(new StringValueExpression("a"), new StringValueExpression("b"))), null),
+                new AndExpression(new StringValueExpression("a"), new StringValueExpression("b"))
+            },
+            {
+                new OneOfExpression(new ContainsExpression("A"), new ContainsExpression("A"), new ContainsExpression("A")),
+                new ContainsExpression("A")
+            }
+        };
 
-            // Assert
-            actual.Should().Be(expected);
-        }
+    [Theory]
+    [MemberData(nameof(SimplifyCases))]
+    public void Given_OneOfExpression_Simplify_should_output_expected_expression(OneOfExpression input, FilterExpression expected)
+    {
+        // Act
+        FilterExpression actual = input.Simplify();
 
-        [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
-        public void Given_OneOfExpression_instance_which_contains_only_one_expression_Simplify_should_return_an_expression_that_is_equivalent_to_the_inner_expression(NonNull<FilterExpression> expression)
-        {
-            // Arrange
-            FilterExpression expected = expression.Item;
-            outputHelper.WriteLine($"input : {expected:d}");
-            OneOfExpression oneOf = new(expected);
+        // Assert
+        actual.Should().Be(expected);
+    }
 
-            // Act
-            FilterExpression actual = oneOf.Simplify();
+    [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
+    public void Given_OneOfExpression_instance_which_contains_only_one_expression_Simplify_should_return_an_expression_that_is_equivalent_to_the_inner_expression(NonNull<FilterExpression> expression)
+    {
+        // Arrange
+        FilterExpression expected = expression.Item;
+        outputHelper.WriteLine($"input : {expected:d}");
+        OneOfExpression oneOf = new(expected);
 
-            outputHelper.WriteLine($"Actual : {actual:d}");
+        // Act
+        FilterExpression actual = oneOf.Simplify();
 
-            // Assert
-            actual.IsEquivalentTo(expected)
-                      .Should()
-                      .BeTrue();
-        }
+        outputHelper.WriteLine($"Actual : {actual:d}");
 
-        [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
-        public void Given_OneOfExpression_Simplify_should_return_an_expression_that_cannot_be_further_simplified(PositiveInt count, NonNull<FilterExpression> expression)
-        {
-            // Arrange
-            FilterExpression[] expressions = [ .. Enumerable.Repeat(expression.Item, count.Item + 2) ];
+        // Assert
+        actual.IsEquivalentTo(expected)
+            .Should()
+            .BeTrue();
+    }
 
-            OneOfExpression oneOfExpression = new(expressions);
+    [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
+    public void Given_OneOfExpression_Simplify_should_return_an_expression_that_cannot_be_further_simplified(PositiveInt count, NonNull<FilterExpression> expression)
+    {
+        // Arrange
+        FilterExpression[] expressions = [ .. Enumerable.Repeat(expression.Item, count.Item + 2) ];
 
-            double complexityBeforeFirstSimplification = oneOfExpression.Complexity;
+        OneOfExpression oneOfExpression = new(expressions);
 
-            // Act
-            FilterExpression simplified = oneOfExpression.Simplify();
+        double complexityBeforeFirstSimplification = oneOfExpression.Complexity;
 
-            // Assert
-            simplified.Complexity.Should()
-                                 .BeLessThan(complexityBeforeFirstSimplification, "The expression must be simpler");
-        }
+        // Act
+        FilterExpression simplified = oneOfExpression.Simplify();
 
-        [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
-        public void Given_OneExpression_that_contains_inner_OneOfExpressions_Simplify_should_flatten_them(NonEmptyArray<FilterExpression> oneOfExpressionGenerator)
-        {
-            // Arrange
-            FilterExpression[] oneOfExpressions = oneOfExpressionGenerator.Item;
-            FilterExpression expected = new OneOfExpression([.. oneOfExpressions]).Simplify();
-            outputHelper.WriteLine($"expected  (debug): {expected:d}");
-            outputHelper.WriteLine($"expected : {expected}");
+        // Assert
+        simplified.Complexity.Should()
+            .BeLessThan(complexityBeforeFirstSimplification, "The expression must be simpler");
+    }
 
-            OneOfExpression initial = new([.. oneOfExpressions]);
-            outputHelper.WriteLine($"initial : {initial:d}");
+    [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
+    public void Given_OneExpression_that_contains_inner_OneOfExpressions_Simplify_should_flatten_them(NonEmptyArray<FilterExpression> oneOfExpressionGenerator)
+    {
+        // Arrange
+        FilterExpression[] oneOfExpressions = oneOfExpressionGenerator.Item;
+        FilterExpression expected = new OneOfExpression([.. oneOfExpressions]).Simplify();
+        outputHelper.WriteLine($"expected  (debug): {expected:d}");
+        outputHelper.WriteLine($"expected : {expected}");
 
-            // Act
-            FilterExpression actual = initial.Simplify();
-            outputHelper.WriteLine($"actual (debug): {actual:d}");
-            outputHelper.WriteLine($"actual : {actual}");
+        OneOfExpression initial = new([.. oneOfExpressions]);
+        outputHelper.WriteLine($"initial : {initial:d}");
 
-            // Assert
-            actual.Should()
-                  .Be(expected);
-        }
+        // Act
+        FilterExpression actual = initial.Simplify();
+        outputHelper.WriteLine($"actual (debug): {actual:d}");
+        outputHelper.WriteLine($"actual : {actual}");
 
-        [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
-        public void Given_several_expressions_When_wrapped_in_OneOfExpression_Then_EscapedParseableString_should_have_expected_value(NonEmptyArray<FilterExpression> expressionGenerators)
-        {
-            // Arrange
-            FilterExpression[] innerExpressions = [.. expressionGenerators.Item];
-            OneOfExpression expression = new(innerExpressions);
-            string expected = $"{{{string.Join("|", innerExpressions.Select(expr => expr.EscapedParseableString))}}}";
+        // Assert
+        actual.Should()
+            .Be(expected);
+    }
 
-            // Act
-            string actual = expression.EscapedParseableString;
+    [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
+    public void Given_several_expressions_When_wrapped_in_OneOfExpression_Then_EscapedParseableString_should_have_expected_value(NonEmptyArray<FilterExpression> expressionGenerators)
+    {
+        // Arrange
+        FilterExpression[] innerExpressions = [.. expressionGenerators.Item];
+        OneOfExpression expression = new(innerExpressions);
+        string expected = $"{{{string.Join("|", innerExpressions.Select(expr => expr.EscapedParseableString))}}}";
 
-            // Assert
-            actual.Should().Be(expected);
-        }
+        // Act
+        string actual = expression.EscapedParseableString;
+
+        // Assert
+        actual.Should().Be(expected);
     }
 }

--- a/test/DataFilters.UnitTests/Grammar/Syntax/OrExpressionTests.cs
+++ b/test/DataFilters.UnitTests/Grammar/Syntax/OrExpressionTests.cs
@@ -1,382 +1,381 @@
-﻿namespace DataFilters.UnitTests.Grammar.Syntax
+﻿namespace DataFilters.UnitTests.Grammar.Syntax;
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using DataFilters.Grammar.Syntax;
+using Helpers;
+using FluentAssertions;
+using FsCheck;
+using FsCheck.Fluent;
+using FsCheck.Xunit;
+using Xunit;
+using Xunit.Abstractions;
+using Xunit.Categories;
+
+[UnitTest]
+public class OrExpressionTests(ITestOutputHelper outputHelper)
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Linq;
-    using DataFilters.Grammar.Syntax;
-    using Helpers;
-    using FluentAssertions;
-    using FsCheck;
-    using FsCheck.Fluent;
-    using FsCheck.Xunit;
-    using Xunit;
-    using Xunit.Abstractions;
-    using Xunit.Categories;
+    [Fact]
+    public void IsFilterExpression() => typeof(OrExpression).Should()
+        .BeAssignableTo<FilterExpression>().And
+        .Implement<IEquatable<OrExpression>>().And
+        .Implement<ISimplifiable>().And
+        .HaveProperty<FilterExpression>("Left").And
+        .HaveProperty<FilterExpression>("Right");
 
-    [UnitTest]
-    public class OrExpressionTests(ITestOutputHelper outputHelper)
+    public static TheoryData<FilterExpression, FilterExpression> ArgumentNullExceptionCases
     {
-        [Fact]
-        public void IsFilterExpression() => typeof(OrExpression).Should()
-                                                                .BeAssignableTo<FilterExpression>().And
-                                                                .Implement<IEquatable<OrExpression>>().And
-                                                                .Implement<ISimplifiable>().And
-                                                                .HaveProperty<FilterExpression>("Left").And
-                                                                .HaveProperty<FilterExpression>("Right");
-
-        public static TheoryData<FilterExpression, FilterExpression> ArgumentNullExceptionCases
+        get
         {
-            get
-            {
-                FilterExpression[] expression = [new StartsWithExpression("ce"), null];
-                TheoryData<FilterExpression, FilterExpression> cases = [];
+            FilterExpression[] expression = [new StartsWithExpression("ce"), null];
+            TheoryData<FilterExpression, FilterExpression> cases = [];
 
-                expression.CrossJoin(expression, (left, right) => (left, right))
-                    .Where(tuple => tuple.left == null || tuple.right is null)
-                    .ForEach(tuple => cases.Add(tuple.left, tuple.right));
+            expression.CrossJoin(expression, (left, right) => (left, right))
+                .Where(tuple => tuple.left == null || tuple.right is null)
+                .ForEach(tuple => cases.Add(tuple.left, tuple.right));
 
-                return cases;
-            }
+            return cases;
         }
-
-        [Theory]
-        [MemberData(nameof(ArgumentNullExceptionCases))]
-        public void Ctor_Throws_ArgumentNullException_When_Argument_Is_Null(FilterExpression left, FilterExpression right)
-        {
-            // Act
-            Action action = () => _ = new OrExpression(left, right);
-
-            // Assert
-            action.Should()
-                .ThrowExactly<ArgumentNullException>("The parameter of the constructor cannot be null");
-        }
-
-        public static TheoryData<OrExpression, object, bool, string> EqualsCases
-            => new()
-            {
-                {
-                    new OrExpression(new StartsWithExpression("prop1"), new StartsWithExpression("prop2")),
-                    new OrExpression(new StartsWithExpression("prop1"), new StartsWithExpression("prop2")),
-                    true,
-                    "comparing two different instances with same property name"
-                },
-                {
-                    new OrExpression(new StartsWithExpression("prop1"), new StartsWithExpression("prop2")),
-                    new OrExpression(new StartsWithExpression("prop1"), new StartsWithExpression("prop3")),
-                    false,
-                    "comparing two different instances with different property name"
-                },
-                {
-                    new OrExpression(new StringValueExpression("prop1"), new StringValueExpression("prop1")),
-                    new StringValueExpression("prop1"),
-                    false,
-                    "comparing to a filter expression that is semantically equivalent"
-                }
-            };
-
-        [Theory]
-        [MemberData(nameof(EqualsCases))]
-        public void Equals_should_behave_has_expected(OrExpression current, object other, bool expected, string reason)
-        {
-            outputHelper.WriteLine($"Current instance : {current}");
-            outputHelper.WriteLine($"Other instance : {other}");
-
-            // Act
-            bool actual = current.Equals(other);
-
-            // Assert
-            actual.Should()
-                .Be(expected, reason);
-        }
-
-        public static TheoryData<OrExpression, FilterExpression, bool, string> IsEquivalentToCases
-            => new()
-            {
-                {
-                    new OrExpression(new StartsWithExpression("prop1"), new StartsWithExpression("prop2")),
-                    new OrExpression(new StartsWithExpression("prop1"), new StartsWithExpression("prop2")),
-                    true,
-                    $"both {nameof(OrExpression)} instances are identical"
-                },
-                {
-                    new OrExpression(new StartsWithExpression("prop1"), new StartsWithExpression("prop2")),
-                    new OrExpression(new StartsWithExpression("prop1"), new StartsWithExpression("prop3")),
-                    false,
-                    $"the two {nameof(OrExpression)} instances contain different data."
-                },
-                {
-                    new OrExpression(new StartsWithExpression("prop1"), new StartsWithExpression("prop2")),
-                    new OrExpression(new StartsWithExpression("prop2"), new StartsWithExpression("prop1")),
-                    true,
-                    $"both {nameof(OrExpression)} contains same data but not in the same order"
-                },
-                {
-                     new OrExpression(new StringValueExpression("prop1"), new StringValueExpression("prop1")),
-                     new StringValueExpression("prop1"),
-                     true,
-                     "comparing to a filter expression that is semantically equivalent"
-                }
-            };
-
-        [Theory]
-        [MemberData(nameof(IsEquivalentToCases))]
-        public void Implements_IsEquivalentTo_Correctly(OrExpression first, FilterExpression other, bool expected, string reason)
-        {
-            outputHelper.WriteLine($"First instance : {first}");
-            outputHelper.WriteLine($"Second instance : {other}");
-
-            // Act
-            bool actual = first.IsEquivalentTo(other);
-
-            // Assert
-            actual.Should()
-                .Be(expected, reason);
-        }
-
-        [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
-        public void Given_two_OrExpression_instances_that_left_and_right_expressions_are_both_equals_IsEquivalentTo_should_return_true(FilterExpression left, FilterExpression right)
-        {
-            // Arrange
-            OrExpression one = new(left, right);
-            OrExpression two = new(left: right, right: left);
-
-            // Act
-            bool actual = one.IsEquivalentTo(two);
-
-            // Assert
-            actual.Should().BeTrue();
-        }
-
-        [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
-        public void Given_OrExpression_and_OneOfExpression_that_contains_the_same_two_expression_then_calling_IsEquivalentTo_with_that_OneOfExpression_should_return_true(FilterExpression left, FilterExpression right)
-        {
-            // Arrange
-            OneOfExpression oneOf = new(left, right);
-            OrExpression or = new(left, right);
-
-            // Act
-            bool actual = or.IsEquivalentTo(oneOf);
-
-            // Assert
-            actual.Should().BeTrue();
-        }
-
-        [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
-        public void Given_ConstantExpression_equals_left_and_left_equals_right_expression_IsEquivalentTo_should_be_true(ConstantValueExpression filterExpression)
-            => Given_FilterExpression_equals_left_and_right_IsEquivalentTo_should_return_true(filterExpression);
-
-        [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
-        public void Given_DateExpression_equals_left_and_left_equals_right_expression_IsEquivalentTo_should_be_true(DateExpression filterExpression)
-            => Given_FilterExpression_equals_left_and_right_IsEquivalentTo_should_return_true(filterExpression);
-
-        [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
-        public void Given_DateTimeExpression_equals_left_and_left_equals_right_expression_IsEquivalentTo_should_be_true(DateTimeExpression filterExpression)
-            => Given_FilterExpression_equals_left_and_right_IsEquivalentTo_should_return_true(filterExpression);
-
-        [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
-        public void Given_AsteriskExpression_equals_left_and_left_equals_right_expression_IsEquivalentTo_should_be_true()
-            => Given_FilterExpression_equals_left_and_right_IsEquivalentTo_should_return_true(AsteriskExpression.Instance);
-
-        [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
-        public void Given_left_eq_right_eq_OrExpression_Simplify_should_returns_the_inner_OrExpression(OrExpression filterExpression)
-        {
-            // Arrange
-            OrExpression orExpression = new(filterExpression, filterExpression);
-            FilterExpression expected = filterExpression.Simplify();
-            outputHelper.WriteLine($"Expected expression: {expected:d}");
-
-            // Act
-            FilterExpression actual = orExpression.Simplify();
-            outputHelper.WriteLine($"Actual expression: {actual:d}");
-
-            // Assert
-            actual.Should().Be(expected);
-        }
-
-        private static void Given_FilterExpression_equals_left_and_right_IsEquivalentTo_should_return_true(FilterExpression expression)
-        {
-            // Arrange
-            OrExpression filterExpression = new(expression, expression);
-
-            // Act
-            bool actual = filterExpression.IsEquivalentTo(expression);
-
-            // Assert
-            actual.Should().BeTrue();
-        }
-
-        [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
-        public void Given_OrExpression_GetComplexity_should_return_sum_of_left_and_right_complexity(OrExpression orExpression)
-            => (Math.Abs(orExpression.Complexity - (orExpression.Left.Complexity + orExpression.Right.Complexity)) < float.Epsilon).ToProperty();
-
-        [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
-        public void Given_left_eq_right_Simplify_should_return_left(FilterExpression expected)
-        {
-            // Arrange
-            OrExpression orExpression = new(expected, expected);
-
-            // Act
-            FilterExpression actual = orExpression.Simplify();
-
-            outputHelper.WriteLine($"Simplified expression : {actual}");
-
-            bool isEquivalent = actual.IsEquivalentTo(expected);
-
-            // Assert
-            isEquivalent.Should()
-                        .BeTrue("the meaning of the expression should remain the same even after being simplified");
-        }
-
-        // [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
-        // public void Given_multiple_expressions_as_OrExpression_parameters_When_simplify(NonNull<OrExpression> firstGenerator, NonNull<OrExpression> secondGenerator, NonNull<OrExpression> thirdGenerator )
-        // {
-        //     // Arrange
-        //     FilterExpression first = firstGenerator.Item;
-        //     FilterExpression second = secondGenerator.Item;
-        //     FilterExpression third = thirdGenerator.Item;
-        //     BinaryFilterExpression right = new OrExpression(second, third);
-        //     OrExpression orExpression = new(first, right);
-        //     FilterExpression expected = new OneOfExpression(orExpression.Left, right.Left, right.Right).Simplify();
-        //     
-        //     // Act
-        //     FilterExpression actual = orExpression.Simplify();
-        //
-        //     outputHelper.WriteLine($"Simplified expression : {actual}");
-        //
-        //     bool isEquivalent = actual.IsEquivalentTo(expected);
-        //
-        //     // Assert
-        //     isEquivalent.Should()
-        //         .BeTrue("the meaning of the expression should remain the same even after being simplified");
-        // }
-
-        public static TheoryData<OrExpression, FilterExpression> SimplifyCases
-            => new()
-            {
-                {
-                    new OrExpression(new NumericValueExpression("1"), new OrExpression(new NumericValueExpression("1"), new NumericValueExpression("1"))),
-                    new NumericValueExpression("1")
-                },
-                {
-                    new OrExpression(new OrExpression(new StringValueExpression("prop1"), new StringValueExpression("prop1")), new OrExpression(new StringValueExpression("prop1"), new StringValueExpression("prop1"))),
-                    new StringValueExpression("prop1")
-                },
-                {
-                    new OrExpression(new OrExpression(new StringValueExpression("1"), new StringValueExpression("2")),
-                                new OrExpression(new StringValueExpression("3"), new StringValueExpression("4"))),
-                    new OneOfExpression(new StringValueExpression("1"),
-                                        new StringValueExpression("2"),
-                                        new StringValueExpression("3"),
-                                        new StringValueExpression("4")
-                    )
-                }
-            };
-
-        [Theory]
-        [MemberData(nameof(SimplifyCases))]
-        public void Given_OrExpression_Simplify_should_return_expected_result(OrExpression orExpression, FilterExpression expected)
-        {
-            // Act
-            FilterExpression actual = orExpression.Simplify();
-            outputHelper.WriteLine($"Actual expression : {actual:d}");
-            outputHelper.WriteLine($"Expected expression : {expected:d}");
-
-            // Assert
-            actual.Should()
-                  .Be(expected);
-        }
-
-        [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
-        public void Given_two_OrExpression_instances_one_and_two_where_oneU002Eleft_eq_twoU002Eright_and_oneU002Eright_eq_twoU002Eleft_IsEquivalentTo_should_return_true(FilterExpression first, FilterExpression second)
-        {
-            // Arrange
-            OrExpression one = new(first, second);
-            OrExpression two = new(second, first);
-
-            // Act
-            bool actual = one.IsEquivalentTo(two);
-
-            // Assert
-            actual.Should()
-                  .BeTrue();
-        }
-
-        [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
-        public void IsEquivalentTo_should_be_reflexive(OrExpression or)
-            => or.IsEquivalentTo(or).Should()
-                                    .BeTrue();
-
-        [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
-        public Property IsEquivalentTo_should_be_symmetric(OrExpression or)
-        {
-            // Arrange
-            OrExpression other = new(or.Left, or.Right);
-
-            // Act
-            return ( or.IsEquivalentTo(other) == other.IsEquivalentTo(or) ).ToProperty();
-        }
-
-        [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
-        public void IsEquivalent_should_be_transitive(OrExpression or)
-        {
-            // Arrange
-            OrExpression other = new(or.Left, or.Right);
-            OrExpression yetAnother = new(other.Left, other.Right);
-
-            // Act
-            bool actual = or.IsEquivalentTo(other);
-            bool expected = other.IsEquivalentTo(yetAnother);
-
-            // Assert
-            actual.Should()
-                  .Be(expected);
-        }
-
-        [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
-        public void Given_right_and_left_are_OrExpression_Constructor_should_wrap_right_and_left_inside_a_GroupExpression_instance(NonNull<BinaryFilterExpression> left,
-                                                                                                                                   NonNull<BinaryFilterExpression> right)
-        {
-            // Act
-            OrExpression or = new(left.Item, right.Item);
-
-            // Assert
-            or.Right.Should()
-                    .BeOfType<GroupExpression>($"Left instance is a '{nameof(BinaryFilterExpression)}'");
-
-            or.Left.Should()
-                   .BeOfType<GroupExpression>($"Right instance is a '{nameof(BinaryFilterExpression)}'");
-        }
-
-        [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
-        public void Given_left_is_ConstantValueExpression_and_right_is_ConstantValueExpression_Constructor_should_leave_right_and_left_untouched(NonNull<ConstantValueExpression> left,
-                                                                                                                                                 NonNull<ConstantValueExpression> right)
-        {
-            // Act
-            OrExpression or = new(left.Item, right.Item);
-
-            // Assert
-            or.Left.Should()
-                    .NotBeOfType<GroupExpression>($"Right a instance is a '{nameof(ConstantValueExpression)}'");
-
-            or.Right.Should()
-                    .NotBeOfType<GroupExpression>($"Left instance is a '{nameof(ConstantValueExpression)}'");
-        }
-
-        [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
-        public void Equals_should_be_commutative(NonNull<OrExpression> first, FilterExpression rightOperand)
-        {
-            OrExpression leftOperand = first.Item;
-            outputHelper.WriteLine($"Left: {leftOperand:d}");
-            outputHelper.WriteLine($"Right: {rightOperand:d}");
-            leftOperand.Equals(rightOperand).Should().Be(rightOperand.Equals(leftOperand));
-        }
-
-        [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
-        public void Equals_should_be_reflexive(NonNull<OrExpression> expression)
-            => expression.Item.Should().Be(expression.Item);
-
-        [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
-        public void Equals_should_be_symmetric(NonNull<OrExpression> expression, NonNull<FilterExpression> otherExpression)
-            => expression.Item.Equals(otherExpression.Item).Should().Be(otherExpression.Item.Equals(expression.Item));
     }
+
+    [Theory]
+    [MemberData(nameof(ArgumentNullExceptionCases))]
+    public void Ctor_Throws_ArgumentNullException_When_Argument_Is_Null(FilterExpression left, FilterExpression right)
+    {
+        // Act
+        Action action = () => _ = new OrExpression(left, right);
+
+        // Assert
+        action.Should()
+            .ThrowExactly<ArgumentNullException>("The parameter of the constructor cannot be null");
+    }
+
+    public static TheoryData<OrExpression, object, bool, string> EqualsCases
+        => new()
+        {
+            {
+                new OrExpression(new StartsWithExpression("prop1"), new StartsWithExpression("prop2")),
+                new OrExpression(new StartsWithExpression("prop1"), new StartsWithExpression("prop2")),
+                true,
+                "comparing two different instances with same property name"
+            },
+            {
+                new OrExpression(new StartsWithExpression("prop1"), new StartsWithExpression("prop2")),
+                new OrExpression(new StartsWithExpression("prop1"), new StartsWithExpression("prop3")),
+                false,
+                "comparing two different instances with different property name"
+            },
+            {
+                new OrExpression(new StringValueExpression("prop1"), new StringValueExpression("prop1")),
+                new StringValueExpression("prop1"),
+                false,
+                "comparing to a filter expression that is semantically equivalent"
+            }
+        };
+
+    [Theory]
+    [MemberData(nameof(EqualsCases))]
+    public void Equals_should_behave_has_expected(OrExpression current, object other, bool expected, string reason)
+    {
+        outputHelper.WriteLine($"Current instance : {current}");
+        outputHelper.WriteLine($"Other instance : {other}");
+
+        // Act
+        bool actual = current.Equals(other);
+
+        // Assert
+        actual.Should()
+            .Be(expected, reason);
+    }
+
+    public static TheoryData<OrExpression, FilterExpression, bool, string> IsEquivalentToCases
+        => new()
+        {
+            {
+                new OrExpression(new StartsWithExpression("prop1"), new StartsWithExpression("prop2")),
+                new OrExpression(new StartsWithExpression("prop1"), new StartsWithExpression("prop2")),
+                true,
+                $"both {nameof(OrExpression)} instances are identical"
+            },
+            {
+                new OrExpression(new StartsWithExpression("prop1"), new StartsWithExpression("prop2")),
+                new OrExpression(new StartsWithExpression("prop1"), new StartsWithExpression("prop3")),
+                false,
+                $"the two {nameof(OrExpression)} instances contain different data."
+            },
+            {
+                new OrExpression(new StartsWithExpression("prop1"), new StartsWithExpression("prop2")),
+                new OrExpression(new StartsWithExpression("prop2"), new StartsWithExpression("prop1")),
+                true,
+                $"both {nameof(OrExpression)} contains same data but not in the same order"
+            },
+            {
+                new OrExpression(new StringValueExpression("prop1"), new StringValueExpression("prop1")),
+                new StringValueExpression("prop1"),
+                true,
+                "comparing to a filter expression that is semantically equivalent"
+            }
+        };
+
+    [Theory]
+    [MemberData(nameof(IsEquivalentToCases))]
+    public void Implements_IsEquivalentTo_Correctly(OrExpression first, FilterExpression other, bool expected, string reason)
+    {
+        outputHelper.WriteLine($"First instance : {first}");
+        outputHelper.WriteLine($"Second instance : {other}");
+
+        // Act
+        bool actual = first.IsEquivalentTo(other);
+
+        // Assert
+        actual.Should()
+            .Be(expected, reason);
+    }
+
+    [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
+    public void Given_two_OrExpression_instances_that_left_and_right_expressions_are_both_equals_IsEquivalentTo_should_return_true(FilterExpression left, FilterExpression right)
+    {
+        // Arrange
+        OrExpression one = new(left, right);
+        OrExpression two = new(left: right, right: left);
+
+        // Act
+        bool actual = one.IsEquivalentTo(two);
+
+        // Assert
+        actual.Should().BeTrue();
+    }
+
+    [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
+    public void Given_OrExpression_and_OneOfExpression_that_contains_the_same_two_expression_then_calling_IsEquivalentTo_with_that_OneOfExpression_should_return_true(FilterExpression left, FilterExpression right)
+    {
+        // Arrange
+        OneOfExpression oneOf = new(left, right);
+        OrExpression or = new(left, right);
+
+        // Act
+        bool actual = or.IsEquivalentTo(oneOf);
+
+        // Assert
+        actual.Should().BeTrue();
+    }
+
+    [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
+    public void Given_ConstantExpression_equals_left_and_left_equals_right_expression_IsEquivalentTo_should_be_true(ConstantValueExpression filterExpression)
+        => Given_FilterExpression_equals_left_and_right_IsEquivalentTo_should_return_true(filterExpression);
+
+    [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
+    public void Given_DateExpression_equals_left_and_left_equals_right_expression_IsEquivalentTo_should_be_true(DateExpression filterExpression)
+        => Given_FilterExpression_equals_left_and_right_IsEquivalentTo_should_return_true(filterExpression);
+
+    [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
+    public void Given_DateTimeExpression_equals_left_and_left_equals_right_expression_IsEquivalentTo_should_be_true(DateTimeExpression filterExpression)
+        => Given_FilterExpression_equals_left_and_right_IsEquivalentTo_should_return_true(filterExpression);
+
+    [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
+    public void Given_AsteriskExpression_equals_left_and_left_equals_right_expression_IsEquivalentTo_should_be_true()
+        => Given_FilterExpression_equals_left_and_right_IsEquivalentTo_should_return_true(AsteriskExpression.Instance);
+
+    [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
+    public void Given_left_eq_right_eq_OrExpression_Simplify_should_returns_the_inner_OrExpression(OrExpression filterExpression)
+    {
+        // Arrange
+        OrExpression orExpression = new(filterExpression, filterExpression);
+        FilterExpression expected = filterExpression.Simplify();
+        outputHelper.WriteLine($"Expected expression: {expected:d}");
+
+        // Act
+        FilterExpression actual = orExpression.Simplify();
+        outputHelper.WriteLine($"Actual expression: {actual:d}");
+
+        // Assert
+        actual.Should().Be(expected);
+    }
+
+    private static void Given_FilterExpression_equals_left_and_right_IsEquivalentTo_should_return_true(FilterExpression expression)
+    {
+        // Arrange
+        OrExpression filterExpression = new(expression, expression);
+
+        // Act
+        bool actual = filterExpression.IsEquivalentTo(expression);
+
+        // Assert
+        actual.Should().BeTrue();
+    }
+
+    [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
+    public void Given_OrExpression_GetComplexity_should_return_sum_of_left_and_right_complexity(OrExpression orExpression)
+        => (Math.Abs(orExpression.Complexity - (orExpression.Left.Complexity + orExpression.Right.Complexity)) < float.Epsilon).ToProperty();
+
+    [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
+    public void Given_left_eq_right_Simplify_should_return_left(FilterExpression expected)
+    {
+        // Arrange
+        OrExpression orExpression = new(expected, expected);
+
+        // Act
+        FilterExpression actual = orExpression.Simplify();
+
+        outputHelper.WriteLine($"Simplified expression : {actual}");
+
+        bool isEquivalent = actual.IsEquivalentTo(expected);
+
+        // Assert
+        isEquivalent.Should()
+            .BeTrue("the meaning of the expression should remain the same even after being simplified");
+    }
+
+    // [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
+    // public void Given_multiple_expressions_as_OrExpression_parameters_When_simplify(NonNull<OrExpression> firstGenerator, NonNull<OrExpression> secondGenerator, NonNull<OrExpression> thirdGenerator )
+    // {
+    //     // Arrange
+    //     FilterExpression first = firstGenerator.Item;
+    //     FilterExpression second = secondGenerator.Item;
+    //     FilterExpression third = thirdGenerator.Item;
+    //     BinaryFilterExpression right = new OrExpression(second, third);
+    //     OrExpression orExpression = new(first, right);
+    //     FilterExpression expected = new OneOfExpression(orExpression.Left, right.Left, right.Right).Simplify();
+    //     
+    //     // Act
+    //     FilterExpression actual = orExpression.Simplify();
+    //
+    //     outputHelper.WriteLine($"Simplified expression : {actual}");
+    //
+    //     bool isEquivalent = actual.IsEquivalentTo(expected);
+    //
+    //     // Assert
+    //     isEquivalent.Should()
+    //         .BeTrue("the meaning of the expression should remain the same even after being simplified");
+    // }
+
+    public static TheoryData<OrExpression, FilterExpression> SimplifyCases
+        => new()
+        {
+            {
+                new OrExpression(new NumericValueExpression("1"), new OrExpression(new NumericValueExpression("1"), new NumericValueExpression("1"))),
+                new NumericValueExpression("1")
+            },
+            {
+                new OrExpression(new OrExpression(new StringValueExpression("prop1"), new StringValueExpression("prop1")), new OrExpression(new StringValueExpression("prop1"), new StringValueExpression("prop1"))),
+                new StringValueExpression("prop1")
+            },
+            {
+                new OrExpression(new OrExpression(new StringValueExpression("1"), new StringValueExpression("2")),
+                    new OrExpression(new StringValueExpression("3"), new StringValueExpression("4"))),
+                new OneOfExpression(new StringValueExpression("1"),
+                    new StringValueExpression("2"),
+                    new StringValueExpression("3"),
+                    new StringValueExpression("4")
+                )
+            }
+        };
+
+    [Theory]
+    [MemberData(nameof(SimplifyCases))]
+    public void Given_OrExpression_Simplify_should_return_expected_result(OrExpression orExpression, FilterExpression expected)
+    {
+        // Act
+        FilterExpression actual = orExpression.Simplify();
+        outputHelper.WriteLine($"Actual expression : {actual:d}");
+        outputHelper.WriteLine($"Expected expression : {expected:d}");
+
+        // Assert
+        actual.Should()
+            .Be(expected);
+    }
+
+    [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
+    public void Given_two_OrExpression_instances_one_and_two_where_oneU002Eleft_eq_twoU002Eright_and_oneU002Eright_eq_twoU002Eleft_IsEquivalentTo_should_return_true(FilterExpression first, FilterExpression second)
+    {
+        // Arrange
+        OrExpression one = new(first, second);
+        OrExpression two = new(second, first);
+
+        // Act
+        bool actual = one.IsEquivalentTo(two);
+
+        // Assert
+        actual.Should()
+            .BeTrue();
+    }
+
+    [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
+    public void IsEquivalentTo_should_be_reflexive(OrExpression or)
+        => or.IsEquivalentTo(or).Should()
+            .BeTrue();
+
+    [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
+    public Property IsEquivalentTo_should_be_symmetric(OrExpression or)
+    {
+        // Arrange
+        OrExpression other = new(or.Left, or.Right);
+
+        // Act
+        return ( or.IsEquivalentTo(other) == other.IsEquivalentTo(or) ).ToProperty();
+    }
+
+    [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
+    public void IsEquivalent_should_be_transitive(OrExpression or)
+    {
+        // Arrange
+        OrExpression other = new(or.Left, or.Right);
+        OrExpression yetAnother = new(other.Left, other.Right);
+
+        // Act
+        bool actual = or.IsEquivalentTo(other);
+        bool expected = other.IsEquivalentTo(yetAnother);
+
+        // Assert
+        actual.Should()
+            .Be(expected);
+    }
+
+    [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
+    public void Given_right_and_left_are_OrExpression_Constructor_should_wrap_right_and_left_inside_a_GroupExpression_instance(NonNull<BinaryFilterExpression> left,
+        NonNull<BinaryFilterExpression> right)
+    {
+        // Act
+        OrExpression or = new(left.Item, right.Item);
+
+        // Assert
+        or.Right.Should()
+            .BeOfType<GroupExpression>($"Left instance is a '{nameof(BinaryFilterExpression)}'");
+
+        or.Left.Should()
+            .BeOfType<GroupExpression>($"Right instance is a '{nameof(BinaryFilterExpression)}'");
+    }
+
+    [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
+    public void Given_left_is_ConstantValueExpression_and_right_is_ConstantValueExpression_Constructor_should_leave_right_and_left_untouched(NonNull<ConstantValueExpression> left,
+        NonNull<ConstantValueExpression> right)
+    {
+        // Act
+        OrExpression or = new(left.Item, right.Item);
+
+        // Assert
+        or.Left.Should()
+            .NotBeOfType<GroupExpression>($"Right a instance is a '{nameof(ConstantValueExpression)}'");
+
+        or.Right.Should()
+            .NotBeOfType<GroupExpression>($"Left instance is a '{nameof(ConstantValueExpression)}'");
+    }
+
+    [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
+    public void Equals_should_be_commutative(NonNull<OrExpression> first, FilterExpression rightOperand)
+    {
+        OrExpression leftOperand = first.Item;
+        outputHelper.WriteLine($"Left: {leftOperand:d}");
+        outputHelper.WriteLine($"Right: {rightOperand:d}");
+        leftOperand.Equals(rightOperand).Should().Be(rightOperand.Equals(leftOperand));
+    }
+
+    [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
+    public void Equals_should_be_reflexive(NonNull<OrExpression> expression)
+        => expression.Item.Should().Be(expression.Item);
+
+    [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
+    public void Equals_should_be_symmetric(NonNull<OrExpression> expression, NonNull<FilterExpression> otherExpression)
+        => expression.Item.Equals(otherExpression.Item).Should().Be(otherExpression.Item.Equals(expression.Item));
 }

--- a/test/DataFilters.UnitTests/Grammar/Syntax/PropertyNameExpressionTests.cs
+++ b/test/DataFilters.UnitTests/Grammar/Syntax/PropertyNameExpressionTests.cs
@@ -1,80 +1,79 @@
-﻿namespace DataFilters.UnitTests.Grammar.Syntax
+﻿namespace DataFilters.UnitTests.Grammar.Syntax;
+
+using System;
+using DataFilters.Grammar.Syntax;
+using FluentAssertions;
+using Xunit;
+using Xunit.Abstractions;
+
+public class PropertyNameTests(ITestOutputHelper outputHelper)
 {
-    using System;
-    using DataFilters.Grammar.Syntax;
-    using FluentAssertions;
-    using Xunit;
-    using Xunit.Abstractions;
+    [Fact]
+    public void IsFilterExpression() => typeof(PropertyName).Should()
+        .HaveConstructor(new[] { typeof(string) }).And
+        .HaveProperty<string>("Name");
 
-    public class PropertyNameTests(ITestOutputHelper outputHelper)
+    [Fact]
+    public void Ctor_Throws_ArgumentNullException_When_Argument_Is_Null()
     {
-        [Fact]
-        public void IsFilterExpression() => typeof(PropertyName).Should()
-                                                                .HaveConstructor(new[] { typeof(string) }).And
-                                                                .HaveProperty<string>("Name");
+        // Act
+        Action action = () => _ = new PropertyName(null);
 
-        [Fact]
-        public void Ctor_Throws_ArgumentNullException_When_Argument_Is_Null()
+        // Assert
+        action.Should()
+            .ThrowExactly<ArgumentNullException>("The parameter of the constructor cannot be null");
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Ctor_Throws_ArgumentOutyException_When_Argument_Is_Null(string name)
+    {
+        // Act
+        Action action = () => _ = new PropertyName(name);
+
+        // Assert
+        action.Should()
+            .ThrowExactly<ArgumentOutOfRangeException>("The parameter of the constructor cannot be empty or whitespace only");
+    }
+
+    public static TheoryData<PropertyName, object, bool, string> EqualsCases
+        => new()
         {
-            // Act
-            Action action = () => _ = new PropertyName(null);
-
-            // Assert
-            action.Should()
-                .ThrowExactly<ArgumentNullException>("The parameter of the constructor cannot be null");
-        }
-
-        [Theory]
-        [InlineData("")]
-        [InlineData("   ")]
-        public void Ctor_Throws_ArgumentOutyException_When_Argument_Is_Null(string name)
-        {
-            // Act
-            Action action = () => _ = new PropertyName(name);
-
-            // Assert
-            action.Should()
-                .ThrowExactly<ArgumentOutOfRangeException>("The parameter of the constructor cannot be empty or whitespace only");
-        }
-
-        public static TheoryData<PropertyName, object, bool, string> EqualsCases
-            => new()
             {
-                {
-                    new PropertyName("prop1"),
-                    new PropertyName("prop1"),
-                    true,
-                    "comparing two different instances with same property name"
-                },
-                {
-                    new PropertyName("prop1"),
-                    new PropertyName("prop2"),
-                    false,
-                    "comparing two different instances with different property name"
-                }
-            };
-
-        [Theory]
-        [MemberData(nameof(EqualsCases))]
-        public void ImplementsEqualsCorrectly(PropertyName first, object other, bool expected, string reason)
-        {
-            outputHelper.WriteLine($"First instance : {first}");
-            outputHelper.WriteLine($"Second instance : {other}");
-
-            // Act
-            bool actual = first.Equals(other);
-            int actualHashCode = first.GetHashCode();
-
-            // Assert
-            actual.Should()
-                .Be(expected, reason);
-
-            object _ = expected switch
+                new PropertyName("prop1"),
+                new PropertyName("prop1"),
+                true,
+                "comparing two different instances with same property name"
+            },
             {
-                true => actualHashCode.Should()
-                    .Be(other?.GetHashCode(), reason),
-                _ => true
-            };
-        }
+                new PropertyName("prop1"),
+                new PropertyName("prop2"),
+                false,
+                "comparing two different instances with different property name"
+            }
+        };
+
+    [Theory]
+    [MemberData(nameof(EqualsCases))]
+    public void ImplementsEqualsCorrectly(PropertyName first, object other, bool expected, string reason)
+    {
+        outputHelper.WriteLine($"First instance : {first}");
+        outputHelper.WriteLine($"Second instance : {other}");
+
+        // Act
+        bool actual = first.Equals(other);
+        int actualHashCode = first.GetHashCode();
+
+        // Assert
+        actual.Should()
+            .Be(expected, reason);
+
+        object _ = expected switch
+        {
+            true => actualHashCode.Should()
+                .Be(other?.GetHashCode(), reason),
+            _ => true
+        };
     }
 }

--- a/test/DataFilters.UnitTests/Grammar/Syntax/RangeBracketValueTests.cs
+++ b/test/DataFilters.UnitTests/Grammar/Syntax/RangeBracketValueTests.cs
@@ -1,132 +1,131 @@
-﻿namespace DataFilters.UnitTests.Grammar.Syntax
+﻿namespace DataFilters.UnitTests.Grammar.Syntax;
+
+using System;
+using System.Linq;
+using DataFilters.Grammar.Syntax;
+using DataFilters.UnitTests.Helpers;
+using FluentAssertions;
+using FsCheck;
+using FsCheck.Fluent;
+using FsCheck.Xunit;
+using Xunit;
+using Xunit.Abstractions;
+
+public class RangeBracketValueTests(ITestOutputHelper outputHelper)
 {
-    using System;
-    using System.Linq;
-    using DataFilters.Grammar.Syntax;
-    using DataFilters.UnitTests.Helpers;
-    using FluentAssertions;
-    using FsCheck;
-    using FsCheck.Fluent;
-    using FsCheck.Xunit;
-    using Xunit;
-    using Xunit.Abstractions;
-
-    public class RangeBracketValueTests(ITestOutputHelper outputHelper)
+    [Property]
+    public void Value_should_be_set_by_the_parameter_of_the_constructor(char start, char end)
     {
-        [Property]
-        public void Value_should_be_set_by_the_parameter_of_the_constructor(char start, char end)
-        {
-            // Act
-            RangeBracketValue rangeBracketValue = new(start, end);
+        // Act
+        RangeBracketValue rangeBracketValue = new(start, end);
 
-            // Assert
-            rangeBracketValue.Start.Should().Be(start);
-            rangeBracketValue.End.Should().Be(end);
-        }
+        // Assert
+        rangeBracketValue.Start.Should().Be(start);
+        rangeBracketValue.End.Should().Be(end);
+    }
 
-        [Property]
-        public void Given_ConstantBracketExpression_contains_consecutive_characters_When_comparing_to_RangeBracketValue_that_has_head_and_tail_Equals_should_returns_true()
-        {
-            // Arrange
-            IArbMap arbMap = ArbMap.Default;
-            Prop.ForAll(arbMap.ArbFor<char>().Filter(char.IsLetter).Filter(char.IsLower), arbMap.ArbFor<char>().Filter(char.IsLetter).Filter(char.IsLower),
-                               (start, end) =>
-                                {
-                                    char[] chrs = [.. new[] { start, end }.OrderBy(x => x)
-];
-                                    char head = chrs[0];
-                                    char tail = chrs[1];
-                                    ConstantBracketValue constantBracketValue = new(Enumerable.Range(head, tail - head + 1)
-                                                                                              .Select(ascii => ((char)ascii).ToString())
-                                                                                              .Aggregate((accumulate, current) => $"{accumulate}{current}"));
+    [Property]
+    public void Given_ConstantBracketExpression_contains_consecutive_characters_When_comparing_to_RangeBracketValue_that_has_head_and_tail_Equals_should_returns_true()
+    {
+        // Arrange
+        IArbMap arbMap = ArbMap.Default;
+        Prop.ForAll(arbMap.ArbFor<char>().Filter(char.IsLetter).Filter(char.IsLower), arbMap.ArbFor<char>().Filter(char.IsLetter).Filter(char.IsLower),
+                (start, end) =>
+                {
+                    char[] chrs = [.. new[] { start, end }.OrderBy(x => x)
+                    ];
+                    char head = chrs[0];
+                    char tail = chrs[1];
+                    ConstantBracketValue constantBracketValue = new(Enumerable.Range(head, tail - head + 1)
+                        .Select(ascii => ((char)ascii).ToString())
+                        .Aggregate((accumulate, current) => $"{accumulate}{current}"));
 
-                                    // Act
-                                    bool actual = new RangeBracketValue(head, tail).Equals(constantBracketValue);
+                    // Act
+                    bool actual = new RangeBracketValue(head, tail).Equals(constantBracketValue);
 
-                                    return actual.When(start < end);
-                                })
-                .QuickCheckThrowOnFailure(outputHelper);
-        }
+                    return actual.When(start < end);
+                })
+            .QuickCheckThrowOnFailure(outputHelper);
+    }
 
-        [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
-        public void Given_left_and_right_RangeBracketValues_left_ne_right_should_be_same_as_not_left_Equals_right(RangeBracketValue left, RangeBracketValue right)
-        {
-            // Arrange
-            bool expected = !left.Equals(right);
+    [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
+    public void Given_left_and_right_RangeBracketValues_left_ne_right_should_be_same_as_not_left_Equals_right(RangeBracketValue left, RangeBracketValue right)
+    {
+        // Arrange
+        bool expected = !left.Equals(right);
 
-            // Act
-            bool actual = left != right;
+        // Act
+        bool actual = left != right;
 
-            // Assert
-            actual.Should().Be(expected);
-        }
+        // Assert
+        actual.Should().Be(expected);
+    }
 
-        [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
-        public void Given_left_and_right_RangeBracketValues_left_gt_right_should_be_same_as_left_Start_gt_right_Start(RangeBracketValue left, RangeBracketValue right)
-        {
-            // Arrange
-            bool expected = left.Start > right.Start;
+    [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
+    public void Given_left_and_right_RangeBracketValues_left_gt_right_should_be_same_as_left_Start_gt_right_Start(RangeBracketValue left, RangeBracketValue right)
+    {
+        // Arrange
+        bool expected = left.Start > right.Start;
 
-            // Act
-            bool actual = left > right;
+        // Act
+        bool actual = left > right;
 
-            // Assert
-            actual.Should().Be(expected);
-        }
+        // Assert
+        actual.Should().Be(expected);
+    }
 
-        [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
-        public void Given_left_and_right_RangeBracketValues_left_lte_right_should_be_same_as_left_lt_right_or_left_eq_right(RangeBracketValue left, RangeBracketValue right)
-        {
-            // Arrange
-            bool expected = left < right || left == right;
+    [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
+    public void Given_left_and_right_RangeBracketValues_left_lte_right_should_be_same_as_left_lt_right_or_left_eq_right(RangeBracketValue left, RangeBracketValue right)
+    {
+        // Arrange
+        bool expected = left < right || left == right;
 
-            // Act
-            bool actual = left <= right;
+        // Act
+        bool actual = left <= right;
 
-            // Assert
-            actual.Should().Be(expected);
-        }
+        // Assert
+        actual.Should().Be(expected);
+    }
 
-        [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
-        public void Given_left_and_right_RangeBracketValues_left_gte_right_should_be_same_as_left_gt_right_or_left_eq_right(RangeBracketValue left, RangeBracketValue right)
-        {
-            // Arrange
-            bool expected = left > right || left == right;
+    [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
+    public void Given_left_and_right_RangeBracketValues_left_gte_right_should_be_same_as_left_gt_right_or_left_eq_right(RangeBracketValue left, RangeBracketValue right)
+    {
+        // Arrange
+        bool expected = left > right || left == right;
 
-            // Act
-            bool actual = left >= right;
+        // Act
+        bool actual = left >= right;
 
-            // Assert
-            actual.Should().Be(expected);
-        }
+        // Assert
+        actual.Should().Be(expected);
+    }
 
-        [Theory]
-        [InlineData('a', 'a', 2)]
-        public void Complexity_should_behave_as_expected(char start, char end, double expected)
-        {
-            // Arrange
-            RangeBracketValue bracketValue = new(start, end);
+    [Theory]
+    [InlineData('a', 'a', 2)]
+    public void Complexity_should_behave_as_expected(char start, char end, double expected)
+    {
+        // Arrange
+        RangeBracketValue bracketValue = new(start, end);
 
-            // Act
-            double actual = bracketValue.Complexity;
+        // Act
+        double actual = bracketValue.Complexity;
 
-            // Assert
-            actual.Should()
-                  .Be(expected);
-        }
+        // Assert
+        actual.Should()
+            .Be(expected);
+    }
 
-        [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
-        public void Given_RangeBracketValue_Complexity_should_depends_on_start_and_end(RangeBracketValue bracketValue)
-        {
-            // Arrange
-            double expected = 1 + Math.Pow(2, bracketValue.End - bracketValue.Start);
+    [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
+    public void Given_RangeBracketValue_Complexity_should_depends_on_start_and_end(RangeBracketValue bracketValue)
+    {
+        // Arrange
+        double expected = 1 + Math.Pow(2, bracketValue.End - bracketValue.Start);
 
-            // Act
-            double actual = bracketValue.Complexity;
+        // Act
+        double actual = bracketValue.Complexity;
 
-            // Assert
-            actual.Should()
-                  .Be(expected);
-        }
+        // Assert
+        actual.Should()
+            .Be(expected);
     }
 }

--- a/test/DataFilters.UnitTests/Grammar/Syntax/StartsWithExpressionTests.cs
+++ b/test/DataFilters.UnitTests/Grammar/Syntax/StartsWithExpressionTests.cs
@@ -2,195 +2,194 @@
 using System.Text;
 using DataFilters.Grammar.Parsing;
 
-namespace DataFilters.UnitTests.Grammar.Syntax
+namespace DataFilters.UnitTests.Grammar.Syntax;
+
+using System;
+using DataFilters.Grammar.Syntax;
+using DataFilters.UnitTests.Helpers;
+using FluentAssertions;
+using FsCheck;
+using FsCheck.Fluent;
+using FsCheck.Xunit;
+using Xunit;
+using Xunit.Categories;
+
+[UnitTest("StartsWith")]
+public class StartsWithExpressionTests
 {
-    using System;
-    using DataFilters.Grammar.Syntax;
-    using DataFilters.UnitTests.Helpers;
-    using FluentAssertions;
-    using FsCheck;
-    using FsCheck.Fluent;
-    using FsCheck.Xunit;
-    using Xunit;
-    using Xunit.Categories;
+    [Fact]
+    public void IsFilterExpression() => typeof(StartsWithExpression).Should()
+        .NotBeAbstract().And
+        .BeAssignableTo<FilterExpression>().And
+        .Implement<IEquatable<StartsWithExpression>>().And
+        .Implement<IParseableString>().And
+        .NotImplement<IBoundaryExpression>();
 
-    [UnitTest("StartsWith")]
-    public class StartsWithExpressionTests
+    [Fact]
+    public void Given_string_argument_is_null_Constructor_should_throw_ArgumentNullException()
     {
-        [Fact]
-        public void IsFilterExpression() => typeof(StartsWithExpression).Should()
-                                                                        .NotBeAbstract().And
-                                                                        .BeAssignableTo<FilterExpression>().And
-                                                                        .Implement<IEquatable<StartsWithExpression>>().And
-                                                                        .Implement<IParseableString>().And
-                                                                        .NotImplement<IBoundaryExpression>();
+        // Act
+        Action action = () => _ = new StartsWithExpression((string)null);
 
-        [Fact]
-        public void Given_string_argument_is_null_Constructor_should_throw_ArgumentNullException()
+        // Assert
+        action.Should()
+            .ThrowExactly<ArgumentNullException>("The parameter of the constructor cannot be null");
+    }
+
+    [Fact]
+    public void Given_TextExpression_argument_is_null_Constructor_should_throw_ArgumentNullException()
+    {
+        // Act
+        Action action = () => _ = new StartsWithExpression((TextExpression)null);
+
+        // Assert
+        action.Should()
+            .ThrowExactly<ArgumentNullException>("The parameter of the constructor cannot be null");
+    }
+
+    [Fact]
+    public void Ctor_Throws_ArgumentOutOfRangeException_When_Argument_Is_Empty()
+    {
+        // Act
+        Action action = () => _ = new StartsWithExpression(string.Empty);
+
+        // Assert
+        action.Should()
+            .ThrowExactly<ArgumentOutOfRangeException>("The parameter of the constructor cannot be empty");
+    }
+
+    [Fact]
+    public void Ctor_DoesNot_Throws_ArgumentOutOfRangeException_When_Argument_Is_WhitespaceOnly()
+    {
+        // Act
+        Action action = () => _ = new StartsWithExpression("  ");
+
+        // Assert
+        action.Should()
+            .NotThrow<ArgumentOutOfRangeException>("The parameter of the constructor can be whitespace only");
+        action.Should()
+            .NotThrow("The parameter of the constructor can be whitespace only");
+    }
+
+    [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
+    public void Equals_should_be_commutative(NonNull<StartsWithExpression> first, FilterExpression second)
+        => first.Item.Equals(second).Should().Be(second.Equals(first.Item));
+
+    [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
+    public void Equals_should_be_reflexive(NonNull<StartsWithExpression> expression)
+        => expression.Item.Should().Be(expression.Item);
+
+    [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
+    public void Equals_should_be_symmetric(NonNull<StartsWithExpression> expression, NonNull<FilterExpression> otherExpression)
+        => (expression.Item.Equals(otherExpression.Item) == otherExpression.Item.Equals(expression.Item)).ToProperty();
+
+    [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
+    public void Given_TextExpression_as_input_EscapedParseableString_should_be_correct(NonNull<TextExpression> text)
+    {
+        // Arrange
+        StartsWithExpression expression = new(text.Item);
+        string expected = $"{text.Item.EscapedParseableString}*";
+
+        // Act
+        string actual = expression.EscapedParseableString;
+
+        // Assert
+        actual.Should()
+            .Be(expected);
+    }
+
+    [Property]
+    public void Given_non_whitespace_string_as_input_as_input_EscapedParseableString_should_be_correct(NonWhiteSpaceString textGenerator)
+    {
+        // Arrange
+        string text = textGenerator.Item;
+        StartsWithExpression expression = new(text);
+        StringValueExpression stringValueExpression = new(text);
+        StringBuilder sb = new (text.Length * 2);
+        foreach (char chr in text)
         {
-            // Act
-            Action action = () => _ = new StartsWithExpression((string)null);
-
-            // Assert
-            action.Should()
-                .ThrowExactly<ArgumentNullException>("The parameter of the constructor cannot be null");
-        }
-
-        [Fact]
-        public void Given_TextExpression_argument_is_null_Constructor_should_throw_ArgumentNullException()
-        {
-            // Act
-            Action action = () => _ = new StartsWithExpression((TextExpression)null);
-
-            // Assert
-            action.Should()
-                .ThrowExactly<ArgumentNullException>("The parameter of the constructor cannot be null");
-        }
-
-        [Fact]
-        public void Ctor_Throws_ArgumentOutOfRangeException_When_Argument_Is_Empty()
-        {
-            // Act
-            Action action = () => _ = new StartsWithExpression(string.Empty);
-
-            // Assert
-            action.Should()
-                .ThrowExactly<ArgumentOutOfRangeException>("The parameter of the constructor cannot be empty");
-        }
-
-        [Fact]
-        public void Ctor_DoesNot_Throws_ArgumentOutOfRangeException_When_Argument_Is_WhitespaceOnly()
-        {
-            // Act
-            Action action = () => _ = new StartsWithExpression("  ");
-
-            // Assert
-            action.Should()
-                .NotThrow<ArgumentOutOfRangeException>("The parameter of the constructor can be whitespace only");
-            action.Should()
-                .NotThrow("The parameter of the constructor can be whitespace only");
-        }
-
-        [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
-        public void Equals_should_be_commutative(NonNull<StartsWithExpression> first, FilterExpression second)
-            => first.Item.Equals(second).Should().Be(second.Equals(first.Item));
-
-        [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
-        public void Equals_should_be_reflexive(NonNull<StartsWithExpression> expression)
-            => expression.Item.Should().Be(expression.Item);
-
-        [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
-        public void Equals_should_be_symmetric(NonNull<StartsWithExpression> expression, NonNull<FilterExpression> otherExpression)
-            => (expression.Item.Equals(otherExpression.Item) == otherExpression.Item.Equals(expression.Item)).ToProperty();
-
-        [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
-        public void Given_TextExpression_as_input_EscapedParseableString_should_be_correct(NonNull<TextExpression> text)
-        {
-            // Arrange
-            StartsWithExpression expression = new(text.Item);
-            string expected = $"{text.Item.EscapedParseableString}*";
-
-            // Act
-            string actual = expression.EscapedParseableString;
-
-            // Assert
-            actual.Should()
-                  .Be(expected);
-        }
-
-        [Property]
-        public void Given_non_whitespace_string_as_input_as_input_EscapedParseableString_should_be_correct(NonWhiteSpaceString textGenerator)
-        {
-            // Arrange
-            string text = textGenerator.Item;
-            StartsWithExpression expression = new(text);
-            StringValueExpression stringValueExpression = new(text);
-            StringBuilder sb = new (text.Length * 2);
-            foreach (char chr in text)
+            if (FilterTokenizer.SpecialCharacters.Contains(chr))
             {
-                if (FilterTokenizer.SpecialCharacters.Contains(chr))
-                {
-                    sb = sb.Append(FilterTokenizer.EscapedCharacter);
-                }
-                sb = sb.Append(chr);
+                sb = sb.Append(FilterTokenizer.EscapedCharacter);
             }
-            string expected = $"{stringValueExpression.EscapedParseableString}*";
-
-            // Act
-            string actual = expression.EscapedParseableString;
-
-            // Assert
-            actual.Should()
-                  .Be(expected);
+            sb = sb.Append(chr);
         }
+        string expected = $"{stringValueExpression.EscapedParseableString}*";
 
-        [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
-        public void Given_StartsWithExpression_When_right_operand_is_EndsWithExpression_Plus_operator_should_return_expected_AndExpression(NonNull<StartsWithExpression> startsWithGen, NonNull<EndsWithExpression> endsWithGen)
-        {
-            // Arrange
-            StartsWithExpression startsWith = startsWithGen.Item;
-            EndsWithExpression endsWith = endsWithGen.Item;
+        // Act
+        string actual = expression.EscapedParseableString;
 
-            AndExpression expected = new(startsWith, endsWith);
+        // Assert
+        actual.Should()
+            .Be(expected);
+    }
 
-            // Act
-            AndExpression actual = startsWith + endsWith;
+    [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
+    public void Given_StartsWithExpression_When_right_operand_is_EndsWithExpression_Plus_operator_should_return_expected_AndExpression(NonNull<StartsWithExpression> startsWithGen, NonNull<EndsWithExpression> endsWithGen)
+    {
+        // Arrange
+        StartsWithExpression startsWith = startsWithGen.Item;
+        EndsWithExpression endsWith = endsWithGen.Item;
 
-            // Assert
-            actual.IsEquivalentTo(expected).Should().BeTrue();
-        }
+        AndExpression expected = new(startsWith, endsWith);
 
-        [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
-        public void Given_StartsWithExpression_When_right_operand_is_StartsWithExpression_Plus_operator_should_return_OneOfExpression(NonNull<StartsWithExpression> leftOperandGen, NonNull<StartsWithExpression> rightOperandGen)
-        {
-            // Arrange
-            StartsWithExpression leftStartsWith = leftOperandGen.Item;
-            StartsWithExpression rightStartsWith = rightOperandGen.Item;
+        // Act
+        AndExpression actual = startsWith + endsWith;
 
-            // bat*man*
-            OneOfExpression expected = new(new StringValueExpression(leftStartsWith.Value + rightStartsWith.Value),
-                                           new AndExpression(leftStartsWith, new ContainsExpression(rightStartsWith.Value)),
-                                           new StartsWithExpression(leftStartsWith.Value + rightStartsWith.Value));
+        // Assert
+        actual.IsEquivalentTo(expected).Should().BeTrue();
+    }
 
-            // Act
-            OneOfExpression actual = leftStartsWith + rightStartsWith;
+    [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
+    public void Given_StartsWithExpression_When_right_operand_is_StartsWithExpression_Plus_operator_should_return_OneOfExpression(NonNull<StartsWithExpression> leftOperandGen, NonNull<StartsWithExpression> rightOperandGen)
+    {
+        // Arrange
+        StartsWithExpression leftStartsWith = leftOperandGen.Item;
+        StartsWithExpression rightStartsWith = rightOperandGen.Item;
 
-            // Assert
-            actual.IsEquivalentTo(expected).Should().BeTrue();
-        }
+        // bat*man*
+        OneOfExpression expected = new(new StringValueExpression(leftStartsWith.Value + rightStartsWith.Value),
+            new AndExpression(leftStartsWith, new ContainsExpression(rightStartsWith.Value)),
+            new StartsWithExpression(leftStartsWith.Value + rightStartsWith.Value));
 
-        [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
-        public void Given_StartsWithExpression_When_right_operand_is_Contains_Plus_operator_should_return_OneOfExpression(NonNull<StartsWithExpression> leftOperandGen, NonNull<ContainsExpression> rightOperandGen)
-        {
-            // Arrange
-            StartsWithExpression leftStartsWith = leftOperandGen.Item;
-            ContainsExpression rightStartsWith = rightOperandGen.Item;
+        // Act
+        OneOfExpression actual = leftStartsWith + rightStartsWith;
 
-            OneOfExpression expected = new(new StringValueExpression(leftStartsWith.Value + rightStartsWith.Value),
-                                           new AndExpression(leftStartsWith, new ContainsExpression(rightStartsWith.Value)),
-                                           new StartsWithExpression(leftStartsWith.Value + rightStartsWith.Value));
+        // Assert
+        actual.IsEquivalentTo(expected).Should().BeTrue();
+    }
 
-            // Act
-            OneOfExpression actual = leftStartsWith + rightStartsWith;
+    [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
+    public void Given_StartsWithExpression_When_right_operand_is_Contains_Plus_operator_should_return_OneOfExpression(NonNull<StartsWithExpression> leftOperandGen, NonNull<ContainsExpression> rightOperandGen)
+    {
+        // Arrange
+        StartsWithExpression leftStartsWith = leftOperandGen.Item;
+        ContainsExpression rightStartsWith = rightOperandGen.Item;
 
-            // Assert
-            actual.IsEquivalentTo(expected).Should().BeTrue();
-        }
+        OneOfExpression expected = new(new StringValueExpression(leftStartsWith.Value + rightStartsWith.Value),
+            new AndExpression(leftStartsWith, new ContainsExpression(rightStartsWith.Value)),
+            new StartsWithExpression(leftStartsWith.Value + rightStartsWith.Value));
 
-        [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
-        public void Given_StartsWithExpression_When_right_operand_is_StringValueExpression_Plus_operator_should_return_expected_AndExpression(NonNull<StartsWithExpression> leftOperandGen, NonNull<StringValueExpression> rightOperandGen)
-        {
-            // Arrange
-            StartsWithExpression leftStartsWith = leftOperandGen.Item;
-            StringValueExpression rightStartsWith = rightOperandGen.Item;
+        // Act
+        OneOfExpression actual = leftStartsWith + rightStartsWith;
 
-            AndExpression expected = leftStartsWith + new EndsWithExpression(rightStartsWith.Value);
+        // Assert
+        actual.IsEquivalentTo(expected).Should().BeTrue();
+    }
 
-            // Act
-            AndExpression actual = leftStartsWith + rightStartsWith;
+    [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
+    public void Given_StartsWithExpression_When_right_operand_is_StringValueExpression_Plus_operator_should_return_expected_AndExpression(NonNull<StartsWithExpression> leftOperandGen, NonNull<StringValueExpression> rightOperandGen)
+    {
+        // Arrange
+        StartsWithExpression leftStartsWith = leftOperandGen.Item;
+        StringValueExpression rightStartsWith = rightOperandGen.Item;
 
-            // Assert
-            actual.IsEquivalentTo(expected).Should().BeTrue();
-        }
+        AndExpression expected = leftStartsWith + new EndsWithExpression(rightStartsWith.Value);
+
+        // Act
+        AndExpression actual = leftStartsWith + rightStartsWith;
+
+        // Assert
+        actual.IsEquivalentTo(expected).Should().BeTrue();
     }
 }

--- a/test/DataFilters.UnitTests/Grammar/Syntax/StringValueExpressionTests.cs
+++ b/test/DataFilters.UnitTests/Grammar/Syntax/StringValueExpressionTests.cs
@@ -2,189 +2,188 @@
 using System.Text;
 using DataFilters.Grammar.Parsing;
 
-namespace DataFilters.UnitTests.Grammar.Syntax
+namespace DataFilters.UnitTests.Grammar.Syntax;
+
+using System;
+using DataFilters.Grammar.Syntax;
+using DataFilters.UnitTests.Helpers;
+using FluentAssertions;
+using FsCheck;
+using FsCheck.Fluent;
+using FsCheck.Xunit;
+using Xunit;
+using Xunit.Abstractions;
+using Xunit.Categories;
+
+[UnitTest]
+public class StringValueExpressionTests(ITestOutputHelper outputHelper)
 {
-    using System;
-    using DataFilters.Grammar.Syntax;
-    using DataFilters.UnitTests.Helpers;
-    using FluentAssertions;
-    using FsCheck;
-    using FsCheck.Fluent;
-    using FsCheck.Xunit;
-    using Xunit;
-    using Xunit.Abstractions;
-    using Xunit.Categories;
+    [Fact]
+    public void IsFilterExpression() => typeof(StringValueExpression).Should()
+        .BeAssignableTo<FilterExpression>().And
+        .Implement<IEquatable<StringValueExpression>>();
 
-    [UnitTest]
-    public class StringValueExpressionTests(ITestOutputHelper outputHelper)
+    [Fact]
+    public void Ctor_Throws_ArgumentNullException_When_Argument_Is_Null()
     {
-        [Fact]
-        public void IsFilterExpression() => typeof(StringValueExpression).Should()
-                                                                           .BeAssignableTo<FilterExpression>().And
-                                                                           .Implement<IEquatable<StringValueExpression>>();
+        // Act
+        Action action = () => _ = new StringValueExpression(null);
 
-        [Fact]
-        public void Ctor_Throws_ArgumentNullException_When_Argument_Is_Null()
+        // Assert
+        action.Should()
+            .ThrowExactly<ArgumentNullException>($"The parameter of  {nameof(StringValueExpression)}'s constructor cannot be null");
+    }
+
+    [Fact]
+    public void Ctor_Throws_ArgumentOutOfRangeException_When_Argument_Is_Empty()
+    {
+        // Act
+        Action action = () => _ = new StringValueExpression(string.Empty);
+
+        // Assert
+        action.Should()
+            .ThrowExactly<ArgumentOutOfRangeException>($"The parameter of  {nameof(StringValueExpression)}'s constructor cannot be empty");
+    }
+
+    [Fact]
+    public void Given_parameter_is_whitespace_Ctor_should_not_throw()
+    {
+        // Act
+        Action action = () => _ = new StringValueExpression(" ");
+
+        // Assert
+        action.Should()
+            .NotThrow($"The parameter of {nameof(StringValueExpression)}'s constructor can be whitespace");
+    }
+
+    [Property]
+    public void Given_two_instances_that_hold_values_that_are_equals_Equals_should_return_true(NonEmptyString value)
+    {
+        // Arrange
+        StringValueExpression first = new(value.Item);
+        StringValueExpression other = new(value.Item);
+
+        // Act
+        bool actual = first.Equals(other);
+
+        // Assert
+        actual.Should()
+            .BeTrue();
+    }
+
+    public static TheoryData<StringValueExpression, object, bool> EqualsCases
+        => new()
         {
-            // Act
-            Action action = () => _ = new StringValueExpression(null);
-
-            // Assert
-            action.Should()
-                .ThrowExactly<ArgumentNullException>($"The parameter of  {nameof(StringValueExpression)}'s constructor cannot be null");
-        }
-
-        [Fact]
-        public void Ctor_Throws_ArgumentOutOfRangeException_When_Argument_Is_Empty()
-        {
-            // Act
-            Action action = () => _ = new StringValueExpression(string.Empty);
-
-            // Assert
-            action.Should()
-                .ThrowExactly<ArgumentOutOfRangeException>($"The parameter of  {nameof(StringValueExpression)}'s constructor cannot be empty");
-        }
-
-        [Fact]
-        public void Given_parameter_is_whitespace_Ctor_should_not_throw()
-        {
-            // Act
-            Action action = () => _ = new StringValueExpression(" ");
-
-            // Assert
-            action.Should()
-                .NotThrow($"The parameter of {nameof(StringValueExpression)}'s constructor can be whitespace");
-        }
-
-        [Property]
-        public void Given_two_instances_that_hold_values_that_are_equals_Equals_should_return_true(NonEmptyString value)
-        {
-            // Arrange
-            StringValueExpression first = new(value.Item);
-            StringValueExpression other = new(value.Item);
-
-            // Act
-            bool actual = first.Equals(other);
-
-            // Assert
-            actual.Should()
-                  .BeTrue();
-        }
-
-        public static TheoryData<StringValueExpression, object, bool> EqualsCases
-            => new()
             {
-                {
-                    new StringValueExpression("True"),
-                    new OrExpression(new StringValueExpression("True"), new StringValueExpression("True")),
-                    false
-                },
-                {
-                    new StringValueExpression("0"),
-                    new NumericValueExpression("0"),
-                    true
-                },
-                {
-                    new StringValueExpression("True"),
-                    new StringValueExpression("True"),
-                    true
-                }
-            };
-
-        [Theory]
-        [MemberData(nameof(EqualsCases))]
-        public void Equals_should_behave_as_expected(StringValueExpression stringValue, object obj, bool expected)
-        {
-            // Act
-            bool actual = stringValue.Equals(obj);
-
-            // Assert
-            actual.Should()
-                  .Be(expected);
-        }
-
-        [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
-        public void Equals_should_be_commutative(StringValueExpression first, FilterExpression second)
-            => (first.Equals(second) == second.Equals(first)).ToProperty().QuickCheckThrowOnFailure();
-
-        [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
-        public void Equals_should_be_reflexive(NonNull<StringValueExpression> expression)
-            => expression.Item.Equals(expression.Item).ToProperty();
-
-        [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
-        public void Equals_should_be_symetric(NonNull<StringValueExpression> expression, NonNull<FilterExpression> otherExpression)
-            => (expression.Item.Equals(otherExpression.Item) == otherExpression.Item.Equals(expression.Item)).ToProperty();
-
-        [Property]
-        public void Given_two_StringValueExpresssions_Equals_should_depends_on_string_input_only(NonWhiteSpaceString input)
-        {
-            // Arrange
-            StringValueExpression first = new(input.Get);
-            StringValueExpression second = new(input.Get);
-
-            // Act
-            (first.Equals(second) == Equals(first.Value, second.Value))
-                .ToProperty()
-                .QuickCheckThrowOnFailure(outputHelper);
-        }
-
-        [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
-        public void Given_StringValueExpression_GetComplexity_should_return_1(StringValueExpression constant) => (Math.Abs(constant.Complexity - 1) < float.Epsilon).ToProperty();
-
-        [Property]
-        public void Given_StringValueExpression_and_TextExpression_are_based_on_same_value_IsEquivalentTo_should_be_true(NonWhiteSpaceString input)
-        {
-            // Arrange
-            StringValueExpression stringValue = new(input.Item);
-            TextExpression textExpression = new(input.Item);
-
-            // Act
-            bool isEquivalent = stringValue.IsEquivalentTo(textExpression);
-
-            // Assert
-            isEquivalent.Should()
-                        .BeTrue($"{nameof(TextExpression)} was created from the same value");
-        }
-
-        [Property]
-        public void Given_StringValueExpression_when_GroupExpression_holds_an_expression_that_is_equals_to_that_StringValueExpression_IsEquivalentTo_should_return_true(NonWhiteSpaceString input)
-        {
-            // Arrange
-            StringValueExpression stringValue = new(input.Item);
-            GroupExpression group = new(new StringValueExpression(input.Item));
-
-            // Act
-            bool actual = stringValue.IsEquivalentTo(group);
-
-            // Assert
-            actual.Should()
-                  .BeTrue();
-        }
-
-        [Property]
-        public void Given_input_as_string_Then_EscapedParseableString_should_be_correct(NonWhiteSpaceString inputGenerator)
-        {
-            // Arrange
-            string input = inputGenerator.Item;
-            StringValueExpression expression = new(input);
-            StringBuilder sbExpected = new (input.Length * 2);
-
-            foreach (char c in input)
+                new StringValueExpression("True"),
+                new OrExpression(new StringValueExpression("True"), new StringValueExpression("True")),
+                false
+            },
             {
-                if (FilterTokenizer.SpecialCharacters.Contains(c))
-                {
-                    sbExpected.Append('\\');
-                }
-                sbExpected.Append(c);
+                new StringValueExpression("0"),
+                new NumericValueExpression("0"),
+                true
+            },
+            {
+                new StringValueExpression("True"),
+                new StringValueExpression("True"),
+                true
             }
+        };
 
-            string expected = sbExpected.ToString();
+    [Theory]
+    [MemberData(nameof(EqualsCases))]
+    public void Equals_should_behave_as_expected(StringValueExpression stringValue, object obj, bool expected)
+    {
+        // Act
+        bool actual = stringValue.Equals(obj);
 
-            // Act
-            string actual = expression.EscapedParseableString;
+        // Assert
+        actual.Should()
+            .Be(expected);
+    }
 
-            // Assert
-            actual.Should().Be(expected);
+    [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
+    public void Equals_should_be_commutative(StringValueExpression first, FilterExpression second)
+        => (first.Equals(second) == second.Equals(first)).ToProperty().QuickCheckThrowOnFailure();
+
+    [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
+    public void Equals_should_be_reflexive(NonNull<StringValueExpression> expression)
+        => expression.Item.Equals(expression.Item).ToProperty();
+
+    [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
+    public void Equals_should_be_symetric(NonNull<StringValueExpression> expression, NonNull<FilterExpression> otherExpression)
+        => (expression.Item.Equals(otherExpression.Item) == otherExpression.Item.Equals(expression.Item)).ToProperty();
+
+    [Property]
+    public void Given_two_StringValueExpresssions_Equals_should_depends_on_string_input_only(NonWhiteSpaceString input)
+    {
+        // Arrange
+        StringValueExpression first = new(input.Get);
+        StringValueExpression second = new(input.Get);
+
+        // Act
+        (first.Equals(second) == Equals(first.Value, second.Value))
+            .ToProperty()
+            .QuickCheckThrowOnFailure(outputHelper);
+    }
+
+    [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
+    public void Given_StringValueExpression_GetComplexity_should_return_1(StringValueExpression constant) => (Math.Abs(constant.Complexity - 1) < float.Epsilon).ToProperty();
+
+    [Property]
+    public void Given_StringValueExpression_and_TextExpression_are_based_on_same_value_IsEquivalentTo_should_be_true(NonWhiteSpaceString input)
+    {
+        // Arrange
+        StringValueExpression stringValue = new(input.Item);
+        TextExpression textExpression = new(input.Item);
+
+        // Act
+        bool isEquivalent = stringValue.IsEquivalentTo(textExpression);
+
+        // Assert
+        isEquivalent.Should()
+            .BeTrue($"{nameof(TextExpression)} was created from the same value");
+    }
+
+    [Property]
+    public void Given_StringValueExpression_when_GroupExpression_holds_an_expression_that_is_equals_to_that_StringValueExpression_IsEquivalentTo_should_return_true(NonWhiteSpaceString input)
+    {
+        // Arrange
+        StringValueExpression stringValue = new(input.Item);
+        GroupExpression group = new(new StringValueExpression(input.Item));
+
+        // Act
+        bool actual = stringValue.IsEquivalentTo(group);
+
+        // Assert
+        actual.Should()
+            .BeTrue();
+    }
+
+    [Property]
+    public void Given_input_as_string_Then_EscapedParseableString_should_be_correct(NonWhiteSpaceString inputGenerator)
+    {
+        // Arrange
+        string input = inputGenerator.Item;
+        StringValueExpression expression = new(input);
+        StringBuilder sbExpected = new (input.Length * 2);
+
+        foreach (char c in input)
+        {
+            if (FilterTokenizer.SpecialCharacters.Contains(c))
+            {
+                sbExpected.Append('\\');
+            }
+            sbExpected.Append(c);
         }
+
+        string expected = sbExpected.ToString();
+
+        // Act
+        string actual = expression.EscapedParseableString;
+
+        // Assert
+        actual.Should().Be(expected);
     }
 }

--- a/test/DataFilters.UnitTests/Grammar/Syntax/TextExpressionTests.cs
+++ b/test/DataFilters.UnitTests/Grammar/Syntax/TextExpressionTests.cs
@@ -11,90 +11,89 @@ using Xunit;
 using Xunit.Abstractions;
 using Xunit.Categories;
 
-namespace DataFilters.UnitTests.Grammar.Syntax
+namespace DataFilters.UnitTests.Grammar.Syntax;
+
+[UnitTest]
+public class TextExpressionTests(ITestOutputHelper outputHelper)
 {
-    [UnitTest]
-    public class TextExpressionTests(ITestOutputHelper outputHelper)
+    [Theory]
+    [InlineData(@"<\\Y!A", @"""<\\\\Y!A""")]
+    [InlineData("1.\"Foo!", @"""1.\""Foo!""")]
+    public void Given_input_EscapedParseableString_should_be_correct(string input, string expected)
     {
-        [Theory]
-        [InlineData(@"<\\Y!A", @"""<\\\\Y!A""")]
-        [InlineData("1.\"Foo!", @"""1.\""Foo!""")]
-        public void Given_input_EscapedParseableString_should_be_correct(string input, string expected)
-        {
-            // Arrange
-            TextExpression text = new(input);
+        // Arrange
+        TextExpression text = new(input);
 
-            // Act
-            string actual = text.EscapedParseableString;
+        // Act
+        string actual = text.EscapedParseableString;
 
-            // Assert
-            actual.Should()
-                  .Be(expected);
-        }
+        // Assert
+        actual.Should()
+            .Be(expected);
+    }
 
-        [Property]
-        public void Equals_to_null_always_returns_false(NonEmptyString input)
-        {
-            // Arrange
-            TextExpression textExpression = new(input.Item);
+    [Property]
+    public void Equals_to_null_always_returns_false(NonEmptyString input)
+    {
+        // Arrange
+        TextExpression textExpression = new(input.Item);
 
-            // Act
-            bool actual = textExpression.Equals(null);
+        // Act
+        bool actual = textExpression.Equals(null);
 
-            // Assert
-            actual.Should()
-                  .BeFalse();
-        }
+        // Assert
+        actual.Should()
+            .BeFalse();
+    }
 
-        [Property]
-        public void Given_two_instances_with_same_input_Equals_should_return_true(NonWhiteSpaceString input)
-        {
-            // Arrange
-            outputHelper.WriteLine($"input : '{input.Item}'");
-            TextExpression first = new(input.Item);
-            TextExpression other = new(input.Item);
+    [Property]
+    public void Given_two_instances_with_same_input_Equals_should_return_true(NonWhiteSpaceString input)
+    {
+        // Arrange
+        outputHelper.WriteLine($"input : '{input.Item}'");
+        TextExpression first = new(input.Item);
+        TextExpression other = new(input.Item);
 
-            // Act
-            bool actual = first.Equals(other);
+        // Act
+        bool actual = first.Equals(other);
 
-            // Assert
-            actual.Should()
-                  .BeTrue();
-        }
+        // Assert
+        actual.Should()
+            .BeTrue();
+    }
 
-        [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
-        public void Equals_should_be_commutative(NonNull<TextExpression> first, FilterExpression second)
-            => (first.Item.Equals(second) == second.Equals(first.Item)).ToProperty()
-                .QuickCheckThrowOnFailure(outputHelper);
+    [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
+    public void Equals_should_be_commutative(NonNull<TextExpression> first, FilterExpression second)
+        => (first.Item.Equals(second) == second.Equals(first.Item)).ToProperty()
+            .QuickCheckThrowOnFailure(outputHelper);
 
-        [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
-        public void Equals_should_be_reflexive(NonNull<TextExpression> expression)
-            => expression.Item.Equals(expression.Item).ToProperty()
-                .QuickCheckThrowOnFailure(outputHelper);
+    [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
+    public void Equals_should_be_reflexive(NonNull<TextExpression> expression)
+        => expression.Item.Equals(expression.Item).ToProperty()
+            .QuickCheckThrowOnFailure(outputHelper);
 
-        [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
-        public void Equals_should_be_symmetric(NonNull<TextExpression> expression, NonNull<FilterExpression> otherExpression)
-            => (expression.Item.Equals(otherExpression.Item) == otherExpression.Item.Equals(expression.Item)).ToProperty();
+    [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
+    public void Equals_should_be_symmetric(NonNull<TextExpression> expression, NonNull<FilterExpression> otherExpression)
+        => (expression.Item.Equals(otherExpression.Item) == otherExpression.Item.Equals(expression.Item)).ToProperty();
 
-        [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
-        public void Given_non_null_TextExpression_EscapedParseableString_should_be_correct(NonWhiteSpaceString textGenerator)
-        {
-            // Arrange
-            string value = textGenerator.Item;
-            string expected = $@"""{value.Replace(@"\", @"\\").Replace(@"""", @"\""")}""";
+    [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
+    public void Given_non_null_TextExpression_EscapedParseableString_should_be_correct(NonWhiteSpaceString textGenerator)
+    {
+        // Arrange
+        string value = textGenerator.Item;
+        string expected = $@"""{value.Replace(@"\", @"\\").Replace(@"""", @"\""")}""";
 
-            TextExpression textExpression = new(value);
+        TextExpression textExpression = new(value);
 
-            // Act
-            string actual = textExpression.EscapedParseableString;
+        // Act
+        string actual = textExpression.EscapedParseableString;
 
-            outputHelper.WriteLine($"expected: '{expected}', actual: '{actual}'");
+        outputHelper.WriteLine($"expected: '{expected}', actual: '{actual}'");
 
-            // Assert
-            actual.Should()
-                  .StartWith(@"""").And
-                  .EndWith(@"""").And
-                  .Be(expected);
-        }
+        // Assert
+        actual.Should()
+            .StartWith(@"""").And
+            .EndWith(@"""").And
+            .Be(expected);
     }
 }

--- a/test/DataFilters.UnitTests/Grammar/Syntax/TimeExpressionTests.cs
+++ b/test/DataFilters.UnitTests/Grammar/Syntax/TimeExpressionTests.cs
@@ -1,144 +1,143 @@
-﻿namespace DataFilters.UnitTests.Grammar.Syntax
+﻿namespace DataFilters.UnitTests.Grammar.Syntax;
+
+using System;
+using DataFilters.Grammar.Syntax;
+using DataFilters.UnitTests.Helpers;
+using FluentAssertions;
+using FsCheck;
+using FsCheck.Fluent;
+using FsCheck.Xunit;
+using Xunit;
+using Xunit.Abstractions;
+using Xunit.Categories;
+
+[UnitTest]
+public class TimeExpressionTests(ITestOutputHelper outputHelper)
 {
-    using System;
-    using DataFilters.Grammar.Syntax;
-    using DataFilters.UnitTests.Helpers;
-    using FluentAssertions;
-    using FsCheck;
-    using FsCheck.Fluent;
-    using FsCheck.Xunit;
-    using Xunit;
-    using Xunit.Abstractions;
-    using Xunit.Categories;
+    [Fact]
+    public void IsFilterExpression() => typeof(TimeExpression).Should()
+        .BeAssignableTo<FilterExpression>().And
+        .Implement<IEquatable<TimeExpression>>().And
+        .HaveConstructor(new[] { typeof(int), typeof(int), typeof(int), typeof(int) }).And
+        .HaveProperty<int>("Hours").And
+        .HaveProperty<int>("Minutes").And
+        .HaveProperty<int>("Seconds").And
+        .HaveProperty<int>("Milliseconds");
 
-    [UnitTest]
-    public class TimeExpressionTests(ITestOutputHelper outputHelper)
+    [Property]
+    public void Ctor_should_build_valid_instance(IntWithMinMax hours,
+        IntWithMinMax minutes,
+        IntWithMinMax seconds,
+        IntWithMinMax milliseconds)
     {
-        [Fact]
-        public void IsFilterExpression() => typeof(TimeExpression).Should()
-                                            .BeAssignableTo<FilterExpression>().And
-                                            .Implement<IEquatable<TimeExpression>>().And
-                                            .HaveConstructor(new[] { typeof(int), typeof(int), typeof(int), typeof(int) }).And
-                                            .HaveProperty<int>("Hours").And
-                                            .HaveProperty<int>("Minutes").And
-                                            .HaveProperty<int>("Seconds").And
-                                            .HaveProperty<int>("Milliseconds");
+        outputHelper.WriteLine($"hours : {hours.Item}");
+        outputHelper.WriteLine($"minutes : {minutes.Item}");
+        outputHelper.WriteLine($"seconds : {seconds.Item}");
+        outputHelper.WriteLine($"milliseconds : {milliseconds.Item}");
 
-        [Property]
-        public void Ctor_should_build_valid_instance(IntWithMinMax hours,
-                                                     IntWithMinMax minutes,
-                                                     IntWithMinMax seconds,
-                                                     IntWithMinMax milliseconds)
-        {
-            outputHelper.WriteLine($"hours : {hours.Item}");
-            outputHelper.WriteLine($"minutes : {minutes.Item}");
-            outputHelper.WriteLine($"seconds : {seconds.Item}");
-            outputHelper.WriteLine($"milliseconds : {milliseconds.Item}");
+        // Arrange
+        Lazy<TimeExpression> timeExpressionBuilder = new(() => new TimeExpression(hours.Item, minutes.Item,
+            seconds.Item, milliseconds.Item));
 
-            // Arrange
-            Lazy<TimeExpression> timeExpressionBuilder = new(() => new TimeExpression(hours.Item, minutes.Item,
-                                                                                      seconds.Item, milliseconds.Item));
+        Action invokingCtor = () => { TimeExpression value = timeExpressionBuilder.Value; };
 
-            Action invokingCtor = () => { TimeExpression value = timeExpressionBuilder.Value; };
-
-            ((Action)(() => invokingCtor.Should().ThrowExactly<ArgumentOutOfRangeException>())).When(hours.Item < 0
-                                                                                                 || minutes.Item < 0 || 59 < minutes.Item
-                                                                                                 || seconds.Item < 0 || 60 < seconds.Item
-                                                                                                 || (seconds.Item == 60 && minutes.Item != 59 && hours.Item != 23)
-                                                                                                 )
-                    .Label("Invalid TimeExpression").Trivial(hours.Item < 0
-                                                             || minutes.Item < 0 || 59 < minutes.Item
-                                                             || seconds.Item < 0 || 60 < seconds.Item
-                                                             || (seconds.Item == 60 && minutes.Item != 59 && hours.Item != 23))
-                .And(() =>
-                {
-                    TimeExpression timeExpression = timeExpressionBuilder.Value;
-                    return timeExpression.Hours == hours.Item
-                           && timeExpression.Minutes == minutes.Item
-                           && timeExpression.Seconds == seconds.Item;
-                })
-                .VerboseCheck(outputHelper);
-        }
-
-        [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
-        public void Equals_should_be_commutative(NonNull<TimeExpression> first, FilterExpression second)
-            => (first.Item.Equals(second) == second.Equals(first.Item)).ToProperty()
-                .QuickCheckThrowOnFailure(outputHelper);
-
-        [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
-        public void Equals_should_be_reflexive(NonNull<TimeExpression> expression)
-            => expression.Item.Equals(expression.Item).ToProperty().QuickCheckThrowOnFailure(outputHelper);
-
-        [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
-        public void Equals_should_be_symetric(NonNull<TimeExpression> expression, NonNull<FilterExpression> otherExpression)
-            => (expression.Item.Equals(otherExpression.Item) == otherExpression.Item.Equals(expression.Item)).ToProperty().QuickCheckThrowOnFailure(outputHelper);
-
-        [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
-        public void Given_non_null_TimeExpression_instance_should_never_be_equal_to_null(TimeExpression instance)
-        {
-            // Act
-            bool actual = instance.Equals(null);
-
-            // Assert
-            actual.Should()
-                  .BeFalse();
-        }
-
-        [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
-        public void Given_two_TimeExpression_instances_that_have_same_values_should_be_equal(NonNegativeInt hours, NonNegativeInt minutes, NonNegativeInt seconds, NonNegativeInt milliseconds)
-        {
-            // Arrange
-            TimeExpression first = new(hours.Item, minutes.Item, seconds.Item, milliseconds.Item);
-            TimeExpression other = new(hours.Item, minutes.Item, seconds.Item, milliseconds.Item);
-
-            // Act
-            bool actual = first.Equals(other);
-
-            // Assert
-            actual.Should()
-                  .BeTrue();
-            first.GetHashCode().Should()
-                               .Be(other.GetHashCode());
-        }
-
-        [Bug(32)]
-        [Theory]
-        [InlineData(00, 00, 00, 00, "00:00:00")]
-        [InlineData(02, 53, 39, 987, "02:53:39.987")]
-        public void Given_TimeExpression_instance_EscapedParseableString_should_be_in_expected_form(int hours,
-                                                                                                    int minutes,
-                                                                                                    int seconds,
-                                                                                                    int milliseconds,
-                                                                                                    string expected)
-        {
-            // Arrange
-            TimeExpression timeExpression = new(hours, minutes, seconds, milliseconds);
-
-            // Act
-            string actual = timeExpression.EscapedParseableString;
-
-            // Assert
-            actual.Should()
-                  .Be(expected);
-        }
-
-        [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
-        public void IsEquivalent_should_be_commutative(NonNull<TimeExpression> first, FilterExpression second)
-        {
-            // Act
-            bool actual = first.Item.IsEquivalentTo(second);
-            bool expected = second.IsEquivalentTo(first.Item);
-
-            // Assert
-            actual.Should().Be(expected);
-        }
-
-        [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
-        public void IsEquivalentTo_should_be_reflexive(NonNull<TimeExpression> expression)
-            => expression.Item.IsEquivalentTo(expression.Item).Should().BeTrue();
-
-        [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
-        public void IsEquivalentTo_should_be_symetric(NonNull<TimeExpression> expression, NonNull<FilterExpression> otherExpression)
-            => expression.Item.IsEquivalentTo(otherExpression.Item).Should().Be(otherExpression.Item.IsEquivalentTo(expression.Item));
+        ((Action)(() => invokingCtor.Should().ThrowExactly<ArgumentOutOfRangeException>())).When(hours.Item < 0
+                || minutes.Item < 0 || 59 < minutes.Item
+                || seconds.Item < 0 || 60 < seconds.Item
+                || (seconds.Item == 60 && minutes.Item != 59 && hours.Item != 23)
+            )
+            .Label("Invalid TimeExpression").Trivial(hours.Item < 0
+                                                     || minutes.Item < 0 || 59 < minutes.Item
+                                                     || seconds.Item < 0 || 60 < seconds.Item
+                                                     || (seconds.Item == 60 && minutes.Item != 59 && hours.Item != 23))
+            .And(() =>
+            {
+                TimeExpression timeExpression = timeExpressionBuilder.Value;
+                return timeExpression.Hours == hours.Item
+                       && timeExpression.Minutes == minutes.Item
+                       && timeExpression.Seconds == seconds.Item;
+            })
+            .VerboseCheck(outputHelper);
     }
+
+    [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
+    public void Equals_should_be_commutative(NonNull<TimeExpression> first, FilterExpression second)
+        => (first.Item.Equals(second) == second.Equals(first.Item)).ToProperty()
+            .QuickCheckThrowOnFailure(outputHelper);
+
+    [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
+    public void Equals_should_be_reflexive(NonNull<TimeExpression> expression)
+        => expression.Item.Equals(expression.Item).ToProperty().QuickCheckThrowOnFailure(outputHelper);
+
+    [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
+    public void Equals_should_be_symetric(NonNull<TimeExpression> expression, NonNull<FilterExpression> otherExpression)
+        => (expression.Item.Equals(otherExpression.Item) == otherExpression.Item.Equals(expression.Item)).ToProperty().QuickCheckThrowOnFailure(outputHelper);
+
+    [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
+    public void Given_non_null_TimeExpression_instance_should_never_be_equal_to_null(TimeExpression instance)
+    {
+        // Act
+        bool actual = instance.Equals(null);
+
+        // Assert
+        actual.Should()
+            .BeFalse();
+    }
+
+    [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
+    public void Given_two_TimeExpression_instances_that_have_same_values_should_be_equal(NonNegativeInt hours, NonNegativeInt minutes, NonNegativeInt seconds, NonNegativeInt milliseconds)
+    {
+        // Arrange
+        TimeExpression first = new(hours.Item, minutes.Item, seconds.Item, milliseconds.Item);
+        TimeExpression other = new(hours.Item, minutes.Item, seconds.Item, milliseconds.Item);
+
+        // Act
+        bool actual = first.Equals(other);
+
+        // Assert
+        actual.Should()
+            .BeTrue();
+        first.GetHashCode().Should()
+            .Be(other.GetHashCode());
+    }
+
+    [Bug(32)]
+    [Theory]
+    [InlineData(00, 00, 00, 00, "00:00:00")]
+    [InlineData(02, 53, 39, 987, "02:53:39.987")]
+    public void Given_TimeExpression_instance_EscapedParseableString_should_be_in_expected_form(int hours,
+        int minutes,
+        int seconds,
+        int milliseconds,
+        string expected)
+    {
+        // Arrange
+        TimeExpression timeExpression = new(hours, minutes, seconds, milliseconds);
+
+        // Act
+        string actual = timeExpression.EscapedParseableString;
+
+        // Assert
+        actual.Should()
+            .Be(expected);
+    }
+
+    [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
+    public void IsEquivalent_should_be_commutative(NonNull<TimeExpression> first, FilterExpression second)
+    {
+        // Act
+        bool actual = first.Item.IsEquivalentTo(second);
+        bool expected = second.IsEquivalentTo(first.Item);
+
+        // Assert
+        actual.Should().Be(expected);
+    }
+
+    [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
+    public void IsEquivalentTo_should_be_reflexive(NonNull<TimeExpression> expression)
+        => expression.Item.IsEquivalentTo(expression.Item).Should().BeTrue();
+
+    [Property(Arbitrary = [typeof(ExpressionsGenerators)])]
+    public void IsEquivalentTo_should_be_symetric(NonNull<TimeExpression> expression, NonNull<FilterExpression> otherExpression)
+        => expression.Item.IsEquivalentTo(otherExpression.Item).Should().Be(otherExpression.Item.IsEquivalentTo(expression.Item));
 }

--- a/test/DataFilters.UnitTests/Helpers/CultureSwitcher.cs
+++ b/test/DataFilters.UnitTests/Helpers/CultureSwitcher.cs
@@ -1,71 +1,70 @@
-﻿namespace DataFilters.UnitTests.Helpers
+﻿namespace DataFilters.UnitTests.Helpers;
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+
+/// <summary>
+/// A helper class to control the <see cref="CultureInfo.CurrentCulture"/> value during tests.
+/// </summary>
+[ExcludeFromCodeCoverage]
+public sealed class CultureSwitcher : IDisposable
 {
-    using System;
-    using System.Diagnostics.CodeAnalysis;
-    using System.Globalization;
+    /// <summary>
+    /// The current culture used by the current instance.
+    /// </summary>
+    public CultureInfo CurrentCulture { get; private set; }
 
     /// <summary>
-    /// A helper class to control the <see cref="CultureInfo.CurrentCulture"/> value during tests.
+    /// Gets/Sets the default culture used throughout the lifecycle of the current instance.
     /// </summary>
-    [ExcludeFromCodeCoverage]
-    public sealed class CultureSwitcher : IDisposable
+    public CultureInfo DefaultCulture { get; set; }
+
+    /// <summary>
+    /// Bulds a new <see cref="CultureSwitcher"/> instance.
+    /// </summary>
+    public CultureSwitcher()
     {
-        /// <summary>
-        /// The current culture used by the current instance.
-        /// </summary>
-        public CultureInfo CurrentCulture { get; private set; }
-
-        /// <summary>
-        /// Gets/Sets the default culture used throughout the lifecycle of the current instance.
-        /// </summary>
-        public CultureInfo DefaultCulture { get; set; }
-
-        /// <summary>
-        /// Bulds a new <see cref="CultureSwitcher"/> instance.
-        /// </summary>
-        public CultureSwitcher()
-        {
-            CurrentCulture = CultureInfo.CurrentCulture;
-            DefaultCulture = CurrentCulture;
-        }
-
-        /// <summary>
-        /// Performs the specified <see cref="action"/> <strong>AFTER</strong> switching <see cref="CultureInfo.CurrentCulture"/>
-        /// to the specified <paramref name="cultureToUse"/>.
-        /// </summary>
-        /// <param name="cultureToUse">Name of the culture to use when running the specified <paramref name="action"/>.</param>
-        /// <param name="action">The action to run with the specified <paramref name="cultureToUse"/>.</param>
-        /// <remarks>
-        /// <paramref name="cultureToUse"/> will be used as Default
-        /// </remarks>
-        public void Run(string cultureToUse, Action action) => Run(CultureInfo.CreateSpecificCulture(cultureToUse), action);
-
-        /// <summary>
-        /// Performs the specified <see cref="action"/> <strong>AFTER</strong> switching <see cref="CultureInfo.CurrentCulture"/> and
-        /// <see cref="CultureInfo.DefaultThreadCurrentCulture"/> to the specified <paramref name="cultureToUse"/>.
-        /// </summary>
-        /// <param name="cultureToUse">The culture to use when running the specified <paramref name="action"/>.</param>
-        /// <param name="action">The action to run</param>
-        public void Run(CultureInfo cultureToUse, Action action)
-        {
-            CurrentCulture = cultureToUse;
-            CultureInfo.CurrentCulture = CurrentCulture;
-            action.Invoke();
-            Dispose();
-        }
-
-        /// <summary>
-        /// Performs the specified <see cref="action"/> <strong>AFTER</strong> switching <see cref="CultureInfo.CurrentCulture"/>
-        /// to <see cref="DefaultCulture"/>.
-        /// </summary>
-        /// <param name="action">Action to run with</param>
-        /// <remarks>
-        /// <see cref="CultureInfo.CurrentCulture"/> and <see cref="CultureInfo.DefaultThreadCurrentCulture"/> will be reverted
-        /// to <see cref="DefaultCulture"/> when the current instance get disposed.
-        /// </remarks>
-        public void Run(Action action) => Run(DefaultCulture.Name, action);
-
-        ///<inheritdoc/>
-        public void Dispose() => CultureInfo.CurrentCulture = DefaultCulture;
+        CurrentCulture = CultureInfo.CurrentCulture;
+        DefaultCulture = CurrentCulture;
     }
+
+    /// <summary>
+    /// Performs the specified <see cref="action"/> <strong>AFTER</strong> switching <see cref="CultureInfo.CurrentCulture"/>
+    /// to the specified <paramref name="cultureToUse"/>.
+    /// </summary>
+    /// <param name="cultureToUse">Name of the culture to use when running the specified <paramref name="action"/>.</param>
+    /// <param name="action">The action to run with the specified <paramref name="cultureToUse"/>.</param>
+    /// <remarks>
+    /// <paramref name="cultureToUse"/> will be used as Default
+    /// </remarks>
+    public void Run(string cultureToUse, Action action) => Run(CultureInfo.CreateSpecificCulture(cultureToUse), action);
+
+    /// <summary>
+    /// Performs the specified <see cref="action"/> <strong>AFTER</strong> switching <see cref="CultureInfo.CurrentCulture"/> and
+    /// <see cref="CultureInfo.DefaultThreadCurrentCulture"/> to the specified <paramref name="cultureToUse"/>.
+    /// </summary>
+    /// <param name="cultureToUse">The culture to use when running the specified <paramref name="action"/>.</param>
+    /// <param name="action">The action to run</param>
+    public void Run(CultureInfo cultureToUse, Action action)
+    {
+        CurrentCulture = cultureToUse;
+        CultureInfo.CurrentCulture = CurrentCulture;
+        action.Invoke();
+        Dispose();
+    }
+
+    /// <summary>
+    /// Performs the specified <see cref="action"/> <strong>AFTER</strong> switching <see cref="CultureInfo.CurrentCulture"/>
+    /// to <see cref="DefaultCulture"/>.
+    /// </summary>
+    /// <param name="action">Action to run with</param>
+    /// <remarks>
+    /// <see cref="CultureInfo.CurrentCulture"/> and <see cref="CultureInfo.DefaultThreadCurrentCulture"/> will be reverted
+    /// to <see cref="DefaultCulture"/> when the current instance get disposed.
+    /// </remarks>
+    public void Run(Action action) => Run(DefaultCulture.Name, action);
+
+    ///<inheritdoc/>
+    public void Dispose() => CultureInfo.CurrentCulture = DefaultCulture;
 }

--- a/test/DataFilters.UnitTests/Helpers/ExpressionsGenerators.cs
+++ b/test/DataFilters.UnitTests/Helpers/ExpressionsGenerators.cs
@@ -1,442 +1,441 @@
-namespace DataFilters.UnitTests.Helpers
+namespace DataFilters.UnitTests.Helpers;
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using DataFilters.Grammar.Parsing;
+using DataFilters.Grammar.Syntax;
+using FsCheck;
+using FsCheck.Fluent;
+using static GeneratorHelper;
+
+public static class ExpressionsGenerators
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Globalization;
-    using System.Linq;
-    using DataFilters.Grammar.Parsing;
-    using DataFilters.Grammar.Syntax;
-    using FsCheck;
-    using FsCheck.Fluent;
-    using static GeneratorHelper;
-
-    public static class ExpressionsGenerators
+    public static Arbitrary<DateTimeExpression> DateTimeExpressions()
     {
-        public static Arbitrary<DateTimeExpression> DateTimeExpressions()
-        {
-            return GetArbitraryFor<DateTime>()
-                                .Filter(dateTime => dateTime is { Hour: >= 0, Minute: >= 0, Second: >= 0, Millisecond: >= 0 })
-                                .Generator
-                                .Zip(TimeExpressions().Generator)
-                                .Select(val => (date: val.Item1, time: val.Item2))
-                                .Zip(OffsetExpressions().Generator)
-                                .Select(val => (val.Item1.date, val.Item1.time, offset: val.Item2))
-                                .Where(val => val.time != null || val.offset != null)
-                                .Select(dateTime => new DateTimeExpression(date: new(year: dateTime.date.Year, month: dateTime.date.Month, day: dateTime.date.Day),
-                                                                           time: new(hours: dateTime.date.Hour, minutes: dateTime.date.Minute, seconds: dateTime.date.Second, milliseconds: dateTime.date.Millisecond),
-                                                                           offset: dateTime.offset))
-                                .ToArbitrary();
-        }
+        return GetArbitraryFor<DateTime>()
+            .Filter(dateTime => dateTime is { Hour: >= 0, Minute: >= 0, Second: >= 0, Millisecond: >= 0 })
+            .Generator
+            .Zip(TimeExpressions().Generator)
+            .Select(val => (date: val.Item1, time: val.Item2))
+            .Zip(OffsetExpressions().Generator)
+            .Select(val => (val.Item1.date, val.Item1.time, offset: val.Item2))
+            .Where(val => val.time != null || val.offset != null)
+            .Select(dateTime => new DateTimeExpression(date: new(year: dateTime.date.Year, month: dateTime.date.Month, day: dateTime.date.Day),
+                time: new(hours: dateTime.date.Hour, minutes: dateTime.date.Minute, seconds: dateTime.date.Second, milliseconds: dateTime.date.Millisecond),
+                offset: dateTime.offset))
+            .ToArbitrary();
+    }
 
-        public static Arbitrary<TimeExpression> TimeExpressions()
-        {
-            return GetArbitraryFor<TimeSpan>()
-                        .Filter(timespan => timespan is { Hours: >= 0, Minutes: >= 0, Seconds: >= 0, Milliseconds: >= 0 })
-                        .Generator
-                        .Select(timespan => new TimeExpression(hours: timespan.Hours,
-                                                               minutes: timespan.Minutes,
-                                                               seconds: timespan.Seconds,
-                                                               milliseconds: timespan.Milliseconds))
-                        .ToArbitrary();
-        }
+    public static Arbitrary<TimeExpression> TimeExpressions()
+    {
+        return GetArbitraryFor<TimeSpan>()
+            .Filter(timespan => timespan is { Hours: >= 0, Minutes: >= 0, Seconds: >= 0, Milliseconds: >= 0 })
+            .Generator
+            .Select(timespan => new TimeExpression(hours: timespan.Hours,
+                minutes: timespan.Minutes,
+                seconds: timespan.Seconds,
+                milliseconds: timespan.Milliseconds))
+            .ToArbitrary();
+    }
 
-        public static Arbitrary<OffsetExpression> OffsetExpressions()
-        {
-            Gen<int> hours = Gen.Choose(0, 23);
-            Gen<int> minutes = Gen.Choose(0, 59);
-            Gen<NumericSign> sign = Gen.OneOf(Gen.Constant(NumericSign.Plus), Gen.Constant(NumericSign.Minus));
+    public static Arbitrary<OffsetExpression> OffsetExpressions()
+    {
+        Gen<int> hours = Gen.Choose(0, 23);
+        Gen<int> minutes = Gen.Choose(0, 59);
+        Gen<NumericSign> sign = Gen.OneOf(Gen.Constant(NumericSign.Plus), Gen.Constant(NumericSign.Minus));
 
-            return hours.Zip(minutes, (hh, mm) => (hours: hh, minutes: mm))
-                        .Zip(sign, (offset, s) => (offset.hours, offset.minutes, sign: s))
-                        .Select(val => (val.hours, val.minutes, val.sign))
-                        .Select(val => new OffsetExpression(val.sign, (uint)val.hours, (uint)val.minutes))
-                                               .OrNull()
-                                               .ToArbitrary();
-        }
+        return hours.Zip(minutes, (hh, mm) => (hours: hh, minutes: mm))
+            .Zip(sign, (offset, s) => (offset.hours, offset.minutes, sign: s))
+            .Select(val => (val.hours, val.minutes, val.sign))
+            .Select(val => new OffsetExpression(val.sign, (uint)val.hours, (uint)val.minutes))
+            .OrNull()
+            .ToArbitrary();
+    }
 
-        public static Arbitrary<DateExpression> DateExpressions()
-        {
-            Gen<DateExpression> dateTimeGenerator = GetArbitraryFor<DateTime>()
-                                        .Generator
-                                        .Select(dateTime => new DateExpression(year: dateTime.Year, month: dateTime.Month, day: dateTime.Day));
+    public static Arbitrary<DateExpression> DateExpressions()
+    {
+        Gen<DateExpression> dateTimeGenerator = GetArbitraryFor<DateTime>()
+            .Generator
+            .Select(dateTime => new DateExpression(year: dateTime.Year, month: dateTime.Month, day: dateTime.Day));
 
 #if NET6_0_OR_GREATER
-            Gen<DateExpression> dateOnlyGenerator = GetArbitraryFor<DateTime>()
-                .Generator
-                .Select(DateOnly.FromDateTime)
-                .Select(date => new DateExpression(year: date.Year, month: date.Month, day: date.Day));
+        Gen<DateExpression> dateOnlyGenerator = GetArbitraryFor<DateTime>()
+            .Generator
+            .Select(DateOnly.FromDateTime)
+            .Select(date => new DateExpression(year: date.Year, month: date.Month, day: date.Day));
 #endif
 
 #if !NET6_0_OR_GREATER
             return dateTimeGenerator.ToArbitrary();
 #else
-            return Gen.OneOf(dateTimeGenerator, dateOnlyGenerator)
-                .ToArbitrary();
+        return Gen.OneOf(dateTimeGenerator, dateOnlyGenerator)
+            .ToArbitrary();
 #endif
-        }
+    }
 
-        public static Arbitrary<ConstantValueExpression> ConstantValueExpressions()
+    public static Arbitrary<ConstantValueExpression> ConstantValueExpressions()
+    {
+        IList<Gen<ConstantValueExpression>> generators = new List<Gen<ConstantValueExpression>>
         {
-            IList<Gen<ConstantValueExpression>> generators = new List<Gen<ConstantValueExpression>>
+            TextExpressions().Generator.Select(value => (ConstantValueExpression) value),
+            StringValueExpressions().Generator.Select(value => (ConstantValueExpression) value),
+            GetArbitraryFor<bool>().Generator.Select(value => (ConstantValueExpression) new StringValueExpression(value.ToString())),
+            GetArbitraryFor<Guid>().Generator.Select(value => (ConstantValueExpression) new GuidValueExpression(value.ToString("d"))),
+            NumericValueExpressions().Generator.Select(value => (ConstantValueExpression) value)
+        };
+
+        return Gen.OneOf(generators)
+            .ToArbitrary();
+    }
+
+    public static Arbitrary<NumericValueExpression> NumericValueExpressions()
+    {
+        IEnumerable<Gen<NumericValueExpression>> generators = new Gen<NumericValueExpression>[]
+        {
+            GetArbitraryFor<int>().Generator.Select(value => new NumericValueExpression(value.ToString(CultureInfo.InvariantCulture))),
+            GetArbitraryFor<long>().Generator.Select(value => new NumericValueExpression(value.ToString(CultureInfo.InvariantCulture))),
+            GetArbitraryFor<NormalFloat>().Generator.Select(value => new NumericValueExpression(value.Item.ToString(CultureInfo.InvariantCulture)))
+        };
+
+        return Gen.OneOf(generators)
+            .ToArbitrary();
+    }
+
+    public static Arbitrary<StringValueExpression> StringValueExpressions()
+        => GetArbitraryFor<NonEmptyString>().Generator
+            .Select(value => value.Item.Any(chr => FilterTokenizer.SpecialCharacters.Contains(chr))
+                ? new TextExpression(value.Item)
+                : new StringValueExpression(value.Item)
+            )
+            .ToArbitrary();
+
+    public static Arbitrary<DurationExpression> DurationExpressions()
+    {
+        Arbitrary<(((PositiveInt years, PositiveInt months, PositiveInt days) date, (PositiveInt hours, PositiveInt minutes, PositiveInt seconds) time) dateTime, PositiveInt milliseconds)> arb = GetArbitraryFor<PositiveInt>().Generator
+            .Three()
+            .Two()
+            .Zip(GetArbitraryFor<PositiveInt>().Generator)
+            .ToArbitrary();
+
+        return arb.Generator.Select(tuple => new DurationExpression(years: tuple.dateTime.date.years.Item,
+                months: tuple.dateTime.date.months.Item,
+                weeks: tuple.dateTime.date.days.Item,
+                days: tuple.dateTime.time.hours.Item,
+                hours: tuple.dateTime.time.minutes.Item,
+                minutes: tuple.dateTime.time.seconds.Item,
+                seconds: tuple.milliseconds.Item))
+            .ToArbitrary();
+    }
+
+    public static Arbitrary<EndsWithExpression> EndsWithExpressions()
+        => Gen.OneOf(GetArbitraryFor<NonEmptyString>().Generator
+                    .Select(nonWhiteSpaceString => new EndsWithExpression(nonWhiteSpaceString.Item)),
+                TextExpressions().Generator.Select(text => new EndsWithExpression(text))
+            )
+            .ToArbitrary();
+
+    public static Arbitrary<StartsWithExpression> StartsWithExpressions()
+        => Gen.OneOf(GetArbitraryFor<NonEmptyString>().Generator
+                    .Select(nonWhiteSpaceString => new StartsWithExpression(nonWhiteSpaceString.Item)),
+                TextExpressions().Generator.Select(text => new StartsWithExpression(text))
+            )
+            .ToArbitrary();
+
+    public static Arbitrary<OrExpression> OrExpressions() => Gen.Sized(SafeOrExpressionGenerator).ToArbitrary();
+
+    public static Arbitrary<AndExpression> AndExpressions() => Gen.Sized(SafeAndExpressionGenerator).ToArbitrary();
+
+    public static Arbitrary<GroupExpression> GroupExpressions() => Gen.Sized(SafeGroupExpressionGenerator).ToArbitrary();
+
+    private static Gen<GroupExpression> SafeGroupExpressionGenerator(int size)
+    {
+        Gen<GroupExpression> gen;
+        switch (size)
+        {
+            case 0:
             {
-                TextExpressions().Generator.Select(value => (ConstantValueExpression) value),
-                StringValueExpressions().Generator.Select(value => (ConstantValueExpression) value),
-                GetArbitraryFor<bool>().Generator.Select(value => (ConstantValueExpression) new StringValueExpression(value.ToString())),
-                GetArbitraryFor<Guid>().Generator.Select(value => (ConstantValueExpression) new GuidValueExpression(value.ToString("d"))),
-                NumericValueExpressions().Generator.Select(value => (ConstantValueExpression) value)
-            };
-
-            return Gen.OneOf(generators)
-                      .ToArbitrary();
-        }
-
-        public static Arbitrary<NumericValueExpression> NumericValueExpressions()
-        {
-            IEnumerable<Gen<NumericValueExpression>> generators = new Gen<NumericValueExpression>[]
-            {
-                GetArbitraryFor<int>().Generator.Select(value => new NumericValueExpression(value.ToString(CultureInfo.InvariantCulture))),
-                GetArbitraryFor<long>().Generator.Select(value => new NumericValueExpression(value.ToString(CultureInfo.InvariantCulture))),
-                GetArbitraryFor<NormalFloat>().Generator.Select(value => new NumericValueExpression(value.Item.ToString(CultureInfo.InvariantCulture)))
-            };
-
-            return Gen.OneOf(generators)
-                      .ToArbitrary();
-        }
-
-        public static Arbitrary<StringValueExpression> StringValueExpressions()
-            => GetArbitraryFor<NonEmptyString>().Generator
-                                                .Select(value => value.Item.Any(chr => FilterTokenizer.SpecialCharacters.Contains(chr))
-                                                    ? new TextExpression(value.Item)
-                                                    : new StringValueExpression(value.Item)
-                                                )
-                                                .ToArbitrary();
-
-        public static Arbitrary<DurationExpression> DurationExpressions()
-        {
-            Arbitrary<(((PositiveInt years, PositiveInt months, PositiveInt days) date, (PositiveInt hours, PositiveInt minutes, PositiveInt seconds) time) dateTime, PositiveInt milliseconds)> arb = GetArbitraryFor<PositiveInt>().Generator
-                                                                                                                                                              .Three()
-                                                                                                                                                              .Two()
-                                                                                                                                                              .Zip(GetArbitraryFor<PositiveInt>().Generator)
-                                                                                                                                                              .ToArbitrary();
-
-            return arb.Generator.Select(tuple => new DurationExpression(years: tuple.dateTime.date.years.Item,
-                                                                        months: tuple.dateTime.date.months.Item,
-                                                                        weeks: tuple.dateTime.date.days.Item,
-                                                                        days: tuple.dateTime.time.hours.Item,
-                                                                        hours: tuple.dateTime.time.minutes.Item,
-                                                                        minutes: tuple.dateTime.time.seconds.Item,
-                                                                        seconds: tuple.milliseconds.Item))
-                    .ToArbitrary();
-        }
-
-        public static Arbitrary<EndsWithExpression> EndsWithExpressions()
-            => Gen.OneOf(GetArbitraryFor<NonEmptyString>().Generator
-                                                          .Select(nonWhiteSpaceString => new EndsWithExpression(nonWhiteSpaceString.Item)),
-                         TextExpressions().Generator.Select(text => new EndsWithExpression(text))
-                        )
-                        .ToArbitrary();
-
-        public static Arbitrary<StartsWithExpression> StartsWithExpressions()
-            => Gen.OneOf(GetArbitraryFor<NonEmptyString>().Generator
-                                                          .Select(nonWhiteSpaceString => new StartsWithExpression(nonWhiteSpaceString.Item)),
-                         TextExpressions().Generator.Select(text => new StartsWithExpression(text))
-                        )
-                        .ToArbitrary();
-
-        public static Arbitrary<OrExpression> OrExpressions() => Gen.Sized(SafeOrExpressionGenerator).ToArbitrary();
-
-        public static Arbitrary<AndExpression> AndExpressions() => Gen.Sized(SafeAndExpressionGenerator).ToArbitrary();
-
-        public static Arbitrary<GroupExpression> GroupExpressions() => Gen.Sized(SafeGroupExpressionGenerator).ToArbitrary();
-
-        private static Gen<GroupExpression> SafeGroupExpressionGenerator(int size)
-        {
-            Gen<GroupExpression> gen;
-            switch (size)
-            {
-                case 0:
-                    {
-                        gen = GenerateFilterExpressions().Generator
-                                                         .Select(expr => new GroupExpression(expr));
-                        break;
-                    }
-
-                default:
-                    {
-                        Gen<GroupExpression> subtree = SafeGroupExpressionGenerator(size / 2);
-                        gen = Gen.OneOf(GenerateFilterExpressions().Generator.Select(expr => new GroupExpression(expr)),
-                                        subtree.Select(expr => new GroupExpression(expr)));
-                        break;
-                    }
+                gen = GenerateFilterExpressions().Generator
+                    .Select(expr => new GroupExpression(expr));
+                break;
             }
 
-            return gen;
+            default:
+            {
+                Gen<GroupExpression> subtree = SafeGroupExpressionGenerator(size / 2);
+                gen = Gen.OneOf(GenerateFilterExpressions().Generator.Select(expr => new GroupExpression(expr)),
+                    subtree.Select(expr => new GroupExpression(expr)));
+                break;
+            }
         }
 
-        /// <summary>
-        /// Generates an arbitrary random <see cref="FilterExpression"/>.
-        /// </summary>
-        public static Arbitrary<FilterExpression> GenerateFilterExpressions()
+        return gen;
+    }
+
+    /// <summary>
+    /// Generates an arbitrary random <see cref="FilterExpression"/>.
+    /// </summary>
+    public static Arbitrary<FilterExpression> GenerateFilterExpressions()
+    {
+        Gen<FilterExpression>[] generators =
+        [
+            EndsWithExpressions().Generator.Select(item => (FilterExpression) item),
+            StartsWithExpressions().Generator.Select(item => (FilterExpression) item),
+            ContainsExpressions().Generator.Select(item => (FilterExpression) item),
+            IntervalExpressions().Generator.Select(item => (FilterExpression) item),
+            DateExpressions().Generator.Select(item => (FilterExpression) item),
+            DateTimeExpressions().Generator.Select(item => (FilterExpression) item),
+            TimeExpressions().Generator.Select(item => (FilterExpression) item),
+            DurationExpressions().Generator.Select(item => (FilterExpression) item),
+            ConstantValueExpressions().Generator.Select(item => (FilterExpression) item),
+            GroupExpressions().Generator.Select(item => (FilterExpression) item)
+        ];
+
+        return Gen.OneOf(generators).ToArbitrary();
+    }
+
+    /// <summary>
+    /// Generates an arbitrary random <see cref="BinaryFilterExpression"/>.
+    /// </summary>
+    /// <returns></returns>
+    public static Arbitrary<BinaryFilterExpression> BinaryFilterExpressions()
+    {
+        Gen<BinaryFilterExpression>[] generators =
+        [
+            AndExpressions().Generator.Select(item => (BinaryFilterExpression) item),
+            OrExpressions().Generator.Select(item => (BinaryFilterExpression) item)
+        ];
+
+        return Gen.OneOf(generators).ToArbitrary();
+    }
+
+    private static Gen<OrExpression> SafeOrExpressionGenerator(int size)
+    {
+        Gen<OrExpression> gen;
+        switch (size)
+        {
+            case 0:
+            {
+                gen = GenerateFilterExpressions().Generator.Two()
+                    .Select(tuple => CreateFilterExpression((tuple.Item1, tuple.Item2), tuple => new OrExpression(tuple.Item1, tuple.Item2)));
+                break;
+            }
+
+            default:
+            {
+                Gen<OrExpression> subtree = SafeOrExpressionGenerator(size / 2);
+                gen = Gen.OneOf(GenerateFilterExpressions().Generator.Two()
+                        .Select(tuple => CreateFilterExpression((tuple.Item1, tuple.Item2),
+                            tuple => new OrExpression(tuple.Item1, tuple.Item2))),
+                    subtree.Two().Select(tuple => CreateFilterExpression((tuple.Item1, tuple.Item2),
+                        tuple => new OrExpression(tuple.Item1, tuple.Item2))));
+                break;
+            }
+        }
+
+        return gen;
+    }
+
+    private static Gen<AndExpression> SafeAndExpressionGenerator(int size)
+    {
+        Gen<AndExpression> gen;
+        switch (size)
+        {
+            case 0:
+            {
+                gen = GenerateFilterExpressions().Generator.Two()
+                    .Select(tuple => CreateFilterExpression((tuple.Item1, tuple.Item2),
+                        tuple => new AndExpression(tuple.Item1, tuple.Item2)));
+                break;
+            }
+
+            default:
+            {
+                Gen<AndExpression> subtree = SafeAndExpressionGenerator(size / 2);
+                gen = Gen.OneOf(GenerateFilterExpressions().Generator.Two()
+                        .Select(tuple => CreateFilterExpression((tuple.Item1, tuple.Item2), tuple => new AndExpression(tuple.Item1, tuple.Item2))),
+                    subtree.Two().Select(tuple => CreateFilterExpression((tuple.Item1, tuple.Item2), tuple => new AndExpression(tuple.Item1, tuple.Item2))));
+                break;
+            }
+        }
+
+        return gen;
+    }
+
+    public static Arbitrary<NotExpression> NotExpressions()
+    {
+        return Gen.Sized(SafeNotExpressionGenerator).ToArbitrary();
+
+        static Gen<NotExpression> SafeNotExpressionGenerator(int size)
         {
             Gen<FilterExpression>[] generators =
             [
-                EndsWithExpressions().Generator.Select(item => (FilterExpression) item),
-                StartsWithExpressions().Generator.Select(item => (FilterExpression) item),
-                ContainsExpressions().Generator.Select(item => (FilterExpression) item),
-                IntervalExpressions().Generator.Select(item => (FilterExpression) item),
-                DateExpressions().Generator.Select(item => (FilterExpression) item),
-                DateTimeExpressions().Generator.Select(item => (FilterExpression) item),
-                TimeExpressions().Generator.Select(item => (FilterExpression) item),
-                DurationExpressions().Generator.Select(item => (FilterExpression) item),
-                ConstantValueExpressions().Generator.Select(item => (FilterExpression) item),
-                GroupExpressions().Generator.Select(item => (FilterExpression) item)
+                AndExpressions().Generator.Select(expr => (FilterExpression)expr),
+                OrExpressions().Generator.Select(expr => (FilterExpression)expr),
+                ConstantValueExpressions().Generator.Select(expr => (FilterExpression)expr),
+                DurationExpressions().Generator.Select(expr => (FilterExpression)expr),
+                DateExpressions().Generator.Select(expr => (FilterExpression)expr),
+                TimeExpressions().Generator.Select(expr => (FilterExpression)expr),
+                DateTimeExpressions().Generator.Select(expr => (FilterExpression)expr),
+                IntervalExpressions().Generator.Select(expr => (FilterExpression)expr)
             ];
 
-            return Gen.OneOf(generators).ToArbitrary();
-        }
-
-        /// <summary>
-        /// Generates an arbitrary random <see cref="BinaryFilterExpression"/>.
-        /// </summary>
-        /// <returns></returns>
-        public static Arbitrary<BinaryFilterExpression> BinaryFilterExpressions()
-        {
-            Gen<BinaryFilterExpression>[] generators =
-            [
-                AndExpressions().Generator.Select(item => (BinaryFilterExpression) item),
-                OrExpressions().Generator.Select(item => (BinaryFilterExpression) item)
-            ];
-
-            return Gen.OneOf(generators).ToArbitrary();
-        }
-
-        private static Gen<OrExpression> SafeOrExpressionGenerator(int size)
-        {
-            Gen<OrExpression> gen;
+            Gen<NotExpression> gen;
             switch (size)
             {
                 case 0:
-                    {
-                        gen = GenerateFilterExpressions().Generator.Two()
-                                                         .Select(tuple => CreateFilterExpression((tuple.Item1, tuple.Item2), tuple => new OrExpression(tuple.Item1, tuple.Item2)));
-                        break;
-                    }
-
-                default:
-                    {
-                        Gen<OrExpression> subtree = SafeOrExpressionGenerator(size / 2);
-                        gen = Gen.OneOf(GenerateFilterExpressions().Generator.Two()
-                                                         .Select(tuple => CreateFilterExpression((tuple.Item1, tuple.Item2),
-                                                                                                 tuple => new OrExpression(tuple.Item1, tuple.Item2))),
-                                        subtree.Two().Select(tuple => CreateFilterExpression((tuple.Item1, tuple.Item2),
-                                                                                              tuple => new OrExpression(tuple.Item1, tuple.Item2))));
-                        break;
-                    }
-            }
-
-            return gen;
-        }
-
-        private static Gen<AndExpression> SafeAndExpressionGenerator(int size)
-        {
-            Gen<AndExpression> gen;
-            switch (size)
-            {
-                case 0:
-                    {
-                        gen = GenerateFilterExpressions().Generator.Two()
-                                                         .Select(tuple => CreateFilterExpression((tuple.Item1, tuple.Item2),
-                                                                                                 tuple => new AndExpression(tuple.Item1, tuple.Item2)));
-                        break;
-                    }
-
-                default:
-                    {
-                        Gen<AndExpression> subtree = SafeAndExpressionGenerator(size / 2);
-                        gen = Gen.OneOf(GenerateFilterExpressions().Generator.Two()
-                                                                             .Select(tuple => CreateFilterExpression((tuple.Item1, tuple.Item2), tuple => new AndExpression(tuple.Item1, tuple.Item2))),
-                                        subtree.Two().Select(tuple => CreateFilterExpression((tuple.Item1, tuple.Item2), tuple => new AndExpression(tuple.Item1, tuple.Item2))));
-                        break;
-                    }
-            }
-
-            return gen;
-        }
-
-        public static Arbitrary<NotExpression> NotExpressions()
-        {
-            return Gen.Sized(SafeNotExpressionGenerator).ToArbitrary();
-
-            static Gen<NotExpression> SafeNotExpressionGenerator(int size)
-            {
-                Gen<FilterExpression>[] generators =
-                [
-                    AndExpressions().Generator.Select(expr => (FilterExpression)expr),
-                    OrExpressions().Generator.Select(expr => (FilterExpression)expr),
-                    ConstantValueExpressions().Generator.Select(expr => (FilterExpression)expr),
-                    DurationExpressions().Generator.Select(expr => (FilterExpression)expr),
-                    DateExpressions().Generator.Select(expr => (FilterExpression)expr),
-                    TimeExpressions().Generator.Select(expr => (FilterExpression)expr),
-                    DateTimeExpressions().Generator.Select(expr => (FilterExpression)expr),
-                    IntervalExpressions().Generator.Select(expr => (FilterExpression)expr)
-                ];
-
-                Gen<NotExpression> gen;
-                switch (size)
                 {
-                    case 0:
-                        {
-                            gen = Gen.OneOf(generators).Select(expr => new NotExpression(expr));
-                            break;
-                        }
-
-                    default:
-                        {
-                            Gen<NotExpression> subtree = SafeNotExpressionGenerator(size / 2);
-                            gen = Gen.OneOf(Gen.OneOf(generators).Select(exp => new NotExpression(exp)),
-                                            subtree.Select(expr => new NotExpression(expr)));
-                            break;
-                        }
+                    gen = Gen.OneOf(generators).Select(expr => new NotExpression(expr));
+                    break;
                 }
 
-                return gen;
+                default:
+                {
+                    Gen<NotExpression> subtree = SafeNotExpressionGenerator(size / 2);
+                    gen = Gen.OneOf(Gen.OneOf(generators).Select(exp => new NotExpression(exp)),
+                        subtree.Select(expr => new NotExpression(expr)));
+                    break;
+                }
             }
+
+            return gen;
         }
-
-        private static TFilterExpression CreateFilterExpression<TFilterExpression>((FilterExpression, FilterExpression) input, Func<(FilterExpression, FilterExpression), TFilterExpression> func)
-            => func.Invoke(input);
-
-        public static Arbitrary<IntervalExpression> IntervalExpressions()
-        {
-            Gen<bool> boolGenerator = GetArbitraryFor<bool>().Generator;
-            (Gen<IBoundaryExpression> gen, Gen<bool> included)[] datesGen = new[]
-            {
-                (DateExpressions().Generator.Select(item => (IBoundaryExpression) item), boolGenerator),
-                (DateTimeExpressions().Generator.Select(item => (IBoundaryExpression) item), boolGenerator)
-            };
-
-            (Gen<IBoundaryExpression> gen, Gen<bool> included)[] numericsGen = new[]
-            {
-                (GetArbitraryFor<short>().Generator.Select(value => (IBoundaryExpression) new NumericValueExpression(value.ToString())), boolGenerator),
-                (GetArbitraryFor<int>().Generator.Select(value => (IBoundaryExpression) new NumericValueExpression(value.ToString())), boolGenerator),
-                (GetArbitraryFor<long>().Generator.Select(value => (IBoundaryExpression) new NumericValueExpression(value.ToString())), boolGenerator),
-                (GetArbitraryFor<NormalFloat>().Generator.Select(value => (IBoundaryExpression) new NumericValueExpression(value.Item.ToString("G19", CultureInfo.InvariantCulture))), boolGenerator)
-            };
-
-            (Gen<IBoundaryExpression> gen, Gen<bool> included) timeGen = (TimeExpressions().Generator.Select(item => (IBoundaryExpression)item), boolGenerator);
-            (Gen<IBoundaryExpression> gen, Gen<bool> included) asteriskGen = (Gen.Constant((IBoundaryExpression)AsteriskExpression.Instance), Gen.Constant(false));
-
-            IEnumerable<Gen<IntervalExpression>> generatorsWithMinAndMax = datesGen.CrossJoin(datesGen)
-                                                                                   .Concat(datesGen.CrossJoin(new[] { timeGen }))
-                                                                                   .Select(tuple => (min: tuple.Item1, max: tuple.Item2))
-                                                                                   .Select(tuple => CreateIntervalExpressionGenerator((tuple.min.gen, tuple.min.included),
-                                                                                                                                      (tuple.max.gen, tuple.max.included)))
-                                                                                   .Concat(numericsGen.CrossJoin(numericsGen)
-                                                                                           .Select(tuple => (min: tuple.Item1, max: tuple.Item2))
-                                                                                           .Select(tuple => CreateIntervalExpressionGenerator((tuple.min.gen, tuple.min.included),
-                                                                                                                                              (tuple.max.gen, tuple.max.included))))
-                                         ;
-
-            IEnumerable<Gen<IntervalExpression>> generatorsWithMinOrMaxOnly = datesGen.CrossJoin(new[] { asteriskGen })
-                                                                                      .Concat(new[] { asteriskGen }.CrossJoin(datesGen))
-                                                                                      .Select(tuple => (min: tuple.Item1, max: tuple.Item2))
-                                                                                      .Select(tuple => CreateIntervalExpressionGenerator((tuple.min.gen, tuple.min.included),
-                                                                                                                                         (tuple.max.gen, tuple.max.included)));
-
-            return Gen.OneOf(generatorsWithMinAndMax.Concat(generatorsWithMinOrMaxOnly))
-                      .ToArbitrary();
-        }
-
-        public static Arbitrary<BoundaryExpression> BoundariesExpressions()
-        {
-            Gen<bool> boolGenerator = GetArbitraryFor<bool>().Generator;
-
-            IList<Gen<BoundaryExpression>> generators = new List<Gen<BoundaryExpression>>
-            {
-                CreateBoundaryGenerator(DateExpressions().Generator.Select(item => (IBoundaryExpression) item), boolGenerator),
-                CreateBoundaryGenerator(DateTimeExpressions().Generator.Select(item => (IBoundaryExpression) item), boolGenerator),
-                CreateBoundaryGenerator(TimeExpressions().Generator.Select(item => (IBoundaryExpression) item), boolGenerator),
-                CreateBoundaryGenerator(Gen.Constant((IBoundaryExpression)AsteriskExpression.Instance), Gen.Constant(false)),
-            };
-
-            return Gen.OneOf(generators)
-                      .ToArbitrary();
-        }
-
-        private static Gen<IntervalExpression> CreateIntervalExpressionGenerator((Gen<IBoundaryExpression> boundaryGenerator, Gen<bool> includedGenerator) genMin, (Gen<IBoundaryExpression> boundaryGenerator, Gen<bool> includedGenerator) genMax)
-        {
-            return CreateBoundaryGenerator(genMin.boundaryGenerator, genMin.includedGenerator)
-                    .Zip(CreateBoundaryGenerator(genMax.boundaryGenerator, genMax.includedGenerator))
-                    .Select(tuple => (min: tuple.Item1, max: tuple.Item2))
-                    .Select(tuple => new IntervalExpression(min: new BoundaryExpression(tuple.min.Expression, tuple.min.Included),
-                                                            max: new BoundaryExpression(tuple.max.Expression, tuple.max.Included)));
-        }
-
-        private static Gen<BoundaryExpression> CreateBoundaryGenerator(Gen<IBoundaryExpression> boundaryGenerator, Gen<bool> includedGenerator)
-        {
-            return boundaryGenerator.Zip(includedGenerator)
-                                    .Select(tuple => new BoundaryExpression(expression: tuple.Item1,
-                                                                            included: tuple.Item2));
-        }
-
-        public static Arbitrary<ContainsExpression> ContainsExpressions()
-            => Gen.OneOf(GetArbitraryFor<NonEmptyString>().Generator
-                                                          .Select(nonWhiteSpaceString => new ContainsExpression(nonWhiteSpaceString.Item)),
-                         TextExpressions().Generator.Select(text => new ContainsExpression(text))
-                        )
-                        .ToArbitrary();
-
-        public static Arbitrary<BracketValue> GenerateRegexValues()
-        {
-            Gen<BracketValue> regexRangeGenerator = RangeBracketValues().Convert(range => (BracketValue)range,
-                                                                                 bracket => (RangeBracketValue)bracket)
-                                                                                                          .Generator;
-            Gen<BracketValue> regexConstantGenerator = ConstantBracketValues().Convert(range => (BracketValue)range,
-                                                                                       bracket => (ConstantBracketValue)bracket)
-                                                                                         .Generator;
-
-            return Gen.OneOf(regexConstantGenerator, regexRangeGenerator).ToArbitrary();
-        }
-
-        private static Arbitrary<ConstantBracketValue> ConstantBracketValues()
-            => GetArbitraryFor<string>().Filter(input => !string.IsNullOrWhiteSpace(input)
-                                                        && input.Length > 1
-                                                        && input.All(char.IsLetterOrDigit))
-                                        .Generator
-                                        .Select(item => new ConstantBracketValue(item))
-                                        .ToArbitrary();
-
-        private static Arbitrary<RangeBracketValue> RangeBracketValues()
-        {
-            return GetArbitraryFor<char>()
-                              .Filter(char.IsLetterOrDigit).Generator
-                              .Two()
-                              .Select(tuple => (start: tuple.Item1, end: tuple.Item2))
-                              .Where(tuple => (tuple.start < tuple.end) && (TupleContainsLetter(tuple) || TupleContainsDigits(tuple)))
-                              .Select(tuple => new RangeBracketValue(tuple.start, tuple.end))
-                              .ToArbitrary();
-
-            static bool TupleContainsLetter((char start, char end) tuple) => char.IsLetter(tuple.start) && char.IsLetter(tuple.end)
-                                                                            && ((char.IsLower(tuple.start) && char.IsLower(tuple.end)) || (char.IsUpper(tuple.start) && char.IsUpper(tuple.end)));
-
-            static bool TupleContainsDigits((char start, char end) tuple) => char.IsDigit(tuple.start) && char.IsDigit(tuple.end);
-        }
-
-        /// <summary>
-        /// <see cref="BracketExpression"/> generator
-        /// </summary>
-        /// <returns><see cref="Arbitrary{BracketExpression}"/></returns>
-        public static Arbitrary<BracketExpression> BracketExpressions()
-            => Gen.OneOf(RangeBracketValues().Generator.Select(x => (BracketValue)x),
-                         ConstantBracketValues().Generator.Select(x => (BracketValue)x))
-                .ArrayOf()
-                .Select(brackets => new BracketExpression(brackets))
-                .ToArbitrary();
-
-        public static Arbitrary<TextExpression> TextExpressions()
-            => ArbMap.Default.ArbFor<NonEmptyString>()
-                             .Generator
-                             .Select(val => new TextExpression(val.Item))
-                             .ToArbitrary();
     }
+
+    private static TFilterExpression CreateFilterExpression<TFilterExpression>((FilterExpression, FilterExpression) input, Func<(FilterExpression, FilterExpression), TFilterExpression> func)
+        => func.Invoke(input);
+
+    public static Arbitrary<IntervalExpression> IntervalExpressions()
+    {
+        Gen<bool> boolGenerator = GetArbitraryFor<bool>().Generator;
+        (Gen<IBoundaryExpression> gen, Gen<bool> included)[] datesGen = new[]
+        {
+            (DateExpressions().Generator.Select(item => (IBoundaryExpression) item), boolGenerator),
+            (DateTimeExpressions().Generator.Select(item => (IBoundaryExpression) item), boolGenerator)
+        };
+
+        (Gen<IBoundaryExpression> gen, Gen<bool> included)[] numericsGen = new[]
+        {
+            (GetArbitraryFor<short>().Generator.Select(value => (IBoundaryExpression) new NumericValueExpression(value.ToString())), boolGenerator),
+            (GetArbitraryFor<int>().Generator.Select(value => (IBoundaryExpression) new NumericValueExpression(value.ToString())), boolGenerator),
+            (GetArbitraryFor<long>().Generator.Select(value => (IBoundaryExpression) new NumericValueExpression(value.ToString())), boolGenerator),
+            (GetArbitraryFor<NormalFloat>().Generator.Select(value => (IBoundaryExpression) new NumericValueExpression(value.Item.ToString("G19", CultureInfo.InvariantCulture))), boolGenerator)
+        };
+
+        (Gen<IBoundaryExpression> gen, Gen<bool> included) timeGen = (TimeExpressions().Generator.Select(item => (IBoundaryExpression)item), boolGenerator);
+        (Gen<IBoundaryExpression> gen, Gen<bool> included) asteriskGen = (Gen.Constant((IBoundaryExpression)AsteriskExpression.Instance), Gen.Constant(false));
+
+        IEnumerable<Gen<IntervalExpression>> generatorsWithMinAndMax = datesGen.CrossJoin(datesGen)
+                .Concat(datesGen.CrossJoin(new[] { timeGen }))
+                .Select(tuple => (min: tuple.Item1, max: tuple.Item2))
+                .Select(tuple => CreateIntervalExpressionGenerator((tuple.min.gen, tuple.min.included),
+                    (tuple.max.gen, tuple.max.included)))
+                .Concat(numericsGen.CrossJoin(numericsGen)
+                    .Select(tuple => (min: tuple.Item1, max: tuple.Item2))
+                    .Select(tuple => CreateIntervalExpressionGenerator((tuple.min.gen, tuple.min.included),
+                        (tuple.max.gen, tuple.max.included))))
+            ;
+
+        IEnumerable<Gen<IntervalExpression>> generatorsWithMinOrMaxOnly = datesGen.CrossJoin(new[] { asteriskGen })
+            .Concat(new[] { asteriskGen }.CrossJoin(datesGen))
+            .Select(tuple => (min: tuple.Item1, max: tuple.Item2))
+            .Select(tuple => CreateIntervalExpressionGenerator((tuple.min.gen, tuple.min.included),
+                (tuple.max.gen, tuple.max.included)));
+
+        return Gen.OneOf(generatorsWithMinAndMax.Concat(generatorsWithMinOrMaxOnly))
+            .ToArbitrary();
+    }
+
+    public static Arbitrary<BoundaryExpression> BoundariesExpressions()
+    {
+        Gen<bool> boolGenerator = GetArbitraryFor<bool>().Generator;
+
+        IList<Gen<BoundaryExpression>> generators = new List<Gen<BoundaryExpression>>
+        {
+            CreateBoundaryGenerator(DateExpressions().Generator.Select(item => (IBoundaryExpression) item), boolGenerator),
+            CreateBoundaryGenerator(DateTimeExpressions().Generator.Select(item => (IBoundaryExpression) item), boolGenerator),
+            CreateBoundaryGenerator(TimeExpressions().Generator.Select(item => (IBoundaryExpression) item), boolGenerator),
+            CreateBoundaryGenerator(Gen.Constant((IBoundaryExpression)AsteriskExpression.Instance), Gen.Constant(false)),
+        };
+
+        return Gen.OneOf(generators)
+            .ToArbitrary();
+    }
+
+    private static Gen<IntervalExpression> CreateIntervalExpressionGenerator((Gen<IBoundaryExpression> boundaryGenerator, Gen<bool> includedGenerator) genMin, (Gen<IBoundaryExpression> boundaryGenerator, Gen<bool> includedGenerator) genMax)
+    {
+        return CreateBoundaryGenerator(genMin.boundaryGenerator, genMin.includedGenerator)
+            .Zip(CreateBoundaryGenerator(genMax.boundaryGenerator, genMax.includedGenerator))
+            .Select(tuple => (min: tuple.Item1, max: tuple.Item2))
+            .Select(tuple => new IntervalExpression(min: new BoundaryExpression(tuple.min.Expression, tuple.min.Included),
+                max: new BoundaryExpression(tuple.max.Expression, tuple.max.Included)));
+    }
+
+    private static Gen<BoundaryExpression> CreateBoundaryGenerator(Gen<IBoundaryExpression> boundaryGenerator, Gen<bool> includedGenerator)
+    {
+        return boundaryGenerator.Zip(includedGenerator)
+            .Select(tuple => new BoundaryExpression(expression: tuple.Item1,
+                included: tuple.Item2));
+    }
+
+    public static Arbitrary<ContainsExpression> ContainsExpressions()
+        => Gen.OneOf(GetArbitraryFor<NonEmptyString>().Generator
+                    .Select(nonWhiteSpaceString => new ContainsExpression(nonWhiteSpaceString.Item)),
+                TextExpressions().Generator.Select(text => new ContainsExpression(text))
+            )
+            .ToArbitrary();
+
+    public static Arbitrary<BracketValue> GenerateRegexValues()
+    {
+        Gen<BracketValue> regexRangeGenerator = RangeBracketValues().Convert(range => (BracketValue)range,
+                bracket => (RangeBracketValue)bracket)
+            .Generator;
+        Gen<BracketValue> regexConstantGenerator = ConstantBracketValues().Convert(range => (BracketValue)range,
+                bracket => (ConstantBracketValue)bracket)
+            .Generator;
+
+        return Gen.OneOf(regexConstantGenerator, regexRangeGenerator).ToArbitrary();
+    }
+
+    private static Arbitrary<ConstantBracketValue> ConstantBracketValues()
+        => GetArbitraryFor<string>().Filter(input => !string.IsNullOrWhiteSpace(input)
+                                                     && input.Length > 1
+                                                     && input.All(char.IsLetterOrDigit))
+            .Generator
+            .Select(item => new ConstantBracketValue(item))
+            .ToArbitrary();
+
+    private static Arbitrary<RangeBracketValue> RangeBracketValues()
+    {
+        return GetArbitraryFor<char>()
+            .Filter(char.IsLetterOrDigit).Generator
+            .Two()
+            .Select(tuple => (start: tuple.Item1, end: tuple.Item2))
+            .Where(tuple => (tuple.start < tuple.end) && (TupleContainsLetter(tuple) || TupleContainsDigits(tuple)))
+            .Select(tuple => new RangeBracketValue(tuple.start, tuple.end))
+            .ToArbitrary();
+
+        static bool TupleContainsLetter((char start, char end) tuple) => char.IsLetter(tuple.start) && char.IsLetter(tuple.end)
+            && ((char.IsLower(tuple.start) && char.IsLower(tuple.end)) || (char.IsUpper(tuple.start) && char.IsUpper(tuple.end)));
+
+        static bool TupleContainsDigits((char start, char end) tuple) => char.IsDigit(tuple.start) && char.IsDigit(tuple.end);
+    }
+
+    /// <summary>
+    /// <see cref="BracketExpression"/> generator
+    /// </summary>
+    /// <returns><see cref="Arbitrary{BracketExpression}"/></returns>
+    public static Arbitrary<BracketExpression> BracketExpressions()
+        => Gen.OneOf(RangeBracketValues().Generator.Select(x => (BracketValue)x),
+                ConstantBracketValues().Generator.Select(x => (BracketValue)x))
+            .ArrayOf()
+            .Select(brackets => new BracketExpression(brackets))
+            .ToArbitrary();
+
+    public static Arbitrary<TextExpression> TextExpressions()
+        => ArbMap.Default.ArbFor<NonEmptyString>()
+            .Generator
+            .Select(val => new TextExpression(val.Item))
+            .ToArbitrary();
 }

--- a/test/DataFilters.UnitTests/Helpers/FilterGenerators.cs
+++ b/test/DataFilters.UnitTests/Helpers/FilterGenerators.cs
@@ -5,160 +5,159 @@ using Bogus;
 using FsCheck;
 using FsCheck.Fluent;
 
-namespace DataFilters.UnitTests.Helpers
+namespace DataFilters.UnitTests.Helpers;
+
+using static GeneratorHelper;
+
+/// <summary>
+/// Helper class which contains usefull FsCheck generators.
+/// </summary>
+internal static class FilterGenerators
 {
-    using static GeneratorHelper;
+    private static readonly Faker Faker = new();
 
     /// <summary>
-    /// Helper class which contains usefull FsCheck generators.
+    /// Generates a <see cref="Arbitrary{Filter}"/> where the value of the filter is a string
     /// </summary>
-    internal static class FilterGenerators
+    internal static Arbitrary<Filter> FiltersOverString()
     {
-        private readonly static Faker Faker = new();
-
-        /// <summary>
-        /// Generates a <see cref="Arbitrary{Filter}"/> where the value of the filter is a string
-        /// </summary>
-        internal static Arbitrary<Filter> FiltersOverString()
-        {
 #if NETCOREAPP3_1
             IEnumerable<FilterOperator> operators = EnumExtensions.GetValues<FilterOperator>();
 #else
-            IEnumerable<FilterOperator> operators = Enum.GetValues<FilterOperator>();
+        IEnumerable<FilterOperator> operators = Enum.GetValues<FilterOperator>();
 #endif
-            Gen<FilterOperator> genOperator = Gen.OneOf(operators.Select(op => Gen.Constant(op)));
+        Gen<FilterOperator> genOperator = Gen.OneOf(operators.Select(op => Gen.Constant(op)));
 
-            return genOperator.Zip(GetArbitraryFor<string>().Generator)
-                              .Select(tuple => (Op: tuple.Item1, Value: tuple.Item2))
-                              .Select(tuple => new Filter(Faker.Hacker.Noun(), tuple.Op, tuple.Value))
-                              .ToArbitrary();
-        }
+        return genOperator.Zip(GetArbitraryFor<string>().Generator)
+            .Select(tuple => (Op: tuple.Item1, Value: tuple.Item2))
+            .Select(tuple => new Filter(Faker.Hacker.Noun(), tuple.Op, tuple.Value))
+            .ToArbitrary();
+    }
 
-        /// <summary>
-        /// Generates a <see cref="Arbitrary{Filter}"/> where the value of the filter is a string
-        /// </summary>
-        internal static Arbitrary<Filter> FiltersOverNumericValues()
-        {
-            Gen<FilterOperator> genOperator = Gen.OneOf(Gen.Constant(FilterOperator.LessThan),
-                                                        Gen.Constant(FilterOperator.LessThanOrEqualTo),
-                                                        Gen.Constant(FilterOperator.EqualTo),
-                                                        Gen.Constant(FilterOperator.GreaterThan),
-                                                        Gen.Constant(FilterOperator.GreaterThanOrEqual),
-                                                        Gen.Constant(FilterOperator.NotEqualTo));
+    /// <summary>
+    /// Generates a <see cref="Arbitrary{Filter}"/> where the value of the filter is a string
+    /// </summary>
+    internal static Arbitrary<Filter> FiltersOverNumericValues()
+    {
+        Gen<FilterOperator> genOperator = Gen.OneOf(Gen.Constant(FilterOperator.LessThan),
+            Gen.Constant(FilterOperator.LessThanOrEqualTo),
+            Gen.Constant(FilterOperator.EqualTo),
+            Gen.Constant(FilterOperator.GreaterThan),
+            Gen.Constant(FilterOperator.GreaterThanOrEqual),
+            Gen.Constant(FilterOperator.NotEqualTo));
 
-            return Gen.OneOf(genOperator.Zip(GetArbitraryFor<int>().Generator)
-                                                         .Select(tuple => (Op: tuple.Item1, Value: tuple.Item2))
-                                                         .Select(tuple => new Filter(Faker.Hacker.Noun(), tuple.Op, tuple.Value)),
-                            genOperator.Zip(GetArbitraryFor<float>().Generator)
-                                                         .Select(tuple => (Op: tuple.Item1, Value: tuple.Item2))
-                                                         .Select(tuple => new Filter(Faker.Hacker.Noun(), tuple.Op, tuple.Value)),
-                            genOperator.Zip(GetArbitraryFor<long>().Generator)
-                                                         .Select(tuple => (Op: tuple.Item1, Value: tuple.Item2))
-                                                         .Select(tuple => new Filter(Faker.Hacker.Noun(), tuple.Op, tuple.Value))
-                                                         )
-                                                         .ToArbitrary()
-                                                         ;
-        }
+        return Gen.OneOf(genOperator.Zip(GetArbitraryFor<int>().Generator)
+                        .Select(tuple => (Op: tuple.Item1, Value: tuple.Item2))
+                        .Select(tuple => new Filter(Faker.Hacker.Noun(), tuple.Op, tuple.Value)),
+                    genOperator.Zip(GetArbitraryFor<float>().Generator)
+                        .Select(tuple => (Op: tuple.Item1, Value: tuple.Item2))
+                        .Select(tuple => new Filter(Faker.Hacker.Noun(), tuple.Op, tuple.Value)),
+                    genOperator.Zip(GetArbitraryFor<long>().Generator)
+                        .Select(tuple => (Op: tuple.Item1, Value: tuple.Item2))
+                        .Select(tuple => new Filter(Faker.Hacker.Noun(), tuple.Op, tuple.Value))
+                )
+                .ToArbitrary()
+            ;
+    }
 
-        /// <summary>
-        /// Generates a <see cref="Arbitrary{Filter}"/> where the value of the filter is a string
-        /// </summary>
-        internal static Arbitrary<Filter> FiltersOverGenericValues<T>()
-        {
+    /// <summary>
+    /// Generates a <see cref="Arbitrary{Filter}"/> where the value of the filter is a string
+    /// </summary>
+    internal static Arbitrary<Filter> FiltersOverGenericValues<T>()
+    {
 #if NETCOREAPP3_1
             IEnumerable<FilterOperator> operators = EnumExtensions.GetValues<FilterOperator>();
 #else
-            IEnumerable<FilterOperator> operators = Enum.GetValues<FilterOperator>();
+        IEnumerable<FilterOperator> operators = Enum.GetValues<FilterOperator>();
 #endif
-            Gen<FilterOperator> genOperator = Gen.OneOf(operators.Select(op => Gen.Constant(op)));
+        Gen<FilterOperator> genOperator = Gen.OneOf(operators.Select(op => Gen.Constant(op)));
 
-            return genOperator.Zip(GetArbitraryFor<T>().Generator)
-                                                         .Select(tuple => (Op: tuple.Item1, Value: tuple.Item2))
-                                                         .Select(tuple => new Filter(Faker.Hacker.Noun(), tuple.Op, tuple.Value))
-                                                         .ToArbitrary();
-        }
+        return genOperator.Zip(GetArbitraryFor<T>().Generator)
+            .Select(tuple => (Op: tuple.Item1, Value: tuple.Item2))
+            .Select(tuple => new Filter(Faker.Hacker.Noun(), tuple.Op, tuple.Value))
+            .ToArbitrary();
+    }
 
-        /// <summary>
-        /// Generates an arbitrary random <see cref="FilterExpression"/>.
-        /// </summary>
-        public static Arbitrary<IFilter> GenerateFilters()
+    /// <summary>
+    /// Generates an arbitrary random <see cref="FilterExpression"/>.
+    /// </summary>
+    public static Arbitrary<IFilter> GenerateFilters()
+    {
+        Gen<IFilter>[] generators =
+        [
+            EndsWithFilter().Generator.Select(filter => (IFilter)filter),
+            StartsWithFilter().Generator.Select(filter => (IFilter)filter),
+            ContainsFilter().Generator.Select(filter => (IFilter)filter),
+            EqualsWithFilter().Generator.Select(filter => (IFilter)filter),
+            Gen.Sized(SafeFilterGenerator).Select(filter => (IFilter)filter),
+            GreaterThanFilter<DateTime>(),
+            GreaterThanOrEqualFilter<DateTime>(),
+            LessThanFilter<DateTime>(),
+            LessThanOrEqualFilter<DateTime>(),
+            FiltersOverNumericValues().Generator.Select(filter => (IFilter)filter)
+        ];
+
+        return Gen.OneOf(generators).ToArbitrary();
+    }
+
+    internal static Arbitrary<Filter> EndsWithFilter() => GenerateFilterOverStrings(FilterOperator.EndsWith);
+
+    internal static Arbitrary<Filter> StartsWithFilter() => GenerateFilterOverStrings(FilterOperator.StartsWith);
+
+    internal static Arbitrary<Filter> ContainsFilter() => GenerateFilterOverStrings(FilterOperator.Contains);
+
+    internal static Arbitrary<Filter> EqualsWithFilter() => GenerateFilterOverStrings(FilterOperator.EqualTo);
+
+    internal static Arbitrary<Filter> GenerateFilterOverStrings(FilterOperator op)
+        => GetArbitraryFor<NonEmptyString>().Generator
+            .Select(value => new Filter(field: Faker.Hacker.Noun(), op, value))
+            .ToArbitrary();
+
+    private static Gen<MultiFilter> SafeFilterGenerator(int size)
+    {
+        Gen<MultiFilter> gen;
+        Gen<FilterLogic> generateLogic = Gen.OneOf(Gen.Constant(FilterLogic.And),
+            Gen.Constant(FilterLogic.Or));
+        switch (size)
         {
-            Gen<IFilter>[] generators =
-            [
-                EndsWithFilter().Generator.Select(filter => (IFilter)filter),
-                StartsWithFilter().Generator.Select(filter => (IFilter)filter),
-                ContainsFilter().Generator.Select(filter => (IFilter)filter),
-                EqualsWithFilter().Generator.Select(filter => (IFilter)filter),
-                Gen.Sized(SafeFilterGenerator).Select(filter => (IFilter)filter),
-                GreaterThanFilter<DateTime>(),
-                GreaterThanOrEqualFilter<DateTime>(),
-                LessThanFilter<DateTime>(),
-                LessThanOrEqualFilter<DateTime>(),
-                FiltersOverNumericValues().Generator.Select(filter => (IFilter)filter)
-            ];
-
-            return Gen.OneOf(generators).ToArbitrary();
-        }
-
-        internal static Arbitrary<Filter> EndsWithFilter() => GenerateFilterOverStrings(FilterOperator.EndsWith);
-
-        internal static Arbitrary<Filter> StartsWithFilter() => GenerateFilterOverStrings(FilterOperator.StartsWith);
-
-        internal static Arbitrary<Filter> ContainsFilter() => GenerateFilterOverStrings(FilterOperator.Contains);
-
-        internal static Arbitrary<Filter> EqualsWithFilter() => GenerateFilterOverStrings(FilterOperator.EqualTo);
-
-        internal static Arbitrary<Filter> GenerateFilterOverStrings(FilterOperator op)
-            => GetArbitraryFor<NonEmptyString>().Generator
-                                                .Select(value => new Filter(field: Faker.Hacker.Noun(), op, value))
-                                                .ToArbitrary();
-
-        private static Gen<MultiFilter> SafeFilterGenerator(int size)
-        {
-            Gen<MultiFilter> gen;
-            Gen<FilterLogic> generateLogic = Gen.OneOf(Gen.Constant(FilterLogic.And),
-                                                       Gen.Constant(FilterLogic.Or));
-            switch (size)
+            case 0:
             {
-                case 0:
-                    {
-                        gen = GenerateFilters().Generator.Two()
-                                               .Select(tuple => new[] { tuple.Item1, tuple.Item2 })
-                                               .Zip(generateLogic)
-                                               .Select(tuple => new MultiFilter { Logic = tuple.Item2, Filters = tuple.Item1 });
-                        break;
-                    }
-
-                default:
-                    {
-                        Gen<MultiFilter> subtree = SafeFilterGenerator(size / 2);
-
-                        gen = Gen.OneOf(GenerateFilters().Generator.Two()
-                                               .Select(tuple => new[] { tuple.Item1, tuple.Item2 })
-                                               .Zip(generateLogic)
-                                               .Select(tuple => new MultiFilter { Logic = tuple.Item2, Filters = tuple.Item1 }),
-                                        subtree);
-                        break;
-                    }
+                gen = GenerateFilters().Generator.Two()
+                    .Select(tuple => new[] { tuple.Item1, tuple.Item2 })
+                    .Zip(generateLogic)
+                    .Select(tuple => new MultiFilter { Logic = tuple.Item2, Filters = tuple.Item1 });
+                break;
             }
 
-            return gen;
+            default:
+            {
+                Gen<MultiFilter> subtree = SafeFilterGenerator(size / 2);
+
+                gen = Gen.OneOf(GenerateFilters().Generator.Two()
+                        .Select(tuple => new[] { tuple.Item1, tuple.Item2 })
+                        .Zip(generateLogic)
+                        .Select(tuple => new MultiFilter { Logic = tuple.Item2, Filters = tuple.Item1 }),
+                    subtree);
+                break;
+            }
         }
 
-        private static Gen<IFilter> GreaterThanFilter<TValue>()
-            => GenerateFilterWithSpecifiedOperatorAndValue<TValue>(FilterOperator.GreaterThan);
-
-        private static Gen<IFilter> GreaterThanOrEqualFilter<TValue>()
-            => GenerateFilterWithSpecifiedOperatorAndValue<TValue>(FilterOperator.GreaterThanOrEqual);
-
-        private static Gen<IFilter> LessThanOrEqualFilter<TValue>()
-            => GenerateFilterWithSpecifiedOperatorAndValue<TValue>(FilterOperator.LessThanOrEqualTo);
-
-        private static Gen<IFilter> LessThanFilter<TValue>()
-            => GenerateFilterWithSpecifiedOperatorAndValue<TValue>(FilterOperator.LessThanOrEqualTo);
-
-        private static Gen<IFilter> GenerateFilterWithSpecifiedOperatorAndValue<TValue>(FilterOperator op)
-            => GetArbitraryFor<TValue>().Generator
-                                        .Select(value => (IFilter)new Filter(Faker.Hacker.Noun(), op, value));
+        return gen;
     }
+
+    private static Gen<IFilter> GreaterThanFilter<TValue>()
+        => GenerateFilterWithSpecifiedOperatorAndValue<TValue>(FilterOperator.GreaterThan);
+
+    private static Gen<IFilter> GreaterThanOrEqualFilter<TValue>()
+        => GenerateFilterWithSpecifiedOperatorAndValue<TValue>(FilterOperator.GreaterThanOrEqual);
+
+    private static Gen<IFilter> LessThanOrEqualFilter<TValue>()
+        => GenerateFilterWithSpecifiedOperatorAndValue<TValue>(FilterOperator.LessThanOrEqualTo);
+
+    private static Gen<IFilter> LessThanFilter<TValue>()
+        => GenerateFilterWithSpecifiedOperatorAndValue<TValue>(FilterOperator.LessThanOrEqualTo);
+
+    private static Gen<IFilter> GenerateFilterWithSpecifiedOperatorAndValue<TValue>(FilterOperator op)
+        => GetArbitraryFor<TValue>().Generator
+            .Select(value => (IFilter)new Filter(Faker.Hacker.Noun(), op, value));
 }

--- a/test/DataFilters.UnitTests/MultiFilterTests.cs
+++ b/test/DataFilters.UnitTests/MultiFilterTests.cs
@@ -3,326 +3,325 @@ using static Newtonsoft.Json.JsonConvert;
 #else
 #endif
 
-namespace DataFilters.UnitTests
+namespace DataFilters.UnitTests;
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using DataFilters.UnitTests.Helpers;
+using FluentAssertions;
+using FsCheck;
+using FsCheck.Xunit;
+using Newtonsoft.Json.Linq;
+using Newtonsoft.Json.Schema;
+using Xunit;
+using Xunit.Abstractions;
+using Xunit.Categories;
+using static DataFilters.FilterLogic;
+using static DataFilters.FilterOperator;
+
+[UnitTest]
+public class MultiFilterTests(ITestOutputHelper output)
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Linq;
-    using System.Linq.Expressions;
-    using DataFilters.UnitTests.Helpers;
-    using FluentAssertions;
-    using FsCheck;
-    using FsCheck.Xunit;
-    using Newtonsoft.Json.Linq;
-    using Newtonsoft.Json.Schema;
-    using Xunit;
-    using Xunit.Abstractions;
-    using Xunit.Categories;
-    using static DataFilters.FilterLogic;
-    using static DataFilters.FilterOperator;
-
-    [UnitTest]
-    public class MultiFilterTests(ITestOutputHelper output)
+    public class Person
     {
-        public class Person
+        public string Firstname { get; set; }
+
+        public string Lastname { get; set; }
+
+        public DateTime BirthDate { get; set; }
+    }
+
+    public static TheoryData<MultiFilter, Expression<Func<string, bool>>> MultiFilterToJsonCases
+        => new()
         {
-            public string Firstname { get; set; }
-
-            public string Lastname { get; set; }
-
-            public DateTime BirthDate { get; set; }
-        }
-
-        public static TheoryData<MultiFilter, Expression<Func<string, bool>>> MultiFilterToJsonCases
-            => new()
             {
-                {
-                    new MultiFilter  {
-                        Logic = Or,
-                        Filters = new [] {
-                            new Filter (field : "Nickname", @operator : EqualTo, value : "Batman"),
-                            new Filter (field : "Nickname", @operator : EqualTo, value : "Robin")
-                        }
-                    },
-                    json =>
-                        JObject.Parse(json).IsValid(MultiFilter.Schema)
-                        && JObject.Parse(json).Properties().Exactly(2)
-
-                        && "or".Equals((string) JObject.Parse(json)[MultiFilter.LogicJsonPropertyName])
-
-                        && "Nickname".Equals((string)JObject.Parse(json)[MultiFilter.FiltersJsonPropertyName][0][Filter.FieldJsonPropertyName])
-                        && "eq".Equals((string)JObject.Parse(json)[MultiFilter.FiltersJsonPropertyName][0][Filter.OperatorJsonPropertyName])
-                        && "Batman".Equals((string)JObject.Parse(json)[MultiFilter.FiltersJsonPropertyName][0][Filter.ValueJsonPropertyName])
-                               &&
-                        "Nickname".Equals((string)JObject.Parse(json)[MultiFilter.FiltersJsonPropertyName][1][Filter.FieldJsonPropertyName])
-                        && "eq".Equals((string)JObject.Parse(json)[MultiFilter.FiltersJsonPropertyName][1][Filter.OperatorJsonPropertyName])
-                        && "Robin".Equals((string)JObject.Parse(json)[MultiFilter.FiltersJsonPropertyName][1][Filter.ValueJsonPropertyName])
-
-
-                },
-                {
-                    new MultiFilter  {
-                        Filters = new [] {
-                            new Filter (field : "Nickname", @operator : EqualTo, value : "Batman"),
-                            new Filter (field : "Nickname", @operator : EqualTo, value : "Robin")
-                        }
-                    },
-                    json =>
-                        JObject.Parse(json).IsValid(MultiFilter.Schema)
-                        && JObject.Parse(json).Properties().Count() == 2
-
-                        && "and".Equals((string) JObject.Parse(json)[MultiFilter.LogicJsonPropertyName])
-
-                        && "Nickname".Equals((string)JObject.Parse(json)[MultiFilter.FiltersJsonPropertyName][0][Filter.FieldJsonPropertyName])
-                        && "eq".Equals((string)JObject.Parse(json)[MultiFilter.FiltersJsonPropertyName][0][Filter.OperatorJsonPropertyName])
-                        && "Batman".Equals((string)JObject.Parse(json)[MultiFilter.FiltersJsonPropertyName][0][Filter.ValueJsonPropertyName])
-                               &&
-                        "Nickname".Equals((string)JObject.Parse(json)[MultiFilter.FiltersJsonPropertyName][1][Filter.FieldJsonPropertyName])
-                        && "eq".Equals((string)JObject.Parse(json)[MultiFilter.FiltersJsonPropertyName][1][Filter.OperatorJsonPropertyName])
-                        && "Robin".Equals((string)JObject.Parse(json)[MultiFilter.FiltersJsonPropertyName][1][Filter.ValueJsonPropertyName])
-
-
-                }
-            };
-
-
-        public static TheoryData<string, bool> CompositeFilterSchemaTestCases
-            => new()
-            {
-                {
-                    "{" +
-                        $"{MultiFilter.LogicJsonPropertyName} : 'or'," +
-                        $"{MultiFilter.FiltersJsonPropertyName}: [" +
-                            $"{{ {Filter.FieldJsonPropertyName} : 'nickname', {Filter.OperatorJsonPropertyName} : 'eq', {Filter.ValueJsonPropertyName} : 'batman' }}," +
-                            $"{{ {Filter.FieldJsonPropertyName} : 'nickname', {Filter.OperatorJsonPropertyName} : 'eq', {Filter.ValueJsonPropertyName} : 'robin' }}" +
-                        "]" +
-                    "}",
-                    true
-                },
-                {
-                    "{" +
-                        $"{MultiFilter.LogicJsonPropertyName} : 'and'," +
-                        $"{MultiFilter.FiltersJsonPropertyName}: [" +
-                            $"{{ {Filter.FieldJsonPropertyName} : 'nickname', {Filter.OperatorJsonPropertyName} : 'eq', {Filter.ValueJsonPropertyName} : 'batman' }}," +
-                            $"{{ {Filter.FieldJsonPropertyName} : 'nickname', {Filter.OperatorJsonPropertyName} : 'eq', {Filter.ValueJsonPropertyName} : 'robin' }}" +
-                        "]" +
-                    "}",
-                    true
-                },
-                {
-                    "{" +
-                        $"{MultiFilter.FiltersJsonPropertyName}: [" +
-                            $"{{ {Filter.FieldJsonPropertyName} : 'nickname', {Filter.OperatorJsonPropertyName} : 'eq', {Filter.ValueJsonPropertyName} : 'batman' }}," +
-                            $"{{ {Filter.FieldJsonPropertyName} : 'nickname', {Filter.OperatorJsonPropertyName} : 'eq', {Filter.ValueJsonPropertyName} : 'robin' }}" +
-                        "]" +
-                    "}",
-                    true
-                },
-                {
-                    "{" +
-                        $"{MultiFilter.FiltersJsonPropertyName}: [" +
-                            $"{{ {Filter.FieldJsonPropertyName} : 'nickname', {Filter.OperatorJsonPropertyName} : 'eq', {Filter.ValueJsonPropertyName} : 'robin' }}" +
-                        "]" +
-                    "}",
-                    false
-                }
-            };
-
-        [Theory]
-        [MemberData(nameof(MultiFilterToJsonCases))]
-        public void MultiFilterToJson(MultiFilter filter, Expression<Func<string, bool>> jsonMatcher)
-        {
-            output.WriteLine($"Testing : {filter}{Environment.NewLine} against {Environment.NewLine} {jsonMatcher} ");
-
-            // Act
-            string json = filter.ToJson();
-
-            output.WriteLine($"{nameof(json)} : {json}");
-
-            // Assert
-            json.Should().Match(jsonMatcher);
-        }
-
-        public static TheoryData<MultiFilter, object, bool, string> EqualsCases
-        {
-            get
-            {
-                TheoryData<MultiFilter, object, bool, string> cases = new()
-                {
-                    {
-                        new MultiFilter
-                        {
-                            Logic = And,
-                            Filters = new IFilter[]{
-                                new Filter("property", EqualTo, "value"),
-                                new Filter("property", EqualTo, "value"),
-                            }
-                        },
-                        new MultiFilter
-                        {
-                            Logic = And,
-                            Filters = new IFilter[]{
-                                new Filter("property", EqualTo, "value"),
-                                new Filter("property", EqualTo, "value"),
-                            }
-                        },
-                        true,
-                        $"Two instances of {nameof(MultiFilter)} contains same ${nameof(MultiFilter.Filters)} in same order"
-                    },
-                    {
-                        new MultiFilter
-                        {
-                            Logic = And,
-                            Filters = new IFilter[]{
-                                new Filter("property", EqualTo, "value"),
-                                new Filter("property", EqualTo, "value"),
-                            }
-                        },
-                        new MultiFilter
-                        {
-                            Logic = And,
-                            Filters = new IFilter[]{
-                                new Filter("property", NotEqualTo, "value"),
-                                new Filter("property", EqualTo, "value"),
-                            }
-                        },
-                        false,
-                        "the second instance contains one filter that has a different operator"
-                    },
-                    {
-                        new MultiFilter
-                        {
-                            Logic = And,
-                            Filters = new IFilter[]{
-                                new Filter("property", EqualTo, "value"),
-                                new Filter("property", EqualTo, "value"),
-                            }
-                        },
-                        null,
-                        false,
-                        "comparing to null"
+                new MultiFilter  {
+                    Logic = Or,
+                    Filters = new [] {
+                        new Filter (field : "Nickname", @operator : EqualTo, value : "Batman"),
+                        new Filter (field : "Nickname", @operator : EqualTo, value : "Robin")
                     }
-                };
+                },
+                json =>
+                    JObject.Parse(json).IsValid(MultiFilter.Schema)
+                    && JObject.Parse(json).Properties().Exactly(2)
 
+                    && "or".Equals((string) JObject.Parse(json)[MultiFilter.LogicJsonPropertyName])
+
+                    && "Nickname".Equals((string)JObject.Parse(json)[MultiFilter.FiltersJsonPropertyName][0][Filter.FieldJsonPropertyName])
+                    && "eq".Equals((string)JObject.Parse(json)[MultiFilter.FiltersJsonPropertyName][0][Filter.OperatorJsonPropertyName])
+                    && "Batman".Equals((string)JObject.Parse(json)[MultiFilter.FiltersJsonPropertyName][0][Filter.ValueJsonPropertyName])
+                    &&
+                    "Nickname".Equals((string)JObject.Parse(json)[MultiFilter.FiltersJsonPropertyName][1][Filter.FieldJsonPropertyName])
+                    && "eq".Equals((string)JObject.Parse(json)[MultiFilter.FiltersJsonPropertyName][1][Filter.OperatorJsonPropertyName])
+                    && "Robin".Equals((string)JObject.Parse(json)[MultiFilter.FiltersJsonPropertyName][1][Filter.ValueJsonPropertyName])
+
+
+            },
+            {
+                new MultiFilter  {
+                    Filters = new [] {
+                        new Filter (field : "Nickname", @operator : EqualTo, value : "Batman"),
+                        new Filter (field : "Nickname", @operator : EqualTo, value : "Robin")
+                    }
+                },
+                json =>
+                    JObject.Parse(json).IsValid(MultiFilter.Schema)
+                    && JObject.Parse(json).Properties().Count() == 2
+
+                    && "and".Equals((string) JObject.Parse(json)[MultiFilter.LogicJsonPropertyName])
+
+                    && "Nickname".Equals((string)JObject.Parse(json)[MultiFilter.FiltersJsonPropertyName][0][Filter.FieldJsonPropertyName])
+                    && "eq".Equals((string)JObject.Parse(json)[MultiFilter.FiltersJsonPropertyName][0][Filter.OperatorJsonPropertyName])
+                    && "Batman".Equals((string)JObject.Parse(json)[MultiFilter.FiltersJsonPropertyName][0][Filter.ValueJsonPropertyName])
+                    &&
+                    "Nickname".Equals((string)JObject.Parse(json)[MultiFilter.FiltersJsonPropertyName][1][Filter.FieldJsonPropertyName])
+                    && "eq".Equals((string)JObject.Parse(json)[MultiFilter.FiltersJsonPropertyName][1][Filter.OperatorJsonPropertyName])
+                    && "Robin".Equals((string)JObject.Parse(json)[MultiFilter.FiltersJsonPropertyName][1][Filter.ValueJsonPropertyName])
+
+
+            }
+        };
+
+
+    public static TheoryData<string, bool> CompositeFilterSchemaTestCases
+        => new()
+        {
+            {
+                "{" +
+                $"{MultiFilter.LogicJsonPropertyName} : 'or'," +
+                $"{MultiFilter.FiltersJsonPropertyName}: [" +
+                $"{{ {Filter.FieldJsonPropertyName} : 'nickname', {Filter.OperatorJsonPropertyName} : 'eq', {Filter.ValueJsonPropertyName} : 'batman' }}," +
+                $"{{ {Filter.FieldJsonPropertyName} : 'nickname', {Filter.OperatorJsonPropertyName} : 'eq', {Filter.ValueJsonPropertyName} : 'robin' }}" +
+                "]" +
+                "}",
+                true
+            },
+            {
+                "{" +
+                $"{MultiFilter.LogicJsonPropertyName} : 'and'," +
+                $"{MultiFilter.FiltersJsonPropertyName}: [" +
+                $"{{ {Filter.FieldJsonPropertyName} : 'nickname', {Filter.OperatorJsonPropertyName} : 'eq', {Filter.ValueJsonPropertyName} : 'batman' }}," +
+                $"{{ {Filter.FieldJsonPropertyName} : 'nickname', {Filter.OperatorJsonPropertyName} : 'eq', {Filter.ValueJsonPropertyName} : 'robin' }}" +
+                "]" +
+                "}",
+                true
+            },
+            {
+                "{" +
+                $"{MultiFilter.FiltersJsonPropertyName}: [" +
+                $"{{ {Filter.FieldJsonPropertyName} : 'nickname', {Filter.OperatorJsonPropertyName} : 'eq', {Filter.ValueJsonPropertyName} : 'batman' }}," +
+                $"{{ {Filter.FieldJsonPropertyName} : 'nickname', {Filter.OperatorJsonPropertyName} : 'eq', {Filter.ValueJsonPropertyName} : 'robin' }}" +
+                "]" +
+                "}",
+                true
+            },
+            {
+                "{" +
+                $"{MultiFilter.FiltersJsonPropertyName}: [" +
+                $"{{ {Filter.FieldJsonPropertyName} : 'nickname', {Filter.OperatorJsonPropertyName} : 'eq', {Filter.ValueJsonPropertyName} : 'robin' }}" +
+                "]" +
+                "}",
+                false
+            }
+        };
+
+    [Theory]
+    [MemberData(nameof(MultiFilterToJsonCases))]
+    public void MultiFilterToJson(MultiFilter filter, Expression<Func<string, bool>> jsonMatcher)
+    {
+        output.WriteLine($"Testing : {filter}{Environment.NewLine} against {Environment.NewLine} {jsonMatcher} ");
+
+        // Act
+        string json = filter.ToJson();
+
+        output.WriteLine($"{nameof(json)} : {json}");
+
+        // Assert
+        json.Should().Match(jsonMatcher);
+    }
+
+    public static TheoryData<MultiFilter, object, bool, string> EqualsCases
+    {
+        get
+        {
+            TheoryData<MultiFilter, object, bool, string> cases = new()
+            {
                 {
-                    MultiFilter filter = new()
+                    new MultiFilter
                     {
                         Logic = And,
                         Filters = new IFilter[]{
                             new Filter("property", EqualTo, "value"),
                             new Filter("property", EqualTo, "value"),
                         }
-                    };
-
-                    cases.Add
-                    (
-                        filter,
-                        filter,
-                        true,
-                        "comparing a too itself must always returns true"
-                    );
+                    },
+                    new MultiFilter
+                    {
+                        Logic = And,
+                        Filters = new IFilter[]{
+                            new Filter("property", EqualTo, "value"),
+                            new Filter("property", EqualTo, "value"),
+                        }
+                    },
+                    true,
+                    $"Two instances of {nameof(MultiFilter)} contains same ${nameof(MultiFilter.Filters)} in same order"
+                },
+                {
+                    new MultiFilter
+                    {
+                        Logic = And,
+                        Filters = new IFilter[]{
+                            new Filter("property", EqualTo, "value"),
+                            new Filter("property", EqualTo, "value"),
+                        }
+                    },
+                    new MultiFilter
+                    {
+                        Logic = And,
+                        Filters = new IFilter[]{
+                            new Filter("property", NotEqualTo, "value"),
+                            new Filter("property", EqualTo, "value"),
+                        }
+                    },
+                    false,
+                    "the second instance contains one filter that has a different operator"
+                },
+                {
+                    new MultiFilter
+                    {
+                        Logic = And,
+                        Filters = new IFilter[]{
+                            new Filter("property", EqualTo, "value"),
+                            new Filter("property", EqualTo, "value"),
+                        }
+                    },
+                    null,
+                    false,
+                    "comparing to null"
                 }
+            };
 
-                cases.Add(
-                        new MultiFilter
-                        {
-                            Logic = And,
-                            Filters = new IFilter[]
-                            {
-                                new Filter("HasSuperpower", EqualTo, false),
-                                new MultiFilter
-                                {
-                                    Logic = Or,
-                                    Filters = new IFilter[]
-                                    {
-                                        new Filter("Lastname", EqualTo, "Wayne"),
-                                        new Filter("Lastname", EqualTo, "Kent")
-                                    }
-                                }
-                            }
-                        },
-                        new MultiFilter
-                        {
-                            Logic = And,
-                            Filters = new IFilter[]
-                            {
-                                new Filter("HasSuperpower", EqualTo, false),
-                                new MultiFilter
-                                {
-                                    Logic = Or,
-                                    Filters = new []
-                                    {
-                                        new Filter("Lastname", EqualTo, "Wayne"),
-                                        new Filter("Lastname", EqualTo, "Kent")
-                                    }
-                                }
-                            }
-                        },
-                        true,
-                        "Two distinct instances of multifilters that holds same data in same order"
-                    );
+            {
+                MultiFilter filter = new()
+                {
+                    Logic = And,
+                    Filters = new IFilter[]{
+                        new Filter("property", EqualTo, "value"),
+                        new Filter("property", EqualTo, "value"),
+                    }
+                };
 
-                return cases;
+                cases.Add
+                (
+                    filter,
+                    filter,
+                    true,
+                    "comparing a too itself must always returns true"
+                );
             }
-        }
 
-        [Theory]
-        [MemberData(nameof(EqualsCases))]
-        public void CompositeFilterImplementsEquatableProperly(MultiFilter first, object second, bool expectedResult, string reason)
-        {
-            output.WriteLine($"first : {first}");
-            output.WriteLine($"second : {second}");
-
-            // Act
-            bool result = first.Equals(second);
-
-            // Assert
-            result.Should()
-                  .Be(expectedResult, reason);
-        }
-
-        [Theory]
-        [MemberData(nameof(CompositeFilterSchemaTestCases))]
-        public void CompositeFilterSchema(string json, bool expectedValidity)
-        {
-            output.WriteLine($"{nameof(json)} : {json}");
-
-            // Arrange
-            JSchema schema = MultiFilter.Schema;
-
-            // Act
-            bool isValid = JObject.Parse(json).IsValid(schema);
-
-            // Assert
-            isValid.Should().Be(expectedValidity);
-        }
-
-        [Property(Arbitrary = [typeof(FilterGenerators)])]
-        public void Given_filter_instance_Negate_should_work_as_expected(FilterLogic logic, NonEmptyArray<IFilter> source)
-        {
-            // Arrange
-            MultiFilter original = new() { Logic = logic, Filters = source.Item };
-
-            // Act
-            IFilter oppositeFilter = original.Negate();
-
-            // Assert
-            MultiFilter result = oppositeFilter.Should()
-                          .BeOfType<MultiFilter>()
-                          .Which;
-
-            result.Logic.Should()
-                        .Be(original.Logic switch
+            cases.Add(
+                new MultiFilter
+                {
+                    Logic = And,
+                    Filters = new IFilter[]
+                    {
+                        new Filter("HasSuperpower", EqualTo, false),
+                        new MultiFilter
                         {
-                            And => Or,
-                            Or => And,
-                            _ => throw new NotSupportedException($"The original {original.Logic} logic is not supported"),
-                        }, "the logic of the resulting filter should be the opposite of the original filter's logic");
+                            Logic = Or,
+                            Filters = new IFilter[]
+                            {
+                                new Filter("Lastname", EqualTo, "Wayne"),
+                                new Filter("Lastname", EqualTo, "Kent")
+                            }
+                        }
+                    }
+                },
+                new MultiFilter
+                {
+                    Logic = And,
+                    Filters = new IFilter[]
+                    {
+                        new Filter("HasSuperpower", EqualTo, false),
+                        new MultiFilter
+                        {
+                            Logic = Or,
+                            Filters = new []
+                            {
+                                new Filter("Lastname", EqualTo, "Wayne"),
+                                new Filter("Lastname", EqualTo, "Kent")
+                            }
+                        }
+                    }
+                },
+                true,
+                "Two distinct instances of multifilters that holds same data in same order"
+            );
 
-            IEnumerable<IFilter> expected = source.Item.Select(filter => filter.Negate());
-            result.Filters.Should()
-                    .HaveSameCount(original.Filters).And
-                    .ContainInOrder(expected);
+            return cases;
         }
+    }
+
+    [Theory]
+    [MemberData(nameof(EqualsCases))]
+    public void CompositeFilterImplementsEquatableProperly(MultiFilter first, object second, bool expectedResult, string reason)
+    {
+        output.WriteLine($"first : {first}");
+        output.WriteLine($"second : {second}");
+
+        // Act
+        bool result = first.Equals(second);
+
+        // Assert
+        result.Should()
+            .Be(expectedResult, reason);
+    }
+
+    [Theory]
+    [MemberData(nameof(CompositeFilterSchemaTestCases))]
+    public void CompositeFilterSchema(string json, bool expectedValidity)
+    {
+        output.WriteLine($"{nameof(json)} : {json}");
+
+        // Arrange
+        JSchema schema = MultiFilter.Schema;
+
+        // Act
+        bool isValid = JObject.Parse(json).IsValid(schema);
+
+        // Assert
+        isValid.Should().Be(expectedValidity);
+    }
+
+    [Property(Arbitrary = [typeof(FilterGenerators)])]
+    public void Given_filter_instance_Negate_should_work_as_expected(FilterLogic logic, NonEmptyArray<IFilter> source)
+    {
+        // Arrange
+        MultiFilter original = new() { Logic = logic, Filters = source.Item };
+
+        // Act
+        IFilter oppositeFilter = original.Negate();
+
+        // Assert
+        MultiFilter result = oppositeFilter.Should()
+            .BeOfType<MultiFilter>()
+            .Which;
+
+        result.Logic.Should()
+            .Be(original.Logic switch
+            {
+                And => Or,
+                Or => And,
+                _ => throw new NotSupportedException($"The original {original.Logic} logic is not supported"),
+            }, "the logic of the resulting filter should be the opposite of the original filter's logic");
+
+        IEnumerable<IFilter> expected = source.Item.Select(filter => filter.Negate());
+        result.Filters.Should()
+            .HaveSameCount(original.Filters).And
+            .ContainInOrder(expected);
     }
 }

--- a/test/DataFilters.UnitTests/MultiOrderTests.cs
+++ b/test/DataFilters.UnitTests/MultiOrderTests.cs
@@ -1,93 +1,92 @@
-﻿namespace DataFilters.UnitTests
+﻿namespace DataFilters.UnitTests;
+
+using DataFilters.TestObjects;
+using FluentAssertions;
+using Xunit;
+using Xunit.Abstractions;
+using static DataFilters.OrderDirection;
+
+public class MultiOrderTests(ITestOutputHelper outputHelper)
 {
-    using DataFilters.TestObjects;
-    using FluentAssertions;
-    using Xunit;
-    using Xunit.Abstractions;
-    using static DataFilters.OrderDirection;
-
-    public class MultiOrderTests(ITestOutputHelper outputHelper)
+    public static TheoryData<MultiOrder<SuperHero>, object, bool, string> EqualsCases
     {
-        public static TheoryData<MultiOrder<SuperHero>, object, bool, string> EqualsCases
+        get
         {
-            get
+            TheoryData<MultiOrder<SuperHero>, object, bool, string> cases = [];
             {
-                TheoryData<MultiOrder<SuperHero>, object, bool, string> cases = [];
-                {
-                    MultiOrder<SuperHero> first = new(
-                        new Order<SuperHero>(expression: nameof(SuperHero.Nickname)),
-                        new Order<SuperHero>(expression: nameof(SuperHero.Age), direction: Descending)
-                    );
+                MultiOrder<SuperHero> first = new(
+                    new Order<SuperHero>(expression: nameof(SuperHero.Nickname)),
+                    new Order<SuperHero>(expression: nameof(SuperHero.Age), direction: Descending)
+                );
 
-                    cases.Add
-                    (
-                        first,
-                        first,
-                        true,
-                        $"A {nameof(MultiOrder<SuperHero>)} instance is equal to itself"
-                    );
-                }
-                {
-                    MultiOrder<SuperHero> first = new(
-                        new Order<SuperHero>(expression: nameof(SuperHero.Nickname)),
-                        new Order<SuperHero>(expression: nameof(SuperHero.Age), direction: Descending)
-                    );
-
-                    MultiOrder<SuperHero> second = new
-                    (
-                        new Order<SuperHero>(expression: nameof(SuperHero.Nickname)),
-                        new Order<SuperHero>(expression: nameof(SuperHero.Age), direction: Descending)
-                    );
-
-                    cases.Add
-                    (
-                        first,
-                        second,
-                        true,
-                        $"Two distinct {nameof(MultiOrder<SuperHero>)} instances holding same data in same order"
-                    );
-                }
-
-                {
-                    MultiOrder<SuperHero> first = new
-                    (
-                        new Order<SuperHero>(expression: nameof(SuperHero.Nickname)),
-                        new Order<SuperHero>(expression: nameof(SuperHero.Age), direction: Descending)
-                    );
-
-                    MultiOrder<SuperHero> second = new
-                    (
-                        new Order<SuperHero>(expression: nameof(SuperHero.Age), direction: Descending),
-                        new Order<SuperHero>(expression: nameof(SuperHero.Nickname))
-                    );
-
-                    cases.Add
-                    (
-                        first,
-                        second,
-                        false,
-                        $"Two distinct {nameof(MultiOrder<SuperHero>)} instances holding same data but not same order"
-                    );
-                }
-
-                return cases;
+                cases.Add
+                (
+                    first,
+                    first,
+                    true,
+                    $"A {nameof(MultiOrder<SuperHero>)} instance is equal to itself"
+                );
             }
+            {
+                MultiOrder<SuperHero> first = new(
+                    new Order<SuperHero>(expression: nameof(SuperHero.Nickname)),
+                    new Order<SuperHero>(expression: nameof(SuperHero.Age), direction: Descending)
+                );
+
+                MultiOrder<SuperHero> second = new
+                (
+                    new Order<SuperHero>(expression: nameof(SuperHero.Nickname)),
+                    new Order<SuperHero>(expression: nameof(SuperHero.Age), direction: Descending)
+                );
+
+                cases.Add
+                (
+                    first,
+                    second,
+                    true,
+                    $"Two distinct {nameof(MultiOrder<SuperHero>)} instances holding same data in same order"
+                );
+            }
+
+            {
+                MultiOrder<SuperHero> first = new
+                (
+                    new Order<SuperHero>(expression: nameof(SuperHero.Nickname)),
+                    new Order<SuperHero>(expression: nameof(SuperHero.Age), direction: Descending)
+                );
+
+                MultiOrder<SuperHero> second = new
+                (
+                    new Order<SuperHero>(expression: nameof(SuperHero.Age), direction: Descending),
+                    new Order<SuperHero>(expression: nameof(SuperHero.Nickname))
+                );
+
+                cases.Add
+                (
+                    first,
+                    second,
+                    false,
+                    $"Two distinct {nameof(MultiOrder<SuperHero>)} instances holding same data but not same order"
+                );
+            }
+
+            return cases;
         }
+    }
 
-        [Theory]
-        [MemberData(nameof(EqualsCases))]
-        public void EqualsTests(IOrder<SuperHero> first, object second, bool expected, string reason)
-        {
-            outputHelper.WriteLine($"{nameof(first)} : '{first}'");
-            outputHelper.WriteLine($"{nameof(second)} : '{second}'");
+    [Theory]
+    [MemberData(nameof(EqualsCases))]
+    public void EqualsTests(IOrder<SuperHero> first, object second, bool expected, string reason)
+    {
+        outputHelper.WriteLine($"{nameof(first)} : '{first}'");
+        outputHelper.WriteLine($"{nameof(second)} : '{second}'");
 
-            // Act
-            bool actual = first.Equals(second);
-            int actualHashCode = first.GetHashCode();
+        // Act
+        bool actual = first.Equals(second);
+        int actualHashCode = first.GetHashCode();
 
-            // Assert
-            actual.Should()
-                .Be(expected, reason);
-        }
+        // Assert
+        actual.Should()
+            .Be(expected, reason);
     }
 }

--- a/test/DataFilters.UnitTests/OrderTests.cs
+++ b/test/DataFilters.UnitTests/OrderTests.cs
@@ -1,77 +1,76 @@
-﻿namespace DataFilters.UnitTests
+﻿namespace DataFilters.UnitTests;
+
+using System;
+using DataFilters.TestObjects;
+using FluentAssertions;
+using Xunit;
+using Xunit.Abstractions;
+using static DataFilters.OrderDirection;
+
+public class OrderTests(ITestOutputHelper outputHelper)
 {
-    using System;
-    using DataFilters.TestObjects;
-    using FluentAssertions;
-    using Xunit;
-    using Xunit.Abstractions;
-    using static DataFilters.OrderDirection;
-
-    public class OrderTests(ITestOutputHelper outputHelper)
+    [Theory]
+    [InlineData("", "Expression is empty")]
+    [InlineData(" ", "Expression is whitespace only")]
+    [InlineData(null, "Expression is null")]
+    public void Ctor_Throws_ArgumentException_If_Expression_Is_Null(string expression, string reason)
     {
-        [Theory]
-        [InlineData("", "Expression is empty")]
-        [InlineData(" ", "Expression is whitespace only")]
-        [InlineData(null, "Expression is null")]
-        public void Ctor_Throws_ArgumentException_If_Expression_Is_Null(string expression, string reason)
+        // Act
+        Action action = () => _ = new Order<object>(expression);
+
+        // Assert
+        action.Should()
+            .Throw<ArgumentException>(reason)
+            .Where(ex => !string.IsNullOrWhiteSpace(ex.ParamName), "Param name cannot be null")
+            .Where(ex => !string.IsNullOrWhiteSpace(ex.Message), "Message cannot be null");
+    }
+
+    public static TheoryData<Order<SuperHero>, object, bool, string> EqualsCases
+    {
+        get
         {
-            // Act
-            Action action = () => _ = new Order<object>(expression);
+            TheoryData<Order<SuperHero>, object, bool, string> cases = [];
+            cases.Add
+            (
+                new Order<SuperHero>("Name"),
+                new Order<SuperHero>("Name"),
+                true,
+                $"Two distinct {nameof(Order<SuperHero>)} instances with same properties must be equal"
+            );
 
-            // Assert
-            action.Should()
-                .Throw<ArgumentException>(reason)
-                .Where(ex => !string.IsNullOrWhiteSpace(ex.ParamName), "Param name cannot be null")
-                .Where(ex => !string.IsNullOrWhiteSpace(ex.Message), "Message cannot be null");
+            Order<SuperHero> sort = new("Name");
+            cases.Add
+            (
+                sort,
+                sort,
+                true,
+                $"A {nameof(Order<SuperHero>)} instance is equal to itself"
+            );
+
+            cases.Add
+            (
+                new Order<SuperHero>("Name", Descending),
+                new Order<SuperHero>("Name"),
+                false,
+                $"Two distinct {nameof(Order<SuperHero>)} instances with same {nameof(Order<SuperHero>.Expression)} but different {nameof(Order<SuperHero>.Direction)} must not be equal"
+            );
+
+            return cases;
         }
+    }
 
-        public static TheoryData<Order<SuperHero>, object, bool, string> EqualsCases
-        {
-            get
-            {
-                TheoryData<Order<SuperHero>, object, bool, string> cases = [];
-                cases.Add
-                (
-                    new Order<SuperHero>("Name"),
-                    new Order<SuperHero>("Name"),
-                    true,
-                    $"Two distinct {nameof(Order<SuperHero>)} instances with same properties must be equal"
-                );
+    [Theory]
+    [MemberData(nameof(EqualsCases))]
+    public void EqualsTests(Order<SuperHero> first, object second, bool expected, string reason)
+    {
+        outputHelper.WriteLine($"{nameof(first)} : '{first}'");
+        outputHelper.WriteLine($"{nameof(second)} : '{second}'");
 
-                Order<SuperHero> sort = new("Name");
-                cases.Add
-                (
-                    sort,
-                    sort,
-                    true,
-                    $"A {nameof(Order<SuperHero>)} instance is equal to itself"
-                );
+        // Act
+        bool actual = first.Equals(second);
 
-                cases.Add
-                (
-                    new Order<SuperHero>("Name", Descending),
-                    new Order<SuperHero>("Name"),
-                    false,
-                    $"Two distinct {nameof(Order<SuperHero>)} instances with same {nameof(Order<SuperHero>.Expression)} but different {nameof(Order<SuperHero>.Direction)} must not be equal"
-                );
-
-                return cases;
-            }
-        }
-
-        [Theory]
-        [MemberData(nameof(EqualsCases))]
-        public void EqualsTests(Order<SuperHero> first, object second, bool expected, string reason)
-        {
-            outputHelper.WriteLine($"{nameof(first)} : '{first}'");
-            outputHelper.WriteLine($"{nameof(second)} : '{second}'");
-
-            // Act
-            bool actual = first.Equals(second);
-
-            // Assert
-            actual.Should()
-                .Be(expected, reason);
-        }
+        // Assert
+        actual.Should()
+            .Be(expected, reason);
     }
 }

--- a/test/DataFilters.UnitTests/OrderValidatorTests.cs
+++ b/test/DataFilters.UnitTests/OrderValidatorTests.cs
@@ -1,37 +1,36 @@
-namespace DataFilters.UnitTests
+namespace DataFilters.UnitTests;
+
+using FluentAssertions;
+
+using FluentValidation.Results;
+
+using Xunit;
+using Xunit.Categories;
+
+[UnitTest]
+[Feature("Ordering")]
+public class OrderValidatorTests
 {
-    using FluentAssertions;
+    private readonly OrderValidator _sut;
 
-    using FluentValidation.Results;
-
-    using Xunit;
-    using Xunit.Categories;
-
-    [UnitTest]
-    [Feature("Ordering")]
-    public class OrderValidatorTests
+    public OrderValidatorTests()
     {
-        private readonly OrderValidator _sut;
+        _sut = new();
+    }
 
-        public OrderValidatorTests()
-        {
-            _sut = new();
-        }
+    [Theory]
+    [InlineData("", false, "Empty order")]
+    [InlineData(" ", false, "Whitespace order")]
+    [InlineData(@"prop[""subprop""]", true, "order by a sub-property")]
+    [InlineData(@"prop[""subprop1""][""subprop2""]", true, "order by second level sub-property")]
+    [InlineData(@"+prop[""subprop1""][""subprop2""], -prop[""subprop1""][""subprop3""]", true, "order by a second level sub-property")]
+    public void Validate(string sort, bool expected, string reason)
+    {
+        // Act
+        ValidationResult validationResult = _sut.Validate(sort);
 
-        [Theory]
-        [InlineData("", false, "Empty order")]
-        [InlineData(" ", false, "Whitespace order")]
-        [InlineData(@"prop[""subprop""]", true, "order by a sub-property")]
-        [InlineData(@"prop[""subprop1""][""subprop2""]", true, "order by second level sub-property")]
-        [InlineData(@"+prop[""subprop1""][""subprop2""], -prop[""subprop1""][""subprop3""]", true, "order by a second level sub-property")]
-        public void Validate(string sort, bool expected, string reason)
-        {
-            // Act
-            ValidationResult validationResult = _sut.Validate(sort);
-
-            // Assert
-            validationResult.IsValid.Should()
-                                    .Be(expected, reason);
-        }
+        // Assert
+        validationResult.IsValid.Should()
+            .Be(expected, reason);
     }
 }

--- a/test/DataFilters.UnitTests/StringExtensionsTests.cs
+++ b/test/DataFilters.UnitTests/StringExtensionsTests.cs
@@ -1,140 +1,139 @@
-﻿namespace DataFilters.UnitTests
+﻿namespace DataFilters.UnitTests;
+
+using System;
+using DataFilters.Casing;
+using DataFilters.TestObjects;
+using FluentAssertions;
+using Xunit;
+using Xunit.Abstractions;
+using static DataFilters.OrderDirection;
+
+public class StringExtensionsTests(ITestOutputHelper outputHelper)
 {
-    using System;
-    using DataFilters.Casing;
-    using DataFilters.TestObjects;
-    using FluentAssertions;
-    using Xunit;
-    using Xunit.Abstractions;
-    using static DataFilters.OrderDirection;
-
-    public class StringExtensionsTests(ITestOutputHelper outputHelper)
+    [Theory]
+    [InlineData(null, "sort expression cannot be null")]
+    [InlineData("  ", "sort expression cannot be whitespace only")]
+    public void Throws_ArgumentNullException_When_Parameter_IsNull(string source, string reason)
     {
-        [Theory]
-        [InlineData(null, "sort expression cannot be null")]
-        [InlineData("  ", "sort expression cannot be whitespace only")]
-        public void Throws_ArgumentNullException_When_Parameter_IsNull(string source, string reason)
+        // Act
+        Action action = () => source.ToSort<SuperHero>();
+
+        // Assert
+        action.Should()
+            .ThrowExactly<ArgumentOutOfRangeException>(reason)
+            .Where(ex => !string.IsNullOrWhiteSpace(ex.ParamName), $"{nameof(ArgumentOutOfRangeException.ParamName)} must not be null")
+            .Where(ex => !string.IsNullOrWhiteSpace(ex.Message), $"{nameof(ArgumentOutOfRangeException.Message)} must not be null");
+    }
+
+    [Theory]
+    [InlineData("prop1 prop2", "sort expression contains two properties that are not separated by a comma")]
+    [InlineData("prop1,prop2,", "sort expression cannot ends with a comma")]
+    [InlineData(",prop1,prop2", "sort expression cannot starts with a comma")]
+    [InlineData("--prop", "sort expression can start with only one hyphen")]
+    public void Given_invalid_expression_ToSort_throws_InvalidSortExpression(string invalidExpression, string reason)
+    {
+        // Act
+        Action action = () => invalidExpression.ToSort<SuperHero>();
+
+        // Assert
+        action.Should()
+            .ThrowExactly<InvalidOrderExpressionException>(reason)
+            .Where(ex => !string.IsNullOrWhiteSpace(ex.Message), $"{nameof(ArgumentOutOfRangeException.Message)} must not be null");
+    }
+
+    public static TheoryData<string, IOrder<SuperHero>> ToSortCases
+        => new()
         {
-            // Act
-            Action action = () => source.ToSort<SuperHero>();
-
-            // Assert
-            action.Should()
-                .ThrowExactly<ArgumentOutOfRangeException>(reason)
-                .Where(ex => !string.IsNullOrWhiteSpace(ex.ParamName), $"{nameof(ArgumentOutOfRangeException.ParamName)} must not be null")
-                .Where(ex => !string.IsNullOrWhiteSpace(ex.Message), $"{nameof(ArgumentOutOfRangeException.Message)} must not be null");
-        }
-
-        [Theory]
-        [InlineData("prop1 prop2", "sort expression contains two properties that are not separated by a comma")]
-        [InlineData("prop1,prop2,", "sort expression cannot ends with a comma")]
-        [InlineData(",prop1,prop2", "sort expression cannot starts with a comma")]
-        [InlineData("--prop", "sort expression can start with only one hyphen")]
-        public void Given_invalid_expression_ToSort_throws_InvalidSortExpression(string invalidExpression, string reason)
-        {
-            // Act
-            Action action = () => invalidExpression.ToSort<SuperHero>();
-
-            // Assert
-            action.Should()
-                .ThrowExactly<InvalidOrderExpressionException>(reason)
-                .Where(ex => !string.IsNullOrWhiteSpace(ex.Message), $"{nameof(ArgumentOutOfRangeException.Message)} must not be null");
-        }
-
-        public static TheoryData<string, IOrder<SuperHero>> ToSortCases
-            => new()
             {
-                {
-                    nameof(SuperHero.Nickname),
-                    new Order<SuperHero>(expression : nameof(SuperHero.Nickname), direction : Ascending)
-                },
-                {
-                    $"+{nameof(SuperHero.Nickname)}",
-                    new Order<SuperHero>(expression : nameof(SuperHero.Nickname), direction : Ascending)
-                },
-                {
-                    $"-{nameof(SuperHero.Nickname)}",
-                    new Order<SuperHero>(expression : nameof(SuperHero.Nickname), direction : Descending)
-                },
-                {
-                    $"{nameof(SuperHero.Nickname)},{nameof(SuperHero.Age)}",
-                    new MultiOrder<SuperHero>
-                    (
-                        new Order<SuperHero>(expression: nameof(SuperHero.Nickname)),
-                        new Order<SuperHero>(expression: nameof(SuperHero.Age))
-                    )
-                },
-                {
-                    $"+{nameof(SuperHero.Nickname)},-{nameof(SuperHero.Age)}",
-                    new MultiOrder<SuperHero>
-                    (
-                        new Order<SuperHero>(expression: nameof(SuperHero.Nickname)),
-                        new Order<SuperHero>(expression: nameof(SuperHero.Age), direction: Descending)
-                    )
-                }
-            };
-
-        [Theory]
-        [MemberData(nameof(ToSortCases))]
-        public void ToSortTests(string sort, IOrder<SuperHero> expected)
-        {
-            outputHelper.WriteLine($"{nameof(sort)} : '{sort}'");
-
-            // Act
-            IOrder<SuperHero> actual = sort.ToSort<SuperHero>();
-
-            outputHelper.WriteLine($"actual sort : '{actual}'");
-
-            // Assert
-            actual.Should()
-                  .Be(expected);
-        }
-
-        public static TheoryData<string, PropertyNameResolutionStrategy, IOrder<Model>> ToSortWithPropertyNameResolutionStrategyCases
-            => new()
+                nameof(SuperHero.Nickname),
+                new Order<SuperHero>(expression : nameof(SuperHero.Nickname), direction : Ascending)
+            },
             {
-                {
-                    "-SnakeCaseProperty",
-                    PropertyNameResolutionStrategy.SnakeCase,
-                    new Order<Model>("snake_case_property", Descending)
-                },
-                {
-                    "SnakeCaseProperty",
-                    PropertyNameResolutionStrategy.SnakeCase,
-                    new Order<Model>("snake_case_property", Ascending)
-                },
-                {
-                    "-SnakeCaseProperty",
-                    PropertyNameResolutionStrategy.SnakeCase,
-                    new Order<Model>("snake_case_property", Descending)
-                },
-                {
-                    "pascal_case_property",
-                    PropertyNameResolutionStrategy.PascalCase,
-                    new Order<Model>("PascalCaseProperty", Ascending)
-                },
-                {
-                    "+pascal_case_property",
-                    PropertyNameResolutionStrategy.PascalCase,
-                    new Order<Model>("PascalCaseProperty", Ascending)
-                },
-                {
-                    "-pascal_case_property",
-                    PropertyNameResolutionStrategy.PascalCase,
-                    new Order<Model>("PascalCaseProperty", Descending)
-                }
-            };
+                $"+{nameof(SuperHero.Nickname)}",
+                new Order<SuperHero>(expression : nameof(SuperHero.Nickname), direction : Ascending)
+            },
+            {
+                $"-{nameof(SuperHero.Nickname)}",
+                new Order<SuperHero>(expression : nameof(SuperHero.Nickname), direction : Descending)
+            },
+            {
+                $"{nameof(SuperHero.Nickname)},{nameof(SuperHero.Age)}",
+                new MultiOrder<SuperHero>
+                (
+                    new Order<SuperHero>(expression: nameof(SuperHero.Nickname)),
+                    new Order<SuperHero>(expression: nameof(SuperHero.Age))
+                )
+            },
+            {
+                $"+{nameof(SuperHero.Nickname)},-{nameof(SuperHero.Age)}",
+                new MultiOrder<SuperHero>
+                (
+                    new Order<SuperHero>(expression: nameof(SuperHero.Nickname)),
+                    new Order<SuperHero>(expression: nameof(SuperHero.Age), direction: Descending)
+                )
+            }
+        };
 
-        [Theory]
-        [MemberData(nameof(ToSortWithPropertyNameResolutionStrategyCases))]
-        public void Given_input_and_PropertyNameResolutionStrategy_ToSort_should_return_appropriate_ISort_instance(string sort, PropertyNameResolutionStrategy propertyNameResolutionStrategy, IOrder<Model> expected)
+    [Theory]
+    [MemberData(nameof(ToSortCases))]
+    public void ToSortTests(string sort, IOrder<SuperHero> expected)
+    {
+        outputHelper.WriteLine($"{nameof(sort)} : '{sort}'");
+
+        // Act
+        IOrder<SuperHero> actual = sort.ToSort<SuperHero>();
+
+        outputHelper.WriteLine($"actual sort : '{actual}'");
+
+        // Assert
+        actual.Should()
+            .Be(expected);
+    }
+
+    public static TheoryData<string, PropertyNameResolutionStrategy, IOrder<Model>> ToSortWithPropertyNameResolutionStrategyCases
+        => new()
         {
-            // Act
-            IOrder<Model> actual = sort.ToOrder<Model>(propertyNameResolutionStrategy);
+            {
+                "-SnakeCaseProperty",
+                PropertyNameResolutionStrategy.SnakeCase,
+                new Order<Model>("snake_case_property", Descending)
+            },
+            {
+                "SnakeCaseProperty",
+                PropertyNameResolutionStrategy.SnakeCase,
+                new Order<Model>("snake_case_property", Ascending)
+            },
+            {
+                "-SnakeCaseProperty",
+                PropertyNameResolutionStrategy.SnakeCase,
+                new Order<Model>("snake_case_property", Descending)
+            },
+            {
+                "pascal_case_property",
+                PropertyNameResolutionStrategy.PascalCase,
+                new Order<Model>("PascalCaseProperty", Ascending)
+            },
+            {
+                "+pascal_case_property",
+                PropertyNameResolutionStrategy.PascalCase,
+                new Order<Model>("PascalCaseProperty", Ascending)
+            },
+            {
+                "-pascal_case_property",
+                PropertyNameResolutionStrategy.PascalCase,
+                new Order<Model>("PascalCaseProperty", Descending)
+            }
+        };
 
-            // Assert
-            actual.Should()
-                  .Be(expected);
-        }
+    [Theory]
+    [MemberData(nameof(ToSortWithPropertyNameResolutionStrategyCases))]
+    public void Given_input_and_PropertyNameResolutionStrategy_ToSort_should_return_appropriate_ISort_instance(string sort, PropertyNameResolutionStrategy propertyNameResolutionStrategy, IOrder<Model> expected)
+    {
+        // Act
+        IOrder<Model> actual = sort.ToOrder<Model>(propertyNameResolutionStrategy);
+
+        // Assert
+        actual.Should()
+            .Be(expected);
     }
 }

--- a/test/DataFilters.UnitTests/Validators/OrderValidatorTests.cs
+++ b/test/DataFilters.UnitTests/Validators/OrderValidatorTests.cs
@@ -1,40 +1,39 @@
-﻿namespace DataFilters.UnitTests.Validators
+﻿namespace DataFilters.UnitTests.Validators;
+
+using FluentAssertions;
+
+using FluentValidation.Results;
+
+using Xunit;
+
+public class OrderValidatorTests
 {
-    using FluentAssertions;
+    private readonly OrderValidator _sut;
 
-    using FluentValidation.Results;
+    public OrderValidatorTests() => _sut = new OrderValidator();
 
-    using Xunit;
-
-    public class OrderValidatorTests
+    [Theory]
+    [InlineData("prop", true, "'prop' is a valid sort expression")]
+    [InlineData("+prop", true, "'+prop' is a valid sort expression")]
+    [InlineData("-prop", true, "'-prop' is a valid sort expression")]
+    [InlineData("--prop", false, "'--prop' is not valid because it starts with two consecutive hyphens")]
+    [InlineData("++prop", false, "'++prop' is not valid because it starts with two consecutive '+'")]
+    [InlineData("+ + prop", false, "'+ + prop' is not valid because it starts with two consecutive '+'")]
+    [InlineData(" ", false, "' ' is not valid because it contains only whitespace")]
+    [InlineData("+ ", false, "'+ ' is not valid because it contains only a '+' followed by whitespaces")]
+    [InlineData("- ", false, "'- ' is not valid because it contains only a '-' followed by whitespaces")]
+    [InlineData("prop1,prop2", true, "'prop1,prop2' is not valid because it contains only a '-' followed by whitespaces")]
+    [InlineData("prop1, prop2", true, "'prop1, prop2' is valid because it contains two properties separated by a comma")]
+    [InlineData("prop1 prop2", false, "'prop1 prop2' is not valid because it contains two properties separated by a whitespace")]
+    [InlineData(",prop1,prop2", false, "',prop1,prop2' is not valid because it starts with a ','")]
+    [InlineData("prop1,prop2,", false, "'prop1,prop2,' is not valid because it ends with a ','")]
+    public void IsValid(string sort, bool expected, string reason)
     {
-        private readonly OrderValidator _sut;
+        // Act
+        ValidationResult actual = _sut.Validate(sort);
 
-        public OrderValidatorTests() => _sut = new OrderValidator();
-
-        [Theory]
-        [InlineData("prop", true, "'prop' is a valid sort expression")]
-        [InlineData("+prop", true, "'+prop' is a valid sort expression")]
-        [InlineData("-prop", true, "'-prop' is a valid sort expression")]
-        [InlineData("--prop", false, "'--prop' is not valid because it starts with two consecutive hyphens")]
-        [InlineData("++prop", false, "'++prop' is not valid because it starts with two consecutive '+'")]
-        [InlineData("+ + prop", false, "'+ + prop' is not valid because it starts with two consecutive '+'")]
-        [InlineData(" ", false, "' ' is not valid because it contains only whitespace")]
-        [InlineData("+ ", false, "'+ ' is not valid because it contains only a '+' followed by whitespaces")]
-        [InlineData("- ", false, "'- ' is not valid because it contains only a '-' followed by whitespaces")]
-        [InlineData("prop1,prop2", true, "'prop1,prop2' is not valid because it contains only a '-' followed by whitespaces")]
-        [InlineData("prop1, prop2", true, "'prop1, prop2' is valid because it contains two properties separated by a comma")]
-        [InlineData("prop1 prop2", false, "'prop1 prop2' is not valid because it contains two properties separated by a whitespace")]
-        [InlineData(",prop1,prop2", false, "',prop1,prop2' is not valid because it starts with a ','")]
-        [InlineData("prop1,prop2,", false, "'prop1,prop2,' is not valid because it ends with a ','")]
-        public void IsValid(string sort, bool expected, string reason)
-        {
-            // Act
-            ValidationResult actual = _sut.Validate(sort);
-
-            // Assert
-            actual.IsValid.Should()
-                .Be(expected, reason);
-        }
+        // Assert
+        actual.IsValid.Should()
+            .Be(expected, reason);
     }
 }


### PR DESCRIPTION
### 💥 Breaking Changes
• Renamed FilterToken.OpenParenthese to FilterToken.LeftParenthesis
• Renamed FilterToken.CloseParenthese to FilterToken.RightParenthesis
• Renamed FilterToken.LeftBrace to FilterToken.LeftCurlyBrace
• Renamed FilterToken.RightBrace to FilterToken.RightCurlyBrace
• Renamed FilterToken.OpenSquaredBracket to FilterToken.LeftSquaredBrace
• Renamed FilterToken.CloseSquaredBracket to FilterToken.RightSquaredBrace
### 🚨 Fixes
• Fixed incorrect parsing of scientific numeric values (with E symbol).
• Fixed incorrect parsing of some expressions that uses * character
• Fixed incorrect parsing of text expressions when used in combination with contains
### 🧹 Housekeeping
• Pipeline fails to publish NuGet packages to GitHub due to incorrect URL
• Refactoring of ISimplifiable implementations
• Updated GitHub nuget registry URL
• Bumped Candoumbe.Pipelines to 0.13.0-rc.39
• Bumped Microsoft.NET.Test.Sdk to 17.11.1
• Updated required NET SDK to 9.0.102
• Set Ubuntu 22.04 image for continuous integration

Full changelog at https://github.com/candoumbe/DataFilters/blob/coldfix/code-cleanup/CHANGELOG.md