### PR TITLE
✨ Update Runner To Use Ubuntu 2404 Image

### DIFF
--- a/build/Build.cs
+++ b/build/Build.cs
@@ -19,7 +19,7 @@ using Nuke.Common.Tools.DotNet;
 
 [GitHubActions(
     "integration",
-    GitHubActionsImage.Ubuntu2204,
+    GitHubActionsImage.Ubuntu2404,
     AutoGenerate = false,
     FetchDepth = 0,
     OnPushBranchesIgnore = [IHaveMainBranch.MainBranchName],
@@ -41,7 +41,7 @@ using Nuke.Common.Tools.DotNet;
 )]
 [GitHubActions(
     "delivery",
-    GitHubActionsImage.Ubuntu2204,
+    GitHubActionsImage.Ubuntu2404,
     AutoGenerate = false,
     FetchDepth = 0,
     OnPushBranches = [IHaveMainBranch.MainBranchName, IGitFlow.ReleaseBranch + "/*"],
@@ -66,7 +66,7 @@ using Nuke.Common.Tools.DotNet;
     ]
 )]
 
-// [GitHubActions("nightly", GitHubActionsImage.Ubuntu2204,
+// [GitHubActions("nightly", GitHubActionsImage.Ubuntu2404,
 //     AutoGenerate = false,
 //     FetchDepth = 0,
 //     OnCronSchedule = "0 0 * * *",
@@ -89,7 +89,7 @@ using Nuke.Common.Tools.DotNet;
 //     ],
 //     PublishArtifacts = true
 // )]
-[GitHubActions("nightly-manual", GitHubActionsImage.Ubuntu2204,
+[GitHubActions("nightly-manual", GitHubActionsImage.Ubuntu2404,
     AutoGenerate = false,
     FetchDepth = 0,
     On = [GitHubActionsTrigger.WorkflowDispatch],


### PR DESCRIPTION
### 💥 Breaking Changes
• Renamed FilterToken.OpenParenthese to FilterToken.LeftParenthesis
• Renamed FilterToken.CloseParenthese to FilterToken.RightParenthesis
• Renamed FilterToken.LeftBrace to FilterToken.LeftCurlyBrace
• Renamed FilterToken.RightBrace to FilterToken.RightCurlyBrace
• Renamed FilterToken.OpenSquaredBracket to FilterToken.LeftSquaredBrace
• Renamed FilterToken.CloseSquaredBracket to FilterToken.RightSquaredBrace
### 🚨 Fixes
• Fixed incorrect parsing of scientific numeric values (with E symbol).
• Fixed incorrect parsing of some expressions that uses * character
• Fixed incorrect parsing of text expressions when used in combination with contains
### 🧹 Housekeeping
• Pipeline fails to publish NuGet packages to GitHub due to incorrect URL
• Refactoring of ISimplifiable implementations
• Updated GitHub nuget registry URL
• Bumped Candoumbe.Pipelines to 0.13.0
• Bumped Microsoft.NET.Test.Sdk to 17.11.1
• Updated required NET SDK to 9.0.102
• Set Ubuntu 22.04 image for continuous integration

Full changelog at https://github.com/candoumbe/DataFilters/blob/feature/update-runner-to-use-ubuntu-2404-image/CHANGELOG.md