### PR TITLE
✨ Nightly Pipeline Runs Mutation Tests

### DIFF
--- a/build/_build.csproj
+++ b/build/_build.csproj
@@ -3,7 +3,7 @@
   <Import Project="../core.props" />
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <RootNamespace></RootNamespace>
     <NoWarn>;CS0649;CS0169;CS1591;</NoWarn>
     <NukeRootDirectory>..</NukeRootDirectory>
@@ -14,6 +14,7 @@
   <ItemGroup>
     <PackageReference Include="Candoumbe.Pipelines" Version="0.13.0" />
     <PackageReference Include="ReportGenerator" Version="5.4.5" />
+    <PackageDownload Include="dotnet-stryker" Version="[4.5.1]"/>
     <PackageDownload Include="GitVersion.Tool" Version="[6.1.0]" />
     <PackageDownload Include="CodecovUploader" Version="[0.8.0]" />
   </ItemGroup>

--- a/src/DataFilters/DataFilters.csproj
+++ b/src/DataFilters/DataFilters.csproj
@@ -13,7 +13,7 @@
     <PackageReference Include="Candoumbe.Miscutilities" Version="0.14.0"/>
     <PackageReference Include="System.Collections.Immutable" Version="8.0.0"/>
     <PackageReference Include="OneOf.Extended" Version="3.0.271"/>
-    <PackageReference Include="Superpower" Version="3.*"/>
-    <PackageReference Include="Newtonsoft.Json.Schema" Version="3.*"/>
+    <PackageReference Include="Superpower" Version="3.0.0"/>
+    <PackageReference Include="Newtonsoft.Json.Schema" Version="3.0.16"/>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
### 💥 Breaking Changes
• Renamed FilterToken.OpenParenthese to FilterToken.LeftParenthesis
• Renamed FilterToken.CloseParenthese to FilterToken.RightParenthesis
• Renamed FilterToken.LeftBrace to FilterToken.LeftCurlyBrace
• Renamed FilterToken.RightBrace to FilterToken.RightCurlyBrace
• Renamed FilterToken.OpenSquaredBracket to FilterToken.LeftSquaredBrace
• Renamed FilterToken.CloseSquaredBracket to FilterToken.RightSquaredBrace
### 🚨 Fixes
• Fixed incorrect parsing of scientific numeric values (with E symbol).
• Fixed incorrect parsing of some expressions that uses * character
• Fixed incorrect parsing of text expressions when used in combination with contains
### 🧹 Housekeeping
• Pipeline fails to publish NuGet packages to GitHub due to incorrect URL
• Refactoring of ISimplifiable implementations
• Updated GitHub nuget registry URL
• Bumped Candoumbe.Pipelines to 0.13.0
• Bumped Microsoft.NET.Test.Sdk to 17.11.1
• Updated required NET SDK to 9.0.102
• Set Ubuntu 22.04 image for continuous integration

Full changelog at https://github.com/candoumbe/DataFilters/blob/feature/nightly-pipeline-runs-mutation-tests/CHANGELOG.md