### PR TITLE
🧹 Code Cleanup

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -4,12 +4,9 @@ tab_width = 4
 indent_size = 4
 indent_style = space
 
-[{*.xml,*.yaml,*.yml,*.csproj,*.json}]
+[{*.csproj,*.json,*.props,*.xml,*.yaml,*.yml}]
 indent_size = 2
 
-
-[{*.csproj,*.json,*.xml,*.props}]
-indent_size = 2
 [*.cs]
 dotnet_style_readonly_field = true:suggestion
 dotnet_style_require_accessibility_modifiers = for_non_interface_members:silent
@@ -48,6 +45,7 @@ csharp_style_pattern_matching_over_is_with_cast_check = true:suggestion
 csharp_style_pattern_matching_over_as_with_null_check = true:suggestion
 csharp_style_prefer_not_pattern = true:suggestion
 csharp_prefer_simple_using_statement = true:suggestion
+csharp_using_directive_placement = outside_namespace:error
 
 # Indentation Options
 csharp_indent_block_contents = true
@@ -132,8 +130,6 @@ dotnet_naming_symbols.private_protected_fields.applicable_kinds = field
 dotnet_naming_style.prefix_private_protected_fields.required_prefix = _
 dotnet_naming_style.prefix_private_protected_fields.capitalization = camel_case
 
-
-
 # public_symbols - Define any public symbol
 dotnet_naming_symbols.public_symbols.applicable_accessibilities = public, internal, protected, protected_internal
 dotnet_naming_symbols.public_symbols.applicable_kinds = method, property, event, delegate
@@ -160,7 +156,6 @@ dotnet_naming_style.tpascalcase.required_prefix = T
 dotnet_naming_style.tpascalcase.required_suffix =
 dotnet_naming_style.tpascalcase.word_separator =
 dotnet_naming_style.tpascalcase.capitalization = pascal_case
-
 
 dotnet_naming_style.camel_case.required_prefix =
 dotnet_naming_style.camel_case.required_suffix =

--- a/.nuke/build.schema.json
+++ b/.nuke/build.schema.json
@@ -31,6 +31,7 @@
         "Coldfix",
         "Compile",
         "Feature",
+        "Format",
         "Hotfix",
         "MutationTests",
         "Pack",
@@ -143,6 +144,18 @@
         "Draft": {
           "type": "boolean",
           "description": "Indicates to open the pull request as 'draft'"
+        },
+        "Formatters": {
+          "type": "array",
+          "description": "Sets of formatters that the tool must apply",
+          "items": {
+            "type": "string",
+            "enum": [
+              "Analyzers",
+              "Style",
+              "Whitespace"
+            ]
+          }
         },
         "GitHubToken": {
           "type": "string",

--- a/.nuke/parameters.local.json
+++ b/.nuke/parameters.local.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "./build.schema.json",
   "GitHubToken": "v1:OhvldXY34GSHTumJiuoWhHPHKwSoVb7B/X19pufOj7+Q2O5n0YnxMIowWmry2b4SbtIW2Ah4uwPP1HpOLvvfB9LO4QIggTf/dAVK00aG+Cp2ZeG/kqhbEsc9c6tV8lZn",
   "NugetApiKey": "v1:pqiQ7rGFSYoCihCFSrdaCRFpf0BoThUJFRbvzCqVjnWssX61zbm6Z7aZH9x1/fOg",
   "CodecovToken": "v1:fD+Tl5VfvzhiKcjphPlwB+e7w7Dj7N645OTAjSoEtozxIae0KhwkqvHBi7RChHK3"

--- a/.nuke/parameters.local.json
+++ b/.nuke/parameters.local.json
@@ -1,6 +1,7 @@
 {
   "$schema": "./build.schema.json",
-  "GitHubToken": "v1:OhvldXY34GSHTumJiuoWhHPHKwSoVb7B/X19pufOj7+Q2O5n0YnxMIowWmry2b4SbtIW2Ah4uwPP1HpOLvvfB9LO4QIggTf/dAVK00aG+Cp2ZeG/kqhbEsc9c6tV8lZn",
-  "NugetApiKey": "v1:pqiQ7rGFSYoCihCFSrdaCRFpf0BoThUJFRbvzCqVjnWssX61zbm6Z7aZH9x1/fOg",
-  "CodecovToken": "v1:fD+Tl5VfvzhiKcjphPlwB+e7w7Dj7N645OTAjSoEtozxIae0KhwkqvHBi7RChHK3"
+  "GitHubToken": "v1:7BfFGmnBKe1ooQo8yMphr67r1btAZvUQuKfSnOHFlreHVIy4QpeuRSVXlBosOxFpXocml1fQbHQfOxsAaBdby1JFobBv8X2G9ymYYATJIH+nzj8jd9pUZEJDDtYzmKOl",
+  "NugetApiKey": "v1:NcNw809QaSHeV0FgscPdgSIg+egDaMafPCpvvKSHau+GVgIqlHrz/KLKBuXWMlbR",
+  "StrykerDashboardApiKey": "v1:VasgG/snrNvxp6hHM0B6i0y7KvvCWhxXgQGXUGzMoZlOXaULMdESZrBUrELYrbuX",
+  "CodecovToken": "v1:Ych71lF0Lgp/15E3LyauNSj3hjMp3EZeGq3uYCiUNqnwuT4+ZHdO2/zAGFGIfCcS"
 }

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -1,11 +1,8 @@
-using Nuke.Common.Tools.GitHub;
-
-namespace DataFilters.ContinuousIntegration;
-
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using Candoumbe.Pipelines.Components;
+using Candoumbe.Pipelines.Components.Formatting;
 using Candoumbe.Pipelines.Components.GitHub;
 using Candoumbe.Pipelines.Components.NuGet;
 using Candoumbe.Pipelines.Components.Workflows;
@@ -16,6 +13,9 @@ using Nuke.Common.ProjectModel;
 using Nuke.Common.Tooling;
 using Nuke.Common.Tools.DotNet;
 using Nuke.Common.Tools.GitHub;
+
+namespace DataFilters.ContinuousIntegration;
+
 
 [GitHubActions(
     "integration",
@@ -122,6 +122,7 @@ public class Build : EnhancedNukeBuild,
     IClean,
     IRestore,
     ICompile,
+    IDotnetFormat,
     IUnitTest,
     IMutationTest,
     IBenchmark,
@@ -196,4 +197,7 @@ public class Build : EnhancedNukeBuild,
             source: new Uri($"https://nuget.pkg.github.com/{this.Get<IHaveGitHubRepository>().GitRepository.GetGitHubOwner()}/index.json"),
             canBeUsed: () => this.As<ICreateGithubRelease>()?.GitHubToken is not null)
     ];
+
+    /// <inheritdoc />
+    bool IDotnetFormat.VerifyNoChanges => IsServerBuild;
 }

--- a/build/_build.csproj
+++ b/build/_build.csproj
@@ -12,7 +12,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Candoumbe.Pipelines" Version="0.13.3" />
+    <PackageReference Include="Candoumbe.Pipelines" Version="0.13.4-fix.4" />
     <PackageReference Include="ReportGenerator" Version="5.4.11" />
     <PackageDownload Include="dotnet-stryker" Version="[4.5.1]"/>
     <PackageDownload Include="GitVersion.Tool" Version="[6.1.0]" />

--- a/src/DataFilters.Queries/FilterToQueries.cs
+++ b/src/DataFilters.Queries/FilterToQueries.cs
@@ -1,9 +1,9 @@
-﻿namespace DataFilters;
-
+﻿
 using System;
 using System.Linq;
 using Queries.Core.Parts.Clauses;
 
+namespace DataFilters;
 /// <summary>
 /// Extensions method <see cref="IFilter"/> type.
 /// </summary>

--- a/src/DataFilters.Queries/OrderExtensions.cs
+++ b/src/DataFilters.Queries/OrderExtensions.cs
@@ -1,9 +1,9 @@
-﻿namespace DataFilters;
-
+﻿
 using System;
 using System.Collections.Generic;
 using Queries.Core.Parts.Sorting;
 
+namespace DataFilters;
 /// <summary>
 /// Extensions method for <see cref="IOrder{T}"/> types
 /// </summary>

--- a/src/DataFilters/Casing/CamelCasePropertyNameResolutionStrategy.cs
+++ b/src/DataFilters/Casing/CamelCasePropertyNameResolutionStrategy.cs
@@ -1,7 +1,7 @@
-﻿namespace DataFilters.Casing;
-
+﻿
 using System;
 
+namespace DataFilters.Casing;
 /// <summary>
 /// <see cref="PropertyNameResolutionStrategy"/> that transform input to it <strong>camelCase</strong> equivalent.
 /// </summary>

--- a/src/DataFilters/Casing/PascalCasePropertyNameResolutionStrategy.cs
+++ b/src/DataFilters/Casing/PascalCasePropertyNameResolutionStrategy.cs
@@ -1,7 +1,7 @@
-﻿namespace DataFilters.Casing;
-
+﻿
 using System;
 
+namespace DataFilters.Casing;
 /// <summary>
 /// <see cref="PropertyNameResolutionStrategy"/> that transform input to it <strong>PascalCase</strong> equivalent.
 /// </summary>

--- a/src/DataFilters/Casing/SnakeCasePropertyNameResolutionStrategy.cs
+++ b/src/DataFilters/Casing/SnakeCasePropertyNameResolutionStrategy.cs
@@ -1,7 +1,7 @@
-﻿namespace DataFilters.Casing;
-
+﻿
 using System;
 
+namespace DataFilters.Casing;
 /// <summary>
 /// <see cref="PropertyNameResolutionStrategy"/> that transform input to its snake_case equivalent.
 /// </summary>

--- a/src/DataFilters/Filter.cs
+++ b/src/DataFilters/Filter.cs
@@ -1,22 +1,21 @@
 using System;
 using System.Collections.Generic;
-using System.Text.RegularExpressions;
-using DataFilters.Converters;
-using Newtonsoft.Json.Schema;
 using System.Text.Json.Serialization;
+using System.Text.RegularExpressions;
+using DataFilters.Serialization;
+using Newtonsoft.Json.Schema;
 
 namespace DataFilters;
-
 /// <summary>
 /// An instance of this class holds a filter
 /// </summary>
-    [JsonConverter(typeof(FilterConverter))]
-    public sealed class Filter : IFilter, IEquatable<Filter>
-    {
-        /// <summary>
-        /// Filter that always returns <c>true</c>
-        /// </summary>
-        public static Filter True => new(default, default);
+[JsonConverter(typeof(FilterConverter))]
+public sealed class Filter : IFilter, IEquatable<Filter>
+{
+    /// <summary>
+    /// Filter that always returns <c>true</c>
+    /// </summary>
+    public static Filter True => new(null, default);
 
     /// <summary>
     /// Pattern that field name should respect.
@@ -48,12 +47,7 @@ namespace DataFilters;
     /// <summary>
     /// <see cref="FilterOperator"/>s that required <see cref="Value"/> to be null.
     /// </summary>
-    public static ISet<FilterOperator> UnaryOperators { get; } = new HashSet<FilterOperator>{
-        FilterOperator.IsEmpty,
-        FilterOperator.IsNotEmpty,
-        FilterOperator.IsNotNull,
-        FilterOperator.IsNull
-    };
+    public static ISet<FilterOperator> UnaryOperators { get; } = new HashSet<FilterOperator> { FilterOperator.IsEmpty, FilterOperator.IsNotEmpty, FilterOperator.IsNotNull, FilterOperator.IsNull };
 
     /// <summary>
     /// Generates the <see cref="JSchema"/> for the specified <see cref="FilterOperator"/>.
@@ -107,35 +101,19 @@ namespace DataFilters;
     /// <summary>
     /// Name of the field  the filter will be applied to
     /// </summary>
-#if NETSTANDARD1_3
-        [JsonProperty(FieldJsonPropertyName, Required = Always)]
-#else
     [JsonPropertyName(FieldJsonPropertyName)]
-#endif
     public string Field { get; }
 
     /// <summary>
     /// Operator to apply to the filter
     /// </summary>
-#if NETSTANDARD1_3
-        [JsonProperty(OperatorJsonPropertyName, Required = Always)]
-        [JsonConverter(typeof(CamelCaseEnumTypeConverter))]
-#else
     [JsonPropertyName(OperatorJsonPropertyName)]
-#endif
     public FilterOperator Operator { get; }
 
     /// <summary>
     /// Value of the filter
     /// </summary>
-#if NETSTANDARD1_3
-        [JsonProperty(ValueJsonPropertyName,
-            Required = AllowNull,
-            DefaultValueHandling = IgnoreAndPopulate,
-            NullValueHandling = NullValueHandling.Ignore)]
-#else
     [JsonPropertyName(ValueJsonPropertyName)]
-#endif
     public object Value { get; }
 
     /// <summary>
@@ -169,14 +147,7 @@ namespace DataFilters;
     }
 
     ///<inheritdoc/>
-#if NETSTANDARD1_3
-        public string ToJson()
-        {
-            return this.Jsonify(new JsonSerializerSettings());
-        }
-#else
     public string ToJson() => this.Jsonify();
-#endif
 
     ///<inheritdoc/>
     public override string ToString() => ToJson();
@@ -194,11 +165,7 @@ namespace DataFilters;
     public bool Equals(IFilter other) => Equals(other as Filter);
 
     ///<inheritdoc/>
-#if NETSTANDARD1_3 || NETSTANDARD2_0
-        public override int GetHashCode() => (Field, Operator, Value).GetHashCode();
-#else
     public override int GetHashCode() => HashCode.Combine(Field, Operator, Value);
-#endif
 
     ///<inheritdoc/>
     public IFilter Negate()

--- a/src/DataFilters/FilterOperator.cs
+++ b/src/DataFilters/FilterOperator.cs
@@ -1,12 +1,8 @@
-﻿namespace DataFilters;
+﻿using System.Text.Json.Serialization;
+using DataFilters.Serialization;
 
-using Converters;
+namespace DataFilters;
 
-#if NETSTANDARD1_3
-    using Newtonsoft.Json;
-#else
-using System.Text.Json.Serialization;
-#endif
 /// <summary>
 /// Operators that can be used when building <see cref="Filter"/> instances.
 /// </summary>

--- a/src/DataFilters/Grammar/Exceptions/BoundariesTypeMismatchException.cs
+++ b/src/DataFilters/Grammar/Exceptions/BoundariesTypeMismatchException.cs
@@ -1,7 +1,7 @@
-﻿namespace DataFilters.Grammar.Exceptions;
-
+﻿
 using System;
 
+namespace DataFilters.Grammar.Exceptions;
 /// <summary>
 /// Exception thrown when a <see cref="Syntax.IntervalExpression"/> has incorrect <see cref="Syntax.IntervalExpression.Min"/>
 /// </summary>

--- a/src/DataFilters/Grammar/Exceptions/IncorrectBoundaryException.cs
+++ b/src/DataFilters/Grammar/Exceptions/IncorrectBoundaryException.cs
@@ -1,7 +1,7 @@
-﻿namespace DataFilters.Grammar.Exceptions;
-
+﻿
 using System;
 
+namespace DataFilters.Grammar.Exceptions;
 /// <summary>
 /// Exception thrown when <see cref="Syntax.IntervalExpression"/> constructor is passed incorrect <see cref="Syntax.BoundaryExpression"/>s.
 /// </summary>

--- a/src/DataFilters/Grammar/Parsing/FilterTokenizer.cs
+++ b/src/DataFilters/Grammar/Parsing/FilterTokenizer.cs
@@ -18,7 +18,7 @@ namespace DataFilters.Grammar.Parsing;
 /// </remarks>
 public class FilterTokenizer : Tokenizer<FilterToken>
 {
-    private TokenizerMode _mode;
+    private TokenizerMode _currentTokenizerMode;
 
     /// <summary>
     /// The <c>_</c> character
@@ -159,7 +159,7 @@ public class FilterTokenizer : Tokenizer<FilterToken>
     /// <summary>
     /// Custom <see cref="Tokenizer{TKind}"/> implementation that serves as the foundation of parsing text.
     /// </summary>
-    public FilterTokenizer() => _mode = TokenizerMode.Normal;
+    public FilterTokenizer() => _currentTokenizerMode = TokenizerMode.Normal;
 
     ///<inheritdoc/>
     protected override IEnumerable<Result<FilterToken>> Tokenize(TextSpan span, TokenizationState<FilterToken> state)
@@ -190,7 +190,7 @@ public class FilterTokenizer : Tokenizer<FilterToken>
                 }
                 case Underscore:
                 {
-                    yield return Result.Value(_mode switch { TokenizerMode.Normal => FilterToken.Underscore, _ => Escaped },
+                    yield return Result.Value(_currentTokenizerMode switch { TokenizerMode.Normal => FilterToken.Underscore, _ => Escaped },
                                               next.Location,
                                               next.Remainder);
                     next = next.Remainder.ConsumeChar();
@@ -198,7 +198,7 @@ public class FilterTokenizer : Tokenizer<FilterToken>
                 }
                 case Pipe:
                 {
-                    yield return Result.Value(_mode switch { TokenizerMode.Normal => Or, _ => Escaped },
+                    yield return Result.Value(_currentTokenizerMode switch { TokenizerMode.Normal => Or, _ => Escaped },
                                               next.Location,
                                               next.Remainder);
                     next = next.Remainder.ConsumeChar();
@@ -206,7 +206,7 @@ public class FilterTokenizer : Tokenizer<FilterToken>
                 }
                 case Comma:
                 {
-                    yield return Result.Value(_mode switch { TokenizerMode.Normal => And, _ => Escaped },
+                    yield return Result.Value(_currentTokenizerMode switch { TokenizerMode.Normal => And, _ => Escaped },
                                               next.Location,
                                               next.Remainder);
                     next = next.Remainder.ConsumeChar();
@@ -214,7 +214,7 @@ public class FilterTokenizer : Tokenizer<FilterToken>
                 }
                 case EqualSign:
                 {
-                    yield return Result.Value(_mode switch { TokenizerMode.Normal => Equal, _ => Escaped },
+                    yield return Result.Value(_currentTokenizerMode switch { TokenizerMode.Normal => Equal, _ => Escaped },
                                               next.Location,
                                               next.Remainder);
                     next = next.Remainder.ConsumeChar();
@@ -222,7 +222,7 @@ public class FilterTokenizer : Tokenizer<FilterToken>
                 }
                 case Asterisk:
                 {
-                    yield return Result.Value(_mode switch { TokenizerMode.Normal => FilterToken.Asterisk, _ => Escaped },
+                    yield return Result.Value(_currentTokenizerMode switch { TokenizerMode.Normal => FilterToken.Asterisk, _ => Escaped },
                                               next.Location,
                                               next.Remainder);
                     next = next.Remainder.ConsumeChar();
@@ -230,7 +230,7 @@ public class FilterTokenizer : Tokenizer<FilterToken>
                 }
                 case LeftCurlyBracket:
                 {
-                    yield return Result.Value(_mode switch { TokenizerMode.Normal => LeftCurlyBrace, _ => Escaped },
+                    yield return Result.Value(_currentTokenizerMode switch { TokenizerMode.Normal => LeftCurlyBrace, _ => Escaped },
                                               next.Location,
                                               next.Remainder);
                     next = next.Remainder.ConsumeChar();
@@ -238,7 +238,7 @@ public class FilterTokenizer : Tokenizer<FilterToken>
                 }
                 case RightCurlyBracket:
                 {
-                    yield return Result.Value(_mode switch { TokenizerMode.Normal => RightCurlyBrace, _ => Escaped },
+                    yield return Result.Value(_currentTokenizerMode switch { TokenizerMode.Normal => RightCurlyBrace, _ => Escaped },
                                               next.Location,
                                               next.Remainder);
                     next = next.Remainder.ConsumeChar();
@@ -246,7 +246,7 @@ public class FilterTokenizer : Tokenizer<FilterToken>
                 }
                 case Bang:
                 {
-                    yield return Result.Value(_mode switch { TokenizerMode.Normal => FilterToken.Bang, _ => Escaped },
+                    yield return Result.Value(_currentTokenizerMode switch { TokenizerMode.Normal => FilterToken.Bang, _ => Escaped },
                                               next.Location,
                                               next.Remainder);
                     next = next.Remainder.ConsumeChar();
@@ -254,7 +254,7 @@ public class FilterTokenizer : Tokenizer<FilterToken>
                 }
                 case LeftSquareBracket:
                 {
-                    yield return Result.Value(_mode switch { TokenizerMode.Normal => LeftSquaredBracket, _ => Escaped },
+                    yield return Result.Value(_currentTokenizerMode switch { TokenizerMode.Normal => LeftSquaredBracket, _ => Escaped },
                                               next.Location,
                                               next.Remainder);
                     next = next.Remainder.ConsumeChar();
@@ -262,7 +262,7 @@ public class FilterTokenizer : Tokenizer<FilterToken>
                 }
                 case RightSquareBracket:
                 {
-                    yield return Result.Value(_mode switch { TokenizerMode.Normal => RightSquaredBracket, _ => Escaped },
+                    yield return Result.Value(_currentTokenizerMode switch { TokenizerMode.Normal => RightSquaredBracket, _ => Escaped },
                                               next.Location,
                                               next.Remainder);
                     next = next.Remainder.ConsumeChar();
@@ -270,7 +270,7 @@ public class FilterTokenizer : Tokenizer<FilterToken>
                 }
                 case Hyphen:
                 {
-                    yield return Result.Value(_mode switch { TokenizerMode.Normal => Dash, _ => Escaped },
+                    yield return Result.Value(_currentTokenizerMode switch { TokenizerMode.Normal => Dash, _ => Escaped },
                                               next.Location,
                                               next.Remainder);
                     next = next.Remainder.ConsumeChar();
@@ -278,7 +278,7 @@ public class FilterTokenizer : Tokenizer<FilterToken>
                 }
                 case LeftParenthesis:
                 {
-                    yield return Result.Value(_mode switch { TokenizerMode.Normal => FilterToken.LeftParenthesis, _ => Escaped },
+                    yield return Result.Value(_currentTokenizerMode switch { TokenizerMode.Normal => FilterToken.LeftParenthesis, _ => Escaped },
                                               next.Location,
                                               next.Remainder);
                     next = next.Remainder.ConsumeChar();
@@ -286,7 +286,7 @@ public class FilterTokenizer : Tokenizer<FilterToken>
                 }
                 case RightParenthesis:
                 {
-                    yield return Result.Value(_mode switch { TokenizerMode.Normal => FilterToken.RightParenthesis, _ => Escaped },
+                    yield return Result.Value(_currentTokenizerMode switch { TokenizerMode.Normal => FilterToken.RightParenthesis, _ => Escaped },
                                               next.Location,
                                               next.Remainder);
                     next = next.Remainder.ConsumeChar();
@@ -294,7 +294,7 @@ public class FilterTokenizer : Tokenizer<FilterToken>
                 }
                 case Space:
                 {
-                    yield return Result.Value(_mode switch { TokenizerMode.Normal => Whitespace, _ => Escaped },
+                    yield return Result.Value(_currentTokenizerMode switch { TokenizerMode.Normal => Whitespace, _ => Escaped },
                                               next.Location,
                                               next.Remainder);
                     next = next.Remainder.ConsumeChar();
@@ -302,7 +302,7 @@ public class FilterTokenizer : Tokenizer<FilterToken>
                 }
                 case ':':
                 {
-                    yield return Result.Value(_mode switch { TokenizerMode.Normal => FilterToken.Colon, _ => Escaped },
+                    yield return Result.Value(_currentTokenizerMode switch { TokenizerMode.Normal => FilterToken.Colon, _ => Escaped },
                                               next.Location,
                                               next.Remainder);
                     next = next.Remainder.ConsumeChar();
@@ -310,7 +310,7 @@ public class FilterTokenizer : Tokenizer<FilterToken>
                 }
                 case Ampersand:
                 {
-                    yield return Result.Value(_mode switch { TokenizerMode.Normal => FilterToken.Ampersand, _ => Escaped },
+                    yield return Result.Value(_currentTokenizerMode switch { TokenizerMode.Normal => FilterToken.Ampersand, _ => Escaped },
                                               next.Location,
                                               next.Remainder);
                     next = next.Remainder.ConsumeChar();
@@ -321,13 +321,13 @@ public class FilterTokenizer : Tokenizer<FilterToken>
                     yield return Result.Value(FilterToken.DoubleQuote,
                                               next.Location,
                                               next.Remainder);
-                    _mode = ToggleMode(_mode);
+                    _currentTokenizerMode = ToggleMode(_currentTokenizerMode);
                     next = next.Remainder.ConsumeChar();
                     break;
                 }
                 case Dot:
                 {
-                    yield return Result.Value(_mode switch { TokenizerMode.Normal => FilterToken.Dot, _ => Escaped },
+                    yield return Result.Value(_currentTokenizerMode switch { TokenizerMode.Normal => FilterToken.Dot, _ => Escaped },
                                               next.Location,
                                               next.Remainder);
                     next = next.Remainder.ConsumeChar();
@@ -336,7 +336,7 @@ public class FilterTokenizer : Tokenizer<FilterToken>
                 case BackSlash:
                 {
                     TextSpan backSlashStart = next.Location;
-                    if (_mode == TokenizerMode.Normal)
+                    if (_currentTokenizerMode == TokenizerMode.Normal)
                     {
                         next = next.Remainder.ConsumeChar();
                         yield return next.HasValue && SpecialCharacters.Contains(next.Value)

--- a/src/DataFilters/Grammar/Syntax/BoundaryExpression.cs
+++ b/src/DataFilters/Grammar/Syntax/BoundaryExpression.cs
@@ -33,17 +33,7 @@ public sealed class BoundaryExpression(IBoundaryExpression expression, bool incl
     public override bool Equals(object obj) => Equals(obj as BoundaryExpression);
 
     ///<inheritdoc/>
-#if !(NETSTANDARD1_3 || NETSTANDARD2_0)
     public override int GetHashCode() => HashCode.Combine(Expression, Included);
-#else
-    public override int GetHashCode()
-    {
-        int hashCode = 1608575900;
-        hashCode = (hashCode * -1521134295) + EqualityComparer<IBoundaryExpression>.Default.GetHashCode(Expression);
-        hashCode = (hashCode * -1521134295) + Included.GetHashCode();
-        return hashCode;
-    }
-#endif
 
     ///<inheritdoc/>
     public static bool operator ==(BoundaryExpression left, BoundaryExpression right) => left switch

--- a/src/DataFilters/Grammar/Syntax/BracketExpression.cs
+++ b/src/DataFilters/Grammar/Syntax/BracketExpression.cs
@@ -20,7 +20,7 @@ namespace DataFilters.Grammar.Syntax;
 /// </remarks>
 public sealed class BracketExpression : FilterExpression, IEquatable<BracketExpression>
 {
-    private static readonly ArrayEqualityComparer<BracketValue> EqualityComparer = new();
+    private static readonly ArrayEqualityComparer<BracketValue> s_equalityComparer = new();
 
     /// <summary>
     /// Builds a new <see cref="BracketExpression"/> instance.
@@ -44,7 +44,7 @@ public sealed class BracketExpression : FilterExpression, IEquatable<BracketExpr
 
     ///<inheritdoc/>
     public bool Equals(BracketExpression other) => other is not null
-                                                   && EqualityComparer.Equals(Values.ToArray(), other.Values.ToArray());
+                                                   && s_equalityComparer.Equals(Values.ToArray(), other.Values.ToArray());
 
     ///<inheritdoc/>
     public override bool Equals(object obj) => obj switch
@@ -55,7 +55,7 @@ public sealed class BracketExpression : FilterExpression, IEquatable<BracketExpr
     };
 
     ///<inheritdoc/>
-    public override int GetHashCode() => EqualityComparer.GetHashCode([.. Values]);
+    public override int GetHashCode() => s_equalityComparer.GetHashCode([.. Values]);
 
     ///<inheritdoc/>
     public override string ToString() => $"{nameof(BracketExpression)} : [{string.Join(",", Values)}]";

--- a/src/DataFilters/Grammar/Syntax/ConstantBracketValue.cs
+++ b/src/DataFilters/Grammar/Syntax/ConstantBracketValue.cs
@@ -1,8 +1,8 @@
-﻿namespace DataFilters.Grammar.Syntax;
-
+﻿
 using System;
 using System.Collections.Generic;
 
+namespace DataFilters.Grammar.Syntax;
 /// <summary>
 /// Stores a constant value used in a bracket expression
 /// </summary>

--- a/src/DataFilters/Grammar/Syntax/ConstantValueExpression.cs
+++ b/src/DataFilters/Grammar/Syntax/ConstantValueExpression.cs
@@ -1,11 +1,9 @@
-﻿using Candoumbe.MiscUtilities.Comparers;
+﻿using System;
+using Candoumbe.MiscUtilities.Comparers;
 using Candoumbe.Types.Strings;
 using Microsoft.Extensions.Primitives;
 
 namespace DataFilters.Grammar.Syntax;
-
-using System;
-
 /// <summary>
 /// An expression that holds a constant value
 /// </summary>

--- a/src/DataFilters/Grammar/Syntax/DateTimeExpression.cs
+++ b/src/DataFilters/Grammar/Syntax/DateTimeExpression.cs
@@ -1,7 +1,7 @@
-﻿namespace DataFilters.Grammar.Syntax;
-
+﻿
 using System;
 
+namespace DataFilters.Grammar.Syntax;
 /// <summary>
 /// A <see cref="FilterExpression"/> implementation that can holds a datetime value
 /// </summary>

--- a/src/DataFilters/Grammar/Syntax/DurationExpression.cs
+++ b/src/DataFilters/Grammar/Syntax/DurationExpression.cs
@@ -1,7 +1,7 @@
-namespace DataFilters.Grammar.Syntax;
 
 using System;
 
+namespace DataFilters.Grammar.Syntax;
 /// <summary>
 /// A <see cref="FilterExpression"/> implementation that contains values associated to a duration (see "https://en.wikipedia.org/wiki/ISO_8601#Durations")
 /// </summary>

--- a/src/DataFilters/Grammar/Syntax/EndsWithExpression.cs
+++ b/src/DataFilters/Grammar/Syntax/EndsWithExpression.cs
@@ -7,10 +7,6 @@ using static DataFilters.Grammar.Parsing.FilterTokenizer;
 
 namespace DataFilters.Grammar.Syntax
 {
-
-#if !NETSTANDARD1_3
-#endif
-
     /// <summary>
     /// A <see cref="FilterExpression"/> that holds a string value
     /// </summary>
@@ -70,22 +66,10 @@ namespace DataFilters.Grammar.Syntax
         /// </summary>
         /// <param name="text"></param>
         /// <exception cref="ArgumentNullException"><paramref name="text"/> is <see langword="null"/>.</exception>
-        public EndsWithExpression(TextExpression text)
-#if !NETSTANDARD1_3
-            : this(new StringSegmentLinkedList( Guard.Against.Null(text, nameof(text)).OriginalString ))
+        public EndsWithExpression(TextExpression text) : this(new StringSegmentLinkedList( Guard.Against.Null(text, nameof(text)).OriginalString ))
         {
             _lazyEscapedParseableString = new Lazy<string>(() => $"*{text.EscapedParseableString}");
         }
-#else
-        {
-            if (text is null)
-            {
-                throw new ArgumentNullException(nameof(text));
-            }
-            _lazyEscapedParseableString = new(() => $"*{text.EscapedParseableString}");
-        }
-#endif
-
         ///<inheritdoc/>
         public bool Equals(EndsWithExpression other) => Value.Equals(other?.Value);
 

--- a/src/DataFilters/Grammar/Syntax/GroupExpression.cs
+++ b/src/DataFilters/Grammar/Syntax/GroupExpression.cs
@@ -1,7 +1,7 @@
-﻿namespace DataFilters.Grammar.Syntax;
-
+﻿
 using System;
 
+namespace DataFilters.Grammar.Syntax;
 /// <summary>
 /// Allows to treat several expressions as a single unit.
 /// </summary>

--- a/src/DataFilters/Grammar/Syntax/IntervalExpression.cs
+++ b/src/DataFilters/Grammar/Syntax/IntervalExpression.cs
@@ -1,10 +1,8 @@
-using System.Runtime.CompilerServices;
+using System;
+using System.Text.Json;
+using DataFilters.Grammar.Exceptions;
 
 namespace DataFilters.Grammar.Syntax;
-
-using System;
-using Exceptions;
-
 /// <summary>
 /// A <see cref="FilterExpression"/> that holds an interval between <see cref="Min"/> and <see cref="Max"/> values.
 /// </summary>
@@ -106,13 +104,8 @@ public sealed class IntervalExpression : FilterExpression, IEquatable<IntervalEx
                         },
                         EscapedParseableString
                     }
-#if NETSTANDARD1_3
-        .Jsonify(new Newtonsoft.Json.JsonSerializerSettings() { Formatting = Newtonsoft.Json.Formatting.Indented })
-#elif NETSTANDARD2_0_OR_GREATER || NET6_0_OR_GREATER
-                    .Jsonify(new() { WriteIndented = true, DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull })
-#endif
-            )
-            ;
+                    .Jsonify(new JsonSerializerOptions { WriteIndented = true, DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull })
+            );
 
         static string GetMinBracket(bool? included) => true.Equals(included) ? "[" : "]";
         static string GetMaxBracket(bool? included) => true.Equals(included) ? "]" : "[";

--- a/src/DataFilters/Grammar/Syntax/OffsetExpression.cs
+++ b/src/DataFilters/Grammar/Syntax/OffsetExpression.cs
@@ -1,7 +1,6 @@
-namespace DataFilters.Grammar.Syntax;
-
 using System;
 
+namespace DataFilters.Grammar.Syntax;
 /// <summary>
 /// <see cref="OffsetExpression"/> records the offset between a time and the UTC time
 /// </summary>
@@ -29,35 +28,35 @@ public sealed class OffsetExpression : FilterExpression, IEquatable<OffsetExpres
 
     private readonly Lazy<string> _lazyParseableString;
 
-        /// <summary>
-        /// Builds a new <see cref="OffsetExpression"/> instance
-        /// </summary>
-        /// <param name="sign"></param>
-        /// <param name="hours"></param>
-        /// <param name="minutes">The sign of </param>
-        public OffsetExpression(NumericSign sign = NumericSign.Plus, uint hours = 0, uint minutes = 0)
+    /// <summary>
+    /// Builds a new <see cref="OffsetExpression"/> instance
+    /// </summary>
+    /// <param name="sign"></param>
+    /// <param name="hours"></param>
+    /// <param name="minutes">The sign of </param>
+    public OffsetExpression(NumericSign sign = NumericSign.Plus, uint hours = 0, uint minutes = 0)
+    {
+        if (hours > 23)
         {
-            if (hours > 23)
-            {
-                throw new ArgumentOutOfRangeException(nameof(hours),
-                    $"{nameof(hours)} must be between 0 and 23 inclusive");
-            }
+            throw new ArgumentOutOfRangeException(nameof(hours),
+                                                  $"{nameof(hours)} must be between 0 and 23 inclusive");
+        }
 
-            if (minutes > 59)
-            {
-                throw new ArgumentOutOfRangeException(nameof(minutes),
-                    $"{nameof(minutes)} must be between 0 and 59 inclusive");
-            }
+        if (minutes > 59)
+        {
+            throw new ArgumentOutOfRangeException(nameof(minutes),
+                                                  $"{nameof(minutes)} must be between 0 and 59 inclusive");
+        }
 
         Hours = (int)hours;
         Minutes = (int)minutes;
         Sign = sign;
 
-        _lazyParseableString = new(() => ( Hours, Minutes, Sign ) switch
+        _lazyParseableString = new(() => (Hours, Minutes, Sign) switch
         {
-            (0, 0, _) => "Z",
+            (0, 0, _)                 => "Z",
             (_, _, NumericSign.Minus) => $"-{Hours:D2}:{Minutes:D2}",
-            _ => $"+{Hours:D2}:{Minutes:D2}",
+            _                         => $"+{Hours:D2}:{Minutes:D2}",
         });
     }
 
@@ -68,44 +67,33 @@ public sealed class OffsetExpression : FilterExpression, IEquatable<OffsetExpres
     public override bool Equals(object obj) => Equals(obj as OffsetExpression);
 
     ///<inheritdoc/>
-    public bool Equals(OffsetExpression other) => ( Hours, Minutes, Sign ) switch
+    public bool Equals(OffsetExpression other) => (Hours, Minutes, Sign) switch
     {
-        (0, 0, _) => other?.Hours == 0 && other?.Minutes == 0,
-        _ => ( Hours, Minutes, Sign ) == ( other?.Hours, other?.Minutes, other?.Sign )
+        (0, 0, _) => other is { Hours: 0, Minutes: 0 },
+        _         => (Hours, Minutes, Sign) == (other?.Hours, other?.Minutes, other?.Sign)
     };
 
     ///<inheritdoc/>
-#if NETSTANDARD2_1_OR_GREATER || NET5_0_OR_GREATER
     public override int GetHashCode() => HashCode.Combine(Hours, Minutes, Sign);
-#else
-        public override int GetHashCode()
-        {
-            int hashCode = -793696894;
-            hashCode = ( hashCode * -1521134295 ) + Hours.GetHashCode();
-            hashCode = ( hashCode * -1521134295 ) + Minutes.GetHashCode();
-            hashCode = ( hashCode * -1521134295 ) + Sign.GetHashCode();
-            return hashCode;
-        }
-#endif
 
-        ///<inheritdoc/>
-        public void Deconstruct(out NumericSign sign, out int hours, out int minutes, out string escapedParseableString,
-            out string originalString)
-        {
-            sign = Sign;
-            hours = Hours;
-            minutes = Minutes;
-            escapedParseableString = EscapedParseableString;
-            originalString = OriginalString;
-        }
+    ///<inheritdoc/>
+    public void Deconstruct(out NumericSign sign, out int hours, out int minutes, out string escapedParseableString,
+                            out string originalString)
+    {
+        sign = Sign;
+        hours = Hours;
+        minutes = Minutes;
+        escapedParseableString = EscapedParseableString;
+        originalString = OriginalString;
+    }
 
     /// <inheritdoc />
     public static bool operator ==(OffsetExpression left, OffsetExpression right) => left switch
     {
         null => right is null,
-        _ => left.Equals(right)
+        _    => left.Equals(right)
     };
 
     /// <inheritdoc />
-    public static bool operator !=(OffsetExpression left, OffsetExpression right) => !( left == right );
+    public static bool operator !=(OffsetExpression left, OffsetExpression right) => !(left == right);
 }

--- a/src/DataFilters/Grammar/Syntax/OneOfExpression.cs
+++ b/src/DataFilters/Grammar/Syntax/OneOfExpression.cs
@@ -1,17 +1,16 @@
-﻿namespace DataFilters.Grammar.Syntax;
-
+﻿
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using Candoumbe.MiscUtilities.Comparers;
 using Utilities;
 
+namespace DataFilters.Grammar.Syntax;
 /// <summary>
 /// a <see cref="FilterExpression"/> that contains multiple <see cref="FilterExpression"/>s as <see cref="Values"/>.
 /// </summary>
 public sealed class OneOfExpression : FilterExpression, IEquatable<OneOfExpression>, ISimplifiable, IEnumerable<FilterExpression>
 {
-    private static readonly ArrayEqualityComparer<FilterExpression> EqualityComparer = new();
+    private static readonly ArrayEqualityComparer<FilterExpression> s_equalityComparer = new();
 
     /// <summary>
     /// Collection of <see cref="FilterExpression"/> that the current instance holds.
@@ -81,7 +80,7 @@ public sealed class OneOfExpression : FilterExpression, IEquatable<OneOfExpressi
     }
 
     ///<inheritdoc/>
-    public bool Equals(OneOfExpression other) => other is not null && EqualityComparer.Equals(_values, other._values);
+    public bool Equals(OneOfExpression other) => other is not null && s_equalityComparer.Equals(_values, other._values);
 
     /// <inheritdoc/>
     public override bool Equals(object obj) => Equals(obj as OneOfExpression);

--- a/src/DataFilters/Grammar/Syntax/OrExpression.cs
+++ b/src/DataFilters/Grammar/Syntax/OrExpression.cs
@@ -1,7 +1,7 @@
-﻿namespace DataFilters.Grammar.Syntax;
-
+﻿
 using System;
 
+namespace DataFilters.Grammar.Syntax;
 /// <summary>
 /// Combines two <see cref="FilterExpression"/>s using the logical <c>OR</c> operator
 /// </summary>
@@ -34,11 +34,7 @@ public sealed class OrExpression : BinaryFilterExpression, IEquatable<OrExpressi
     public override bool Equals(object obj) => Equals(obj as OrExpression);
 
     ///<inheritdoc/>
-#if NETSTANDARD1_3 || NETSTANDARD2_0
-        public override int GetHashCode() => (Left, Right).GetHashCode();
-#else
     public override int GetHashCode() => HashCode.Combine(Left, Right);
-#endif
 
     ///<inheritdoc/>
     public override string ToString() => _lazyToString.Value;

--- a/src/DataFilters/Grammar/Syntax/PropertyName.cs
+++ b/src/DataFilters/Grammar/Syntax/PropertyName.cs
@@ -1,15 +1,11 @@
-﻿namespace DataFilters.Grammar.Syntax;
-
+﻿
 using System;
 
+namespace DataFilters.Grammar.Syntax;
 /// <summary>
 /// a <see cref="PropertyName"/> holds the name of a property a filter is build against.
 /// </summary>
-#if NETSTANDARD1_3
-    public class PropertyName : IEquatable<PropertyName>
-#else
 public record PropertyName
-#endif
 {
     /// <summary>
     /// Name of the property a filter is applied to
@@ -36,18 +32,4 @@ public record PropertyName
 
         Name = name;
     }
-
-#if NETSTANDARD1_3
-        ///<inheritdoc/>
-        public bool Equals(PropertyName other) => Name == other?.Name;
-
-        ///<inheritdoc/>
-        public override bool Equals(object obj) => Equals(obj as PropertyName);
-
-        ///<inheritdoc/>
-        public override int GetHashCode() => Name.GetHashCode();
-
-        ///<inheritdoc/>
-        public override string ToString() => $"{nameof(PropertyName)}[{Name}]";
-#endif
 }

--- a/src/DataFilters/Grammar/Syntax/RangeBracketValue.cs
+++ b/src/DataFilters/Grammar/Syntax/RangeBracketValue.cs
@@ -1,8 +1,8 @@
-﻿namespace DataFilters.Grammar.Syntax;
-
+﻿
 using System;
 using System.Collections.Generic;
 
+namespace DataFilters.Grammar.Syntax;
 /// <summary>
 /// stores a range value used in a bracket expression
 /// </summary>
@@ -30,23 +30,19 @@ public sealed class RangeBracketValue(char start, char end) : BracketValue, IEqu
         public override bool Equals(object obj)
         {
             bool equals;
-            switch (obj)
+            if (obj is ConstantBracketValue constantBracketValue)
             {
-                case ConstantBracketValue constantBracketValue:
-                    char[] chars = [.. constantBracketValue.Value];
-                    char head = chars[0];
-#if NETSTANDARD2_1_OR_GREATER || NET5_0_OR_GREATER
-                    char tail = chars[^1];
-#else
-                    char tail = chars[chars.Length - 1];
-#endif
+                char[] chars = [.. constantBracketValue.Value];
+                char head = chars[0];
+                char tail = chars[^1];
                 equals = (Start, End).Equals((head, tail));
-                break;
-            default:
+            }
+            else
+            {
                 equals = Equals(obj as RangeBracketValue);
-                break;
-        }
-        return equals;
+            }
+
+            return equals;
     }
 
     ///<inheritdoc />
@@ -68,18 +64,7 @@ public sealed class RangeBracketValue(char start, char end) : BracketValue, IEqu
     public static bool operator >=(RangeBracketValue left, RangeBracketValue right) => left > right || left == right;
 
     ///<inheritdoc />
-#if NETSTANDARD2_1_OR_GREATER || NET5_0_OR_GREATER
     public override int GetHashCode() => HashCode.Combine(Start, End);
-#else
-        public override int GetHashCode()
-        {
-            int hashCode = -1676728671;
-            hashCode = (hashCode * -1521134295) + Start.GetHashCode();
-            hashCode = (hashCode * -1521134295) + End.GetHashCode();
-            return hashCode;
-        }
-
-#endif
 
     ///<inheritdoc />
     public override string EscapedParseableString => $"[{Start}-{End}]";

--- a/src/DataFilters/Grammar/Syntax/StartsWithExpression.cs
+++ b/src/DataFilters/Grammar/Syntax/StartsWithExpression.cs
@@ -1,10 +1,9 @@
-﻿using Microsoft.Extensions.Primitives;
-using DataFilters.Grammar.Parsing;
-
-using System;
+﻿using System;
 using System.Linq;
 using Ardalis.GuardClauses;
 using Candoumbe.Types.Strings;
+using DataFilters.Grammar.Parsing;
+using Microsoft.Extensions.Primitives;
 
 namespace DataFilters.Grammar.Syntax;
 

--- a/src/DataFilters/Grammar/Syntax/StringValueExpression.cs
+++ b/src/DataFilters/Grammar/Syntax/StringValueExpression.cs
@@ -2,7 +2,6 @@
 using System;
 using System.Linq;
 using Candoumbe.Types.Strings;
-using Microsoft.Extensions.Primitives;
 using static DataFilters.Grammar.Parsing.FilterTokenizer;
 
 namespace DataFilters.Grammar.Syntax;
@@ -22,7 +21,7 @@ public class StringValueExpression : ConstantValueExpression, IEquatable<StringV
     /// The <see cref="EscapedParseableString"/> property automatically escapes <see cref="SpecialCharacters"/> from <paramref name="value"/>.
     /// </remarks>
     /// <param name="value">value of the expression.</param>
-    /// <exception cref="Argument"></exception>
+    /// <exception cref="ArgumentOutOfRangeException">value is empty</exception>
     public StringValueExpression(ReadOnlySpan<char> value) : this(new StringSegmentLinkedList(value))
     {
         // if (!value.HasValue)

--- a/src/DataFilters/Grammar/Syntax/TimeExpression.cs
+++ b/src/DataFilters/Grammar/Syntax/TimeExpression.cs
@@ -1,7 +1,7 @@
-﻿namespace DataFilters.Grammar.Syntax;
-
+﻿
 using System;
 
+namespace DataFilters.Grammar.Syntax;
 /// <summary>
 /// A <see cref="FilterExpression"/> that only consists of time part.
 /// </summary>

--- a/src/DataFilters/IFilter.cs
+++ b/src/DataFilters/IFilter.cs
@@ -1,9 +1,9 @@
-﻿namespace DataFilters;
+﻿using System;
 
-using System;
+namespace DataFilters;
 
 /// <summary>
-/// Defines the basic shape of a filter
+/// Defines the basic shape of a filter.
 /// </summary>
 public interface IFilter : IEquatable<IFilter>
 {
@@ -19,8 +19,6 @@ public interface IFilter : IEquatable<IFilter>
     /// <returns>The exact opposite of the current instance.</returns>
     IFilter Negate();
 
-#if NETSTANDARD2_1 || NET5_0_OR_GREATER
     ///<inheritdoc/>
-    public virtual void ToString() => ToJson();
-#endif
+    public void ToString() => ToJson();
 }

--- a/src/DataFilters/IOrder.cs
+++ b/src/DataFilters/IOrder.cs
@@ -1,7 +1,6 @@
-﻿namespace DataFilters;
+﻿using System;
 
-using System;
-
+namespace DataFilters;
 /// <summary>
 /// Marker interface
 /// </summary>
@@ -16,9 +15,5 @@ public interface IOrder<T> : IEquatable<IOrder<T>>
     /// Two <see cref="IOrder{T}"/> instances are equivalent when, given an expression, one can be swapped for the other without altering the meaning of the whole expression.
     /// </remarks>
     /// <returns><c>true</c> when current instance and <c>other</c> are equivalent and <c>false</c> otherwise.</returns>
-#if !(NETSTANDARD1_3 || NETSTANDARD2_0)
-    public virtual bool IsEquivalentTo(IOrder<T> other) => Equals(other);
-#else
-        bool IsEquivalentTo(IOrder<T> other);
-#endif
+    public bool IsEquivalentTo(IOrder<T> other) => Equals(other);
 }

--- a/src/DataFilters/InvalidOrderExpressionException.cs
+++ b/src/DataFilters/InvalidOrderExpressionException.cs
@@ -1,7 +1,7 @@
-﻿namespace DataFilters;
-
+﻿
 using System;
 
+namespace DataFilters;
 /// <summary>
 /// Exception thrown for an invalid sort expression.
 /// </summary>

--- a/src/DataFilters/MultiOrder.cs
+++ b/src/DataFilters/MultiOrder.cs
@@ -1,11 +1,11 @@
-﻿namespace DataFilters;
-
+﻿
 using System;
 using System.Collections.Generic;
 using System.Linq;
 
 using Utilities;
 
+namespace DataFilters;
 /// <summary>
 /// Allow to sort by multiple <see cref="Order{T}"/> expression
 /// </summary>
@@ -21,16 +21,15 @@ public class MultiOrder<T>(params Order<T>[] orders) : IOrder<T>, IEquatable<Mul
     /// </summary>
     public IEnumerable<Order<T>> Orders => _orders;
 
-    private readonly Order<T>[] _orders = orders.Where(s => s is not null)
-        .ToArray();
+    private readonly Order<T>[] _orders = [ .. orders.Where(s => s is not null) ];
 
-    private static readonly ArrayEqualityComparer<Order<T>> EqualityComparer = new();
+    private static readonly ArrayEqualityComparer<Order<T>> s_equalityComparer = new();
 
     /// <inheritdoc/>
     public bool Equals(IOrder<T> other) => Equals(other as MultiOrder<T>);
 
     /// <inheritdoc/>
-    public bool Equals(MultiOrder<T> other) => other is not null && EqualityComparer.Equals(_orders, other._orders);
+    public bool Equals(MultiOrder<T> other) => other is not null && s_equalityComparer.Equals(_orders, other._orders);
 
     /// <inheritdoc/>
     public override bool Equals(object obj) => Equals(obj as MultiOrder<T>);
@@ -40,7 +39,7 @@ public class MultiOrder<T>(params Order<T>[] orders) : IOrder<T>, IEquatable<Mul
                                                    && Orders.SequenceEqual(otherMultisort.Orders);
 
     /// <inheritdoc/>
-    public override int GetHashCode() => EqualityComparer.GetHashCode(_orders);
+    public override int GetHashCode() => s_equalityComparer.GetHashCode(_orders);
 
     /// <inheritdoc/>
     public override string ToString() => $"{nameof(Orders)}:[{string.Join(",", Orders.Select(x => x.ToString()))}]";

--- a/src/DataFilters/OrderValidator.cs
+++ b/src/DataFilters/OrderValidator.cs
@@ -1,15 +1,13 @@
-﻿using FluentValidation;
+﻿using System;
 using System.Linq;
+using System.Text.RegularExpressions;
+using FluentValidation;
 
 namespace DataFilters;
-
-using System;
-using System.Text.RegularExpressions;
-
 /// <summary>
 /// Validates sort expression
 /// </summary>
-public class OrderValidator : AbstractValidator<string>
+public partial class OrderValidator : AbstractValidator<string>
 {
     private const string FieldPattern = Filter.ValidFieldNamePattern;
     /// <summary>
@@ -28,11 +26,15 @@ public class OrderValidator : AbstractValidator<string>
         {
             string[] incorrectExpressions = search.Split([Separator])
                 // TODO use ZLinq
-                        .Where(x => !_orderRegex.IsMatch(x))
-                        .Select(x => $@"""{x}""")
-                        .ToArray();
+                    .Where(x => !_orderRegex.IsMatch(x))
+                    .Select(x => $"""
+                                  "{x}"
+                                  """)
+                    .ToArray();
 
-            return $"Sort expression{(incorrectExpressions.Length == 1 ? string.Empty : "s")} {string.Join(", ", incorrectExpressions)} " +
-                   $@"do{(incorrectExpressions.Length == 1 ? "es" : string.Empty)} not match ""{Pattern}"".";
+            return $"""
+                    Sort expression{(incorrectExpressions.Length == 1 ? string.Empty : "s")} {string.Join(", ", incorrectExpressions)}
+                    do{(incorrectExpressions.Length == 1 ? "es" : string.Empty)} not match "{Pattern}.
+                    """;
         });
 }

--- a/src/DataFilters/Serialization/CamelCaseEnumTypeConverter.cs
+++ b/src/DataFilters/Serialization/CamelCaseEnumTypeConverter.cs
@@ -1,7 +1,7 @@
-﻿namespace DataFilters.Converters;
-
-using Newtonsoft.Json.Converters;
+﻿using Newtonsoft.Json.Converters;
 using Newtonsoft.Json.Serialization;
+
+namespace DataFilters.Serialization;
 
 /// <summary>
 /// Converter that specifies that enum members should be converted using CamelCaseNamingStrategy

--- a/src/DataFilters/Serialization/FilterConverter.cs
+++ b/src/DataFilters/Serialization/FilterConverter.cs
@@ -1,29 +1,18 @@
-﻿namespace DataFilters.Converters;
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
-
-#if NETSTANDARD1_3
-    using Newtonsoft.Json;
-    using Newtonsoft.Json.Linq;
-#else
 using System.Text.Json;
 using System.Text.Json.Serialization;
-#endif
+
+namespace DataFilters.Serialization;
 
 /// <summary>
 /// <see cref="JsonConverter"/> implementation that can convert from/to <see cref="Filter"/>
 /// </summary>
-#if NETSTANDARD1_3
-    public class FilterConverter : JsonConverter
-#else
 public class FilterConverter : JsonConverter<Filter>
-
-#endif
 {
-    private static readonly IImmutableDictionary<string, FilterOperator> Operators = new Dictionary<string, FilterOperator>
+    private static readonly IImmutableDictionary<string, FilterOperator> s_operators = new Dictionary<string, FilterOperator>
     {
         ["contains"] = FilterOperator.Contains,
         ["ncontains"] = FilterOperator.NotContains,
@@ -43,49 +32,6 @@ public class FilterConverter : JsonConverter<Filter>
         ["nstartswith"] = FilterOperator.NotStartsWith
     }.ToImmutableDictionary();
 
-#if NETSTANDARD1_3
-        /// <inheritdoc/>
-        public override bool CanConvert(Type objectType) => objectType == typeof(Filter);
-
-        /// <inheritdoc/>
-        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
-        {
-            Filter filter = null;
-
-            JToken token = JToken.ReadFrom(reader);
-            if (objectType == typeof(Filter) && token.Type == JTokenType.Object)
-            {
-                IEnumerable<JProperty> properties = ((JObject)token).Properties();
-
-                if (properties.Any(prop => prop.Name == Filter.FieldJsonPropertyName)
-                     && properties.Any(prop => prop.Name == Filter.OperatorJsonPropertyName))
-                {
-                    string field = token[Filter.FieldJsonPropertyName].Value<string>();
-                    FilterOperator @operator = _operators[token[Filter.OperatorJsonPropertyName].Value<string>()];
-                    object value = null;
-                    if (!Filter.UnaryOperators.Contains(@operator))
-                    {
-                        JToken valueToken = token[Filter.ValueJsonPropertyName];
-                        value = valueToken?.Type switch
-                        {
-                            JTokenType.String => valueToken.Value<string>(),
-                            JTokenType.Boolean => valueToken.Value<bool>(),
-                            JTokenType.Integer => valueToken.Value<long>(),
-                            JTokenType.Float => valueToken.Value<float>(),
-                            JTokenType.Null => null,
-                            null => null,
-                            _ => throw new NotSupportedException($"Unexpected valueTokenType {valueToken.Type} when dealing with operator {@operator}")
-
-                        };
-                    }
-                    filter = new Filter(field, @operator, value);
-                }
-            }
-
-            return filter?.As(objectType);
-        }
-
-#else
     ///<inheritdoc/>
     public override Filter Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
     {
@@ -110,7 +56,7 @@ public class FilterConverter : JsonConverter<Filter>
         }
 
         reader.Read();
-        FilterOperator op = Operators[reader.GetString()];
+        FilterOperator op = s_operators[reader.GetString()];
         if (!Filter.UnaryOperators.Contains(op))
         {
             if (reader.Read() && reader.TokenType == JsonTokenType.PropertyName && Filter.ValueJsonPropertyName == reader.GetString())
@@ -143,47 +89,28 @@ public class FilterConverter : JsonConverter<Filter>
         return new Filter(field, op, value);
     }
 
-#endif
 
     ///<inheritdoc/>
-#if NETSTANDARD1_3
-        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
-        {
-            Filter filter = (Filter)value;
-#else
     public override void Write(Utf8JsonWriter writer, Filter value, JsonSerializerOptions options)
     {
         Filter filter = value;
-#endif
         writer.WriteStartObject();
 
         // Field
         writer.WritePropertyName(Filter.FieldJsonPropertyName);
-#if NETSTANDARD1_3
-            writer.WriteValue(filter.Field);
-#else
         writer.WriteStringValue(filter.Field);
-#endif
-
         // operator
         writer.WritePropertyName(Filter.OperatorJsonPropertyName);
-        KeyValuePair<string, FilterOperator> kv = Operators.Single(item => item.Value == filter.Operator);
+        KeyValuePair<string, FilterOperator> kv = s_operators.Single(item => item.Value == filter.Operator);
 
-#if NETSTANDARD1_3
-            writer.WriteValue(kv.Key);
-#else
         writer.WriteStringValue(kv.Key);
-#endif
 
         // value (only if the operator is not an unary operator)
         if (!Filter.UnaryOperators.Contains(filter.Operator))
         {
             writer.WritePropertyName(Filter.ValueJsonPropertyName);
-#if NETSTANDARD1_3
-                writer.WriteValue(filter.Value);
-#else
+
             writer.WriteStringValue(filter.Value.ToString());
-#endif
         }
 
         writer.WriteEndObject();

--- a/src/DataFilters/Serialization/FilterOperatorConverter.cs
+++ b/src/DataFilters/Serialization/FilterOperatorConverter.cs
@@ -1,28 +1,19 @@
-﻿namespace DataFilters.Converters;
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
-#if NETSTANDARD1_3
-    using Newtonsoft.Json;
-#else
 using System.Text.Json;
 using System.Text.Json.Serialization;
-#endif
+
+namespace DataFilters.Serialization;
 
 /// <summary>
 /// <see cref="JsonConverter"/> implementation that can handle (de)serialization of <see cref="FilterOperator"/>
 /// from/to JSon .
 /// </summary>
-#if NETSTANDARD1_3
-    public class FilterOperatorConverter : JsonConverter
-    {
-#else
 public class FilterOperatorConverter : JsonConverter<FilterOperator>
 {
-#endif
-    private static readonly IImmutableDictionary<string, FilterOperator> Operators = new Dictionary<string, FilterOperator>
+    private static readonly IImmutableDictionary<string, FilterOperator> s_operators = new Dictionary<string, FilterOperator>
     {
         ["contains"] = FilterOperator.Contains,
         ["ncontains"] = FilterOperator.NotContains,
@@ -42,23 +33,6 @@ public class FilterOperatorConverter : JsonConverter<FilterOperator>
         ["nstartswith"] = FilterOperator.NotStartsWith
     }.ToImmutableDictionary();
 
-#if NETSTANDARD1_3
-        /// <inheritdoc/>
-        public override bool CanConvert(Type objectType) => typeof(FilterOperator) == objectType;
-
-        /// <inheritdoc/>
-        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
-        {
-            if (reader.TokenType != JsonToken.String)
-            {
-                throw new JsonReaderException();
-            }
-
-            string op = reader.ReadAsString();
-
-            return _operators[op.ToLower()];
-        }
-#else
     /// <inheritdoc/>
     public override FilterOperator Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
     {
@@ -68,28 +42,13 @@ public class FilterOperatorConverter : JsonConverter<FilterOperator>
         }
 
         string op = reader.GetString();
-        return Operators[op.ToLower()];
+        return s_operators[op.ToLower()];
     }
-#endif
-
-#if NETSTANDARD1_3
-        /// <inheritdoc/>
-        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
-        {
-            KeyValuePair<string, FilterOperator> result = _operators.Single(op => op.Value == (FilterOperator)value);
-            writer.WriteValue(result.Key);
-        }
-#else
 
     /// <inheritdoc/>
     public override void Write(Utf8JsonWriter writer, FilterOperator value, JsonSerializerOptions options)
     {
-#if NETSTANDARD2_0
-        string key = Operators.Single(op => op.Value == value).Key;
-#else
-        (string key, _) = Operators.Single(op => op.Value == value);
-#endif
+        (string key, _) = s_operators.Single(op => op.Value == value);
         writer.WriteStringValue(key);
     }
-#endif
 }

--- a/src/Datafilters.Expressions/OrderExpression.cs
+++ b/src/Datafilters.Expressions/OrderExpression.cs
@@ -1,9 +1,8 @@
-﻿namespace DataFilters.Expressions;
-
-using System;
+﻿using System;
 using System.Linq.Expressions;
-
 using static DataFilters.OrderDirection;
+
+namespace DataFilters.Expressions;
 
 /// <summary>
 /// An instance of this class holds an <see cref="LambdaExpression"/> which defines a property and its related <see cref="OrderDirection"/> to use to order collections

--- a/src/Datafilters.Expressions/OrderExtensions.cs
+++ b/src/Datafilters.Expressions/OrderExtensions.cs
@@ -1,8 +1,8 @@
-﻿namespace DataFilters;
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 using DataFilters.Expressions;
+
+namespace DataFilters;
 
 /// <summary>
 /// Extension methods for <see cref="IOrder{T}"/> instances.

--- a/src/Datafilters.Expressions/QueryableExtensions.cs
+++ b/src/Datafilters.Expressions/QueryableExtensions.cs
@@ -1,9 +1,9 @@
-﻿namespace System.Linq;
-
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq.Expressions;
 using DataFilters;
 using DataFilters.Expressions;
+
+namespace System.Linq;
 
 /// <summary>
 /// Provides extension methods for ordering a collection of entities.

--- a/test/DataFilters.Expressions.UnitTests/FilterToExpressionsTests.cs
+++ b/test/DataFilters.Expressions.UnitTests/FilterToExpressionsTests.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
@@ -9,12 +10,11 @@ using NodaTime;
 using Xunit;
 using Xunit.Abstractions;
 using Xunit.Categories;
+using static DataFilters.Expressions.NullableValueBehavior;
+using static DataFilters.FilterLogic;
+using static DataFilters.FilterOperator;
 
 namespace DataFilters.Expressions.UnitTests;
-
-using static NullableValueBehavior;
-using static FilterLogic;
-using static FilterOperator;
 
 [Feature("Filters")]
 [UnitTest]
@@ -69,7 +69,7 @@ public class FilterToExpressionTests(ITestOutputHelper output)
                             PeakShape = TimeOnly.FromTimeSpan(13.Hours())
                         },
 #else
-                        new SuperHero { Firstname = "Bruce", Lastname = "Wayne", Height = 190, Nickname = "Batman", BirthDate = 1.April(1938) },  
+                        new SuperHero { Firstname = "Bruce", Lastname = "Wayne", Height = 190, Nickname = "Batman", BirthDate = 1.April(1938) },
 #endif
                         new SuperHero { Firstname = "Clark", Lastname = "Kent", Height = 190, Nickname = "Superman" }
                     },
@@ -93,17 +93,19 @@ public class FilterToExpressionTests(ITestOutputHelper output)
                     new MultiFilter
                     {
                         Logic = And,
-                        Filters = new IFilter[] {
+                        Filters =
+                        [
                             new Filter(field: nameof(SuperHero.Firstname), @operator: Contains, value: "a"),
                             new MultiFilter
                             {
                                 Logic = Or,
-                                Filters = new[] {
+                                Filters =
+                                [
                                     new Filter(field: nameof(SuperHero.Nickname), @operator: EqualTo, value: "Batman"),
                                     new Filter(field: nameof(SuperHero.Nickname), @operator: EqualTo, value: "Superman")
-                                }
+                                ]
                             }
-                        }
+                        ]
                     },
                     NoAction,
                     item => item.Firstname.Contains('a') && (item.Nickname == "Batman" || item.Nickname == "Superman")
@@ -120,28 +122,30 @@ public class FilterToExpressionTests(ITestOutputHelper output)
 #else
                         new SuperHero { Firstname = "Bruce", Lastname = "Wayne", Height = 190, Nickname = "Batman", LastBattleDate = 25.December(2012) },
                         new SuperHero { Firstname = "Clark", Lastname = "Kent", Height = 190, Nickname = "Superman", LastBattleDate = 13.January(2007)},
-                        new SuperHero { Firstname = "Barry", Lastname = "Allen", Height = 190, Nickname = "Flash", LastBattleDate = 18.April(2014) }  
+                        new SuperHero { Firstname = "Barry", Lastname = "Allen", Height = 190, Nickname = "Flash", LastBattleDate = 18.April(2014) }
 #endif
                     },
                     new MultiFilter
                     {
                         Logic = And,
-                        Filters = new IFilter[] {
+                        Filters =
+                        [
                             new Filter(field: nameof(SuperHero.Firstname), @operator: Contains, value: "a"),
                             new MultiFilter
                             {
                                 Logic = And,
-                                Filters = new[] {
+                                Filters =
+                                [
 #if NET6_0_OR_GREATER
                                     new Filter(field: nameof(SuperHero.LastBattleDate), @operator: GreaterThan, value: DateOnly.FromDateTime(1.January(2007))),
-                                    new Filter(field: nameof(SuperHero.LastBattleDate), @operator: LessThan, value: DateOnly.FromDateTime(31.December(2012))),
+                                    new Filter(field: nameof(SuperHero.LastBattleDate), @operator: FilterOperator.LessThan, value: DateOnly.FromDateTime(31.December(2012))),
 #else
 		                            new Filter(field : nameof(SuperHero.LastBattleDate), @operator : GreaterThan, value : 1.January(2007)),
                                     new Filter(field : nameof(SuperHero.LastBattleDate), @operator : FilterOperator.LessThan, value : 31.December(2012))
 #endif
-                                }
+                                ]
                             }
-                        }
+                        ]
                     },
                     NoAction,
 
@@ -157,8 +161,7 @@ public class FilterToExpressionTests(ITestOutputHelper output)
 #endif
                 },
                 {
-                    new[]
-                    {
+                    [
 #if NET6_0_OR_GREATER
                         new SuperHero { Firstname = "Bruce", Lastname = "Wayne", Height = 190, Nickname = "Batman", LastBattleDate = DateOnly.FromDateTime(25.December(2012)) },
                         new SuperHero { Firstname = "Clark", Lastname = "Kent", Height = 190, Nickname = "Superman", LastBattleDate = DateOnly.FromDateTime(13.January(2007)) },
@@ -166,28 +169,30 @@ public class FilterToExpressionTests(ITestOutputHelper output)
 #else
                         new SuperHero { Firstname = "Bruce", Lastname = "Wayne", Height = 190, Nickname = "Batman", LastBattleDate = 25.December(2012) },
                         new SuperHero { Firstname = "Clark", Lastname = "Kent", Height = 190, Nickname = "Superman", LastBattleDate = 13.January(2007)},
-                        new SuperHero { Firstname = "Barry", Lastname = "Allen", Height = 190, Nickname = "Flash", LastBattleDate = 18.April(2014) }  
+                        new SuperHero { Firstname = "Barry", Lastname = "Allen", Height = 190, Nickname = "Flash", LastBattleDate = 18.April(2014) }
 #endif
-                    },
+                    ],
                     new MultiFilter
                     {
                         Logic = And,
-                        Filters = new IFilter[] {
+                        Filters =
+                        [
                             new Filter(field: nameof(SuperHero.Firstname), @operator: Contains, value: "a"),
                             new MultiFilter
                             {
                                 Logic = And,
-                                Filters = new[] {
+                                Filters =
+                                [
 #if NET6_0_OR_GREATER
                                     new Filter(field: nameof(SuperHero.LastBattleDate), @operator: GreaterThan, value: DateOnly.FromDateTime(1.January(2007))),
-                                    new Filter(field: nameof(SuperHero.LastBattleDate), @operator: LessThan, value: DateOnly.FromDateTime(31.December(2012)))
+                                    new Filter(field: nameof(SuperHero.LastBattleDate), @operator: FilterOperator.LessThan, value: DateOnly.FromDateTime(31.December(2012)))
 #else
 		                            new Filter(field : nameof(SuperHero.LastBattleDate), @operator : GreaterThan, value : 1.January(2007)),
                                     new Filter(field : nameof(SuperHero.LastBattleDate), @operator : FilterOperator.LessThan, value : 31.December(2012))
-#endif           
-                                }
+#endif
+                                ]
                             }
-                        }
+                        ]
                     },
                     NoAction,
 #if NET6_0_OR_GREATER
@@ -239,7 +244,7 @@ public class FilterToExpressionTests(ITestOutputHelper output)
                             }
                         }
                     ],
-                    new Filter(field: @$"{nameof(SuperHero.Henchman)}[""{nameof(Henchman.Weapons)}""][""{nameof(Weapon.Name)}""]",
+                    new Filter(field: $"""{nameof(SuperHero.Henchman)}["{nameof(Henchman.Weapons)}"]["{nameof(Weapon.Name)}"]""",
                                @operator: EqualTo,
                                value: "stick"),
                     NoAction,
@@ -304,7 +309,7 @@ public class FilterToExpressionTests(ITestOutputHelper output)
                             Firstname = "Dick", Lastname = "Grayson", Nickname = "Robin"
                         }
                     },
-                    new SuperHero 
+                    new SuperHero
                     {
                         Firstname = "Clark", Lastname = "Kent", Height = 190, Nickname = "Superman",
                         Henchman = new Henchman
@@ -582,11 +587,11 @@ public class FilterToExpressionTests(ITestOutputHelper output)
                 new MultiFilter
                 {
                     Logic = Or,
-                    Filters = new IFilter[]
-                    {
+                    Filters =
+                    [
                         new Filter(field : nameof(SuperHero.Powers), @operator : Contains, value: "heat"),
-                        new Filter(field : nameof(SuperHero.Powers), @operator : Contains, value: "speed"),
-                    }
+                        new Filter(field : nameof(SuperHero.Powers), @operator : Contains, value: "speed")
+                    ]
                 },
                 NoAction,
                 item => item.Powers.Any(power => power.Contains("heat") || power.Contains("speed"))
@@ -626,7 +631,7 @@ public class FilterToExpressionTests(ITestOutputHelper output)
                     new SuperHero { Firstname = "Clark", Lastname = "Kent", Height = 190, Nickname = "Superman" },
                     new SuperHero { Firstname = null, Lastname = "", Height = 178, Nickname = "Sinestro" }
                 ],
-                new Filter(field : nameof(SuperHero.Height), @operator : LessThan, value: 150),
+                new Filter(field : nameof(SuperHero.Height), @operator : FilterOperator.LessThan, value: 150),
                 NoAction,
                 item => item.Height < 150
             }
@@ -692,7 +697,7 @@ public class FilterToExpressionTests(ITestOutputHelper output)
         => new()
         {
             {
-#if NET6_0_OR_GREATER
+#if NET8_0_OR_GREATER
                 [
                     new SuperHero { Firstname = "Bruce", Lastname = "Wayne", Height = 190, Nickname = "Batman", LastBattleDate = DateOnly.FromDateTime(25.December(2012)) },
                     new SuperHero { Firstname = "Clark", Lastname = "Kent", Height = 190, Nickname = "Superman", LastBattleDate = DateOnly.FromDateTime(13.January(2007))},
@@ -769,7 +774,7 @@ public class FilterToExpressionTests(ITestOutputHelper output)
     [InlineData(IsNotEmpty, "")]
     [InlineData(IsNull, "")]
     [InlineData(IsNotNull, "")]
-    [InlineData(LessThan, " ")]
+    [InlineData(FilterOperator.LessThan, " ")]
     [InlineData(LessThanOrEqualTo, " ")]
     [InlineData(NotEqualTo, " ")]
     [InlineData(StartsWith, " ")]

--- a/test/DataFilters.Expressions.UnitTests/Hero.cs
+++ b/test/DataFilters.Expressions.UnitTests/Hero.cs
@@ -1,8 +1,8 @@
-﻿namespace DataFilters.Expressions.UnitTests;
-
+﻿
 using System;
 using System.Collections.Generic;
 
+namespace DataFilters.Expressions.UnitTests;
 public class Hero : IEquatable<Hero>
 {
     public string Name { get; set; }

--- a/test/DataFilters.Expressions.UnitTests/NodaTimeClass.cs
+++ b/test/DataFilters.Expressions.UnitTests/NodaTimeClass.cs
@@ -1,8 +1,8 @@
-﻿namespace DataFilters.Expressions.UnitTests;
-
+﻿
 using System.Diagnostics.CodeAnalysis;
 using NodaTime;
 
+namespace DataFilters.Expressions.UnitTests;
 [ExcludeFromCodeCoverage]
 public class NodaTimeClass
 {

--- a/test/DataFilters.Expressions.UnitTests/QueryableExtensionsTests.cs
+++ b/test/DataFilters.Expressions.UnitTests/QueryableExtensionsTests.cs
@@ -1,5 +1,4 @@
-﻿namespace DataFilters.Expressions.UnitTests;
-
+﻿
 using System;
 using System.Linq;
 using FluentAssertions;
@@ -7,6 +6,7 @@ using Xunit;
 using Xunit.Abstractions;
 using Xunit.Categories;
 
+namespace DataFilters.Expressions.UnitTests;
 [UnitTest]
 public class QueryableExtensionsTests(ITestOutputHelper outputHelper)
 {

--- a/test/DataFilters.Expressions.UnitTests/ToOrderClauseTests.cs
+++ b/test/DataFilters.Expressions.UnitTests/ToOrderClauseTests.cs
@@ -1,5 +1,4 @@
-﻿namespace DataFilters.Expressions.UnitTests;
-
+﻿
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -10,6 +9,7 @@ using Xunit;
 using Xunit.Categories;
 using static DataFilters.OrderDirection;
 
+namespace DataFilters.Expressions.UnitTests;
 [UnitTest]
 [Feature("Expressions")]
 public class ToOrderClauseTests

--- a/test/DataFilters.PerformanceTests/GroupParserPerformanceTests.cs
+++ b/test/DataFilters.PerformanceTests/GroupParserPerformanceTests.cs
@@ -28,7 +28,7 @@ public class GroupParserPerformanceTests
     {
         _tokenizer = new FilterTokenizer();
         StringBuilder sb = new StringBuilder();
-            
+
         // Ajout des parenthèses ouvrantes
         for (int i = 0; i < ParenthesesCount; i++)
         {
@@ -45,10 +45,10 @@ public class GroupParserPerformanceTests
         }
 
         _constructedString = sb.ToString();
-            
+
         _tokens = _tokenizer.Tokenize(_constructedString);
     }
-        
+
     [Benchmark]
     public GroupExpression Parse() => FilterTokenParser.Group.Parse(_tokens);
 

--- a/test/DataFilters.Queries.UnitTests/FilterToQueriesTests.cs
+++ b/test/DataFilters.Queries.UnitTests/FilterToQueriesTests.cs
@@ -1,4 +1,3 @@
-namespace DataFilters.Queries.UnitTests;
 
 using System;
 using FluentAssertions;
@@ -8,6 +7,7 @@ using Xunit;
 using Xunit.Abstractions;
 using static DataFilters.FilterOperator;
 
+namespace DataFilters.Queries.UnitTests;
 public class FilterToQueriesTests(ITestOutputHelper outputHelper)
 {
     public static TheoryData<IFilter, IWhereClause> FilterToWhereCases

--- a/test/DataFilters.Queries.UnitTests/OrderToQueriesTests.cs
+++ b/test/DataFilters.Queries.UnitTests/OrderToQueriesTests.cs
@@ -1,5 +1,4 @@
-﻿namespace DataFilters.Queries.UnitTests;
-
+﻿
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -10,6 +9,7 @@ using Xunit;
 using Xunit.Abstractions;
 using static global::Queries.Core.Parts.Sorting.OrderDirection;
 
+namespace DataFilters.Queries.UnitTests;
 public class OrderToQueriesTests(ITestOutputHelper outputHelper)
 {
     public class Person

--- a/test/DataFilters.TestObjects/Appointment.cs
+++ b/test/DataFilters.TestObjects/Appointment.cs
@@ -1,7 +1,7 @@
+using System;
+
 namespace DataFilters.TestObjects
 {
-    using System;
-
     public class Appointment
     {
         public string Name { get; set; }

--- a/test/DataFilters.TestObjects/Model.cs
+++ b/test/DataFilters.TestObjects/Model.cs
@@ -1,7 +1,7 @@
-﻿namespace DataFilters.TestObjects
-{
-    using System.Diagnostics.CodeAnalysis;
+﻿using System.Diagnostics.CodeAnalysis;
 
+namespace DataFilters.TestObjects
+{
     [ExcludeFromCodeCoverage]
     public class Model
     {
@@ -9,8 +9,8 @@
 
 #pragma warning disable IDE1006 // Styles d'affectation de noms
         public string snake_case_property { get; set; }
-#pragma warning restore IDE1006 // Styles d'affectation de noms
 
         public string CAPITALCASINGPROPERTY { get; set; }
+#pragma warning restore IDE1006 // Styles d'affectation de noms
     }
 }

--- a/test/DataFilters.TestObjects/Person.cs
+++ b/test/DataFilters.TestObjects/Person.cs
@@ -1,8 +1,8 @@
+using System;
+using System.Diagnostics.CodeAnalysis;
+
 namespace DataFilters.TestObjects
 {
-    using System;
-    using System.Diagnostics.CodeAnalysis;
-
     [ExcludeFromCodeCoverage]
     public class Person
     {

--- a/test/DataFilters.TestObjects/SuperHero.cs
+++ b/test/DataFilters.TestObjects/SuperHero.cs
@@ -1,10 +1,10 @@
-﻿namespace DataFilters.TestObjects
-{
-    using System;
-    using System.Collections.Generic;
-    using System.Diagnostics.CodeAnalysis;
-    using System.Linq;
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 
+namespace DataFilters.TestObjects
+{
     [ExcludeFromCodeCoverage]
     public class SuperHero : Person
     {

--- a/test/DataFilters.UnitTests/Converters/DataFilterConvertersTests.cs
+++ b/test/DataFilters.UnitTests/Converters/DataFilterConvertersTests.cs
@@ -1,9 +1,4 @@
-﻿#if NETCOREAPP2_1
-using static Newtonsoft.Json.JsonConvert;
-#endif
-namespace DataFilters.UnitTests.Converters;
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
@@ -16,6 +11,8 @@ using Xunit.Abstractions;
 using Xunit.Categories;
 using static DataFilters.FilterLogic;
 using static DataFilters.FilterOperator;
+
+namespace DataFilters.UnitTests.Converters;
 
 [UnitTest]
 [Feature("Converters")]

--- a/test/DataFilters.UnitTests/FilterExtensionsTests.cs
+++ b/test/DataFilters.UnitTests/FilterExtensionsTests.cs
@@ -17,374 +17,283 @@ public class FilterExtensionsTests(ITestOutputHelper outputHelper)
 {
     public static TheoryData<string, IFilter> ToFilterCases
         => new()
+        {
+            {
+                $"{nameof(Person.Firstname)}=Hal&{nameof(Person.Lastname)}=Jordan", new MultiFilter
                 {
-                    {
-                        $"{nameof(Person.Firstname)}=Hal&{nameof(Person.Lastname)}=Jordan",
-                        new MultiFilter
-                        {
-                            Logic = And,
-                            Filters =
-                            [
-                                new Filter(nameof(Person.Firstname), EqualTo, "Hal"),
-                            new Filter(nameof(Person.Lastname), EqualTo, "Jordan")
-                            ]
+                    Logic = And,
+                    Filters =
+                    [
+                        new Filter(nameof(Person.Firstname), EqualTo, "Hal"),
+                        new Filter(nameof(Person.Lastname), EqualTo, "Jordan")
+                    ]
                 }
             },
-
+            { string.Empty, new Filter(field: null, @operator: EqualTo) },
+            { string.Empty, Filter.True },
+            { $"{nameof(Person.Firstname)}=!*wayne", new Filter(field: nameof(Person.Firstname), @operator: NotEndsWith, value: "wayne") },
             {
-                string.Empty,
-                new Filter(field: null, @operator: EqualTo)
+                $"{nameof(Person.Firstname)}=Vandal|Genghis", new MultiFilter
+                {
+                    Logic = Or,
+                    Filters =
+                    [
+                        new Filter(field: nameof(Person.Firstname), @operator: EqualTo, value: "Vandal"),
+                        new Filter(field: nameof(Person.Firstname), @operator: EqualTo, value: "Genghis")
+                    ]
+                }
             },
             {
-                string.Empty,
-                Filter.True
-            },
-            {
-                $"{nameof(Person.Firstname)}=!*wayne",
-                new Filter(field: nameof(Person.Firstname), @operator: NotEndsWith, value: "wayne")
-            },
-            {
-                $"{nameof(Person.Firstname)}=Vandal|Genghis",
+                $"{nameof(Person.Firstname)}=(V*|G*),(*l|*s)", new MultiFilter
+                {
+                    Logic = And,
+                    Filters =
+                    [
                         new MultiFilter
                         {
                             Logic = Or,
                             Filters =
-                            [
-                                new Filter(field: nameof(Person.Firstname), @operator: EqualTo, value: "Vandal"),
-                            new Filter(field: nameof(Person.Firstname), @operator: EqualTo, value: "Genghis")
-                            ]
-                        }
-                    },
-                    {
-                        $"{nameof(Person.Firstname)}=(V*|G*),(*l|*s)",
-                        new MultiFilter
-                        {
-                            Logic = And,
-                            Filters =
-                            [
-                                new MultiFilter
-                            {
-                                Logic = Or,
-                                Filters =
                             [
                                 new Filter(field: nameof(Person.Firstname), @operator: StartsWith, value: "V"),
                                 new Filter(field: nameof(Person.Firstname), @operator: StartsWith, value: "G")
                             ]
-                            },
-                            new MultiFilter
-                            {
-                                Logic = Or,
-                                Filters =
+                        },
+                        new MultiFilter
+                        {
+                            Logic = Or,
+                            Filters =
                             [
                                 new Filter(field: nameof(Person.Firstname), @operator: EndsWith, value: "l"),
                                 new Filter(field: nameof(Person.Firstname), @operator: EndsWith, value: "s")
                             ]
-                            }
-                            ]
+                        }
+                    ]
                 }
             },
-
+            { string.Empty, Filter.True },
+            { "Firstname=Bruce", new Filter("Firstname", EqualTo, "Bruce") },
+            { "Firstname=!Bruce", new Filter("Firstname", NotEqualTo, "Bruce") },
+            { "Firstname=!!Bruce", new Filter("Firstname", EqualTo, "Bruce") },
             {
-                string.Empty,
-                Filter.True
+                "Firstname=Bruce|Dick", new MultiFilter
+                {
+                    Logic = Or,
+                    Filters =
+                    [
+                        new Filter("Firstname", EqualTo, "Bruce"),
+                        new Filter("Firstname", EqualTo, "Dick")
+                    ]
+                }
             },
-
+            { "Firstname=Bru*", new Filter("Firstname", StartsWith, "Bru") },
+            { "Firstname=*Bru", new Filter("Firstname", EndsWith, "Bru") },
+            { "Height=[100 TO *[", new Filter("Height", GreaterThanOrEqual, 100) },
             {
-                "Firstname=Bruce",
-                new Filter("Firstname", EqualTo, "Bruce")
+                "Height=[100 TO 200]", new MultiFilter
+                {
+                    Logic = And,
+                    Filters =
+                    [
+                        new Filter("Height", GreaterThanOrEqual, 100),
+                        new Filter("Height", LessThanOrEqualTo, 200)
+                    ]
+                }
             },
-
             {
-                "Firstname=!Bruce",
-                new Filter("Firstname", NotEqualTo, "Bruce")
+                "Height=]100 TO 200[", new MultiFilter
+                {
+                    Logic = And,
+                    Filters =
+                    [
+                        new Filter("Height", GreaterThan, 100),
+                        new Filter("Height", FilterOperator.LessThan, 200)
+                    ]
+                }
             },
-
+            { "Height=]* TO 200]", new Filter("Height", LessThanOrEqualTo, 200) },
             {
-                "Firstname=!!Bruce",
-                new Filter("Firstname", EqualTo, "Bruce")
+                "Nickname=Bat*,*man", new MultiFilter
+                {
+                    Logic = And,
+                    Filters =
+                    [
+                        new Filter("Nickname", StartsWith, "Bat"),
+                        new Filter("Nickname", EndsWith, "man")
+                    ]
+                }
             },
-
-                    {
-                        "Firstname=Bruce|Dick",
+            {
+                "Nickname=Bat*man", new MultiFilter
+                {
+                    Logic = And,
+                    Filters =
+                    [
+                        new Filter("Nickname", StartsWith, "Bat"),
+                        new Filter("Nickname", EndsWith, "man")
+                    ]
+                }
+            },
+            {
+                "Nickname=Bat*,*man*", new MultiFilter
+                {
+                    Logic = And,
+                    Filters =
+                    [
+                        new Filter("Nickname", StartsWith, "Bat"),
+                        new Filter("Nickname", Contains, "man")
+                    ]
+                }
+            },
+            { "Firstname=!Bru*", new Filter("Firstname", NotStartsWith, "Bru") },
+            {
+                "Nickname=!(Bat*man)", new MultiFilter
+                {
+                    Logic = Or,
+                    Filters =
+                    [
+                        new Filter("Nickname", NotStartsWith, "Bat"),
+                        new Filter("Nickname", NotEndsWith, "man")
+                    ]
+                }
+            },
+            {
+                "Firstname=Bru*&Lastname=Wayne", new MultiFilter
+                {
+                    Logic = And,
+                    Filters =
+                    [
+                        new Filter("Firstname", StartsWith, "Bru"),
+                        new Filter("Lastname", EqualTo, "Wayne")
+                    ]
+                }
+            },
+            {
+                "Firstname=Br[uU]ce", new MultiFilter
+                {
+                    Logic = Or,
+                    Filters =
+                    [
+                        new Filter("Firstname", EqualTo, "Bruce"),
+                        new Filter("Firstname", EqualTo, "BrUce")
+                    ]
+                }
+            },
+            {
+                "Firstname=*Br[uU]", new MultiFilter
+                {
+                    Logic = Or,
+                    Filters =
+                    [
+                        new Filter("Firstname", EndsWith, "Bru"),
+                        new Filter("Firstname", EndsWith, "BrU"),
+                    ]
+                }
+            },
+            {
+                "Firstname=!(Bruce|Wayne)", new MultiFilter
+                {
+                    Logic = And,
+                    Filters =
+                    [
+                        new Filter("Firstname", NotEqualTo, "Bruce"),
+                        new Filter("Firstname", NotEqualTo, "Wayne")
+                    ]
+                }
+            },
+            {
+                "Firstname=(Bruce|Wayne)", new MultiFilter
+                {
+                    Logic = Or,
+                    Filters =
+                    [
+                        new Filter("Firstname", EqualTo, "Bruce"),
+                        new Filter("Firstname", EqualTo, "Wayne")
+                    ]
+                }
+            },
+            {
+                "Firstname=(Bat*|Sup*)|(*man|*er)", new MultiFilter
+                {
+                    Logic = Or,
+                    Filters =
+                    [
                         new MultiFilter
                         {
                             Logic = Or,
                             Filters =
-                            [
-                                new Filter("Firstname", EqualTo, "Bruce"),
-                            new Filter("Firstname", EqualTo, "Dick")
-                            ]
-                }
-            },
-
-            {
-                "Firstname=Bru*",
-                new Filter("Firstname", StartsWith, "Bru")
-            },
-
-            {
-                "Firstname=*Bru",
-                new Filter("Firstname", EndsWith, "Bru")
-            },
-
-            {
-                "Height=[100 TO *[",
-                new Filter("Height", GreaterThanOrEqual, 100)
-            },
-
-                    {
-                        "Height=[100 TO 200]",
-                        new MultiFilter
-                        {
-                            Logic = And,
-                            Filters =
-                            [
-                                new Filter("Height", GreaterThanOrEqual, 100),
-                            new Filter("Height", LessThanOrEqualTo, 200)
-                            ]
-                }
-            },
-
-                    {
-                        "Height=]100 TO 200[",
-                        new MultiFilter
-                        {
-                            Logic = And,
-                            Filters =
-                            [
-                                new Filter("Height", GreaterThan, 100),
-                            new Filter("Height", FilterOperator.LessThan, 200)
-                            ]
-                }
-            },
-
-            {
-                "Height=]* TO 200]",
-                new Filter("Height", LessThanOrEqualTo, 200)
-            },
-
-                    {
-                        "Nickname=Bat*,*man",
-                        new MultiFilter
-                        {
-                            Logic = And,
-                            Filters =
-                            [
-                                new Filter("Nickname", StartsWith, "Bat"),
-                            new Filter("Nickname", EndsWith, "man")
-                            ]
-                }
-            },
-
-                    {
-                        "Nickname=Bat*man",
-                        new MultiFilter
-                        {
-                            Logic = And,
-                            Filters =
-                            [
-                                new Filter("Nickname", StartsWith, "Bat"),
-                            new Filter("Nickname", EndsWith, "man")
-                            ]
-                }
-            },
-
-                    {
-                        "Nickname=Bat*,*man*",
-                        new MultiFilter
-                        {
-                            Logic = And,
-                            Filters =
-                            [
-                                new Filter("Nickname", StartsWith, "Bat"),
-                            new Filter("Nickname", Contains, "man")
-                            ]
-                }
-            },
-
-            {
-                "Firstname=!Bru*",
-                new Filter("Firstname", NotStartsWith, "Bru")
-            },
-
-                    {
-                        "Nickname=!(Bat*man)",
-                        new MultiFilter
-                        {
-                            Logic = Or,
-                            Filters =
-                            [
-                                new Filter("Nickname", NotStartsWith, "Bat"),
-                            new Filter("Nickname", NotEndsWith, "man")
-                            ]
-                }
-            },
-
-                    {
-                        "Firstname=Bru*&Lastname=Wayne",
-                        new MultiFilter
-                        {
-                            Logic = And,
-                            Filters =
-                            [
-                                new Filter("Firstname", StartsWith, "Bru"),
-                            new Filter("Lastname", EqualTo, "Wayne")
-                            ]
-                }
-            },
-
-                    {
-                        "Firstname=Br[uU]ce",
-                        new MultiFilter
-                        {
-                            Logic = Or,
-                            Filters =
-                            [
-                                new Filter("Firstname", EqualTo, "Bruce"),
-                            new Filter("Firstname", EqualTo, "BrUce")
-                            ]
-                }
-            },
-
-                    {
-                        "Firstname=*Br[uU]",
-                        new MultiFilter
-                        {
-                            Logic = Or,
-                            Filters =
-                            [
-                                new Filter("Firstname", EndsWith, "Bru"),
-                                new Filter("Firstname", EndsWith, "BrU"),
-                            ]
-                }
-            },
-
-                    {
-                        "Firstname=!(Bruce|Wayne)",
-                        new MultiFilter
-                        {
-                            Logic = And,
-                            Filters =
-                            [
-                                new Filter("Firstname", NotEqualTo, "Bruce"),
-                                new Filter("Firstname", NotEqualTo, "Wayne")
-                            ]
-                }
-            },
-
-                    {
-                        "Firstname=(Bruce|Wayne)",
-                        new MultiFilter
-                        {
-                            Logic = Or,
-                            Filters =
-                            [
-                                new Filter("Firstname", EqualTo, "Bruce"),
-                                new Filter("Firstname", EqualTo, "Wayne")
-                            ]
-                }
-            },
-
-                    {
-                        "Firstname=(Bat*|Sup*)|(*man|*er)",
-                        new MultiFilter
-                        {
-                            Logic = Or,
-                            Filters =
-                            [
-                                new MultiFilter
-                            {
-                                Logic = Or,
-                                Filters =
                             [
                                 new Filter("Firstname", StartsWith, "Bat"),
                                 new Filter("Firstname", StartsWith, "Sup")
                             ]
-                            },
-                            new MultiFilter
-                            {
-                                Logic = Or,
-                                Filters =
+                        },
+                        new MultiFilter
+                        {
+                            Logic = Or,
+                            Filters =
                             [
                                 new Filter("Firstname", EndsWith, "man"),
                                 new Filter("Firstname", EndsWith, "er")
                             ]
                         }
-                            ]
+                    ]
                 }
             },
-
+            { @"BattleCry=*\!", new Filter(field: "BattleCry", @operator: EndsWith, "!") },
+            { @"BattleCry=\**", new Filter(field: "BattleCry", @operator: StartsWith, "*") },
             {
-                @"BattleCry=*\!",
-                new Filter(field: "BattleCry", @operator: EndsWith, "!")
+                "BirthDate=]2016-10-18 TO 2016-10-25[", new MultiFilter
+                {
+                    Logic = And,
+                    Filters =
+                    [
+                        new Filter(nameof(SuperHero.BirthDate), GreaterThan, DateOnly.FromDateTime(18.October(2016))),
+                        new Filter(nameof(SuperHero.BirthDate), FilterOperator.LessThan, DateOnly.FromDateTime(25.October(2016)))
+                    ]
+                }
             },
-
             {
-                @"BattleCry=\**",
-                new Filter(field: "BattleCry", @operator: StartsWith, "*")
-            },
-
-                    {
-                        "BirthDate=]2016-10-18 TO 2016-10-25[",
-                        new MultiFilter
-                        {
-                            Logic = And,
-                            Filters =
-                            [
-                                new Filter(nameof(SuperHero.BirthDate), GreaterThan, DateOnly.FromDateTime(18.October(2016))),
-                                new Filter(nameof(SuperHero.BirthDate), FilterOperator.LessThan, DateOnly.FromDateTime(25.October(2016)))
-                            ]
+                "BirthDate=]2016-10-18T18:00:00 TO 2016-10-25T19:00:00[", new MultiFilter
+                {
+                    Logic = And,
+                    Filters =
+                    [
+                        new Filter(nameof(SuperHero.BirthDate), GreaterThan, DateOnly.FromDateTime(18.October(2016))),
+                        new Filter(nameof(SuperHero.BirthDate), FilterOperator.LessThan, DateOnly.FromDateTime(25.October(2016)))
+                    ]
                 }
             },
-
-                    {
-                        "BirthDate=]2016-10-18T18:00:00 TO 2016-10-25T19:00:00[",
-                        new MultiFilter
-                        {
-                            Logic = And,
-                            Filters =
-                            [
-                                new Filter(nameof(SuperHero.BirthDate), GreaterThan, DateOnly.FromDateTime(18.October(2016))),
-                                new Filter(nameof(SuperHero.BirthDate), FilterOperator.LessThan, DateOnly.FromDateTime(25.October(2016)))
-                            ]
+            {
+                "DateTimeWithOffset=]2016-10-18T18:00:00Z TO 2016-10-18T23:00:00-02:00[", new MultiFilter
+                {
+                    Logic = And,
+                    Filters =
+                    [
+                        new Filter("DateTimeWithOffset", GreaterThan, 18.October(2016).Add(18.Hours()).ToDateTimeOffset()),
+                        new Filter("DateTimeWithOffset", FilterOperator.LessThan, 18.October(2016).Add(23.Hours()).ToDateTimeOffset(-2.Hours()))
+                    ]
                 }
             },
-
-                    {
-                        "DateTimeWithOffset=]2016-10-18T18:00:00Z TO 2016-10-18T23:00:00-02:00[",
+            {
+                "Nickname={Bat|Sup|Wonder}*,*m[ae]n", new MultiFilter
+                {
+                    Logic = And,
+                    Filters =
+                    [
                         new MultiFilter
                         {
-                            Logic = And,
+                            Logic = Or,
                             Filters =
                             [
-                                new Filter("DateTimeWithOffset", GreaterThan, 18.October(2016).Add(18.Hours()).ToDateTimeOffset()),
-                                new Filter("DateTimeWithOffset", FilterOperator.LessThan, 18.October(2016).Add(23.Hours()).ToDateTimeOffset(-2.Hours()))
-                            ]
-                }
-            },
-
-                    {
-                        "Nickname={Bat|Sup|Wonder}*,*m[ae]n",
-                        new MultiFilter
-                        {
-                            Logic = And,
-                            Filters =
-                            [
-                                new MultiFilter
-                                {
-                                    Logic = Or,
-                                    Filters =
-                                    [
                                 new Filter(nameof(SuperHero.Nickname), StartsWith, "Bat"),
                                 new Filter(nameof(SuperHero.Nickname), StartsWith, "Sup"),
                                 new Filter(nameof(SuperHero.Nickname), StartsWith, "Wonder")
                             ]
-                                },
-                                new MultiFilter
-                                {
-                                    Logic = Or,
-                                    Filters =
-                                    [
+                        },
+                        new MultiFilter
+                        {
+                            Logic = Or,
+                            Filters =
+                            [
                                 new Filter(nameof(SuperHero.Nickname), EndsWith, "man"),
                                 new Filter(nameof(SuperHero.Nickname), EndsWith, "men")
                             ]
@@ -423,19 +332,7 @@ public class FilterExtensionsTests(ITestOutputHelper outputHelper)
     }
 
     public static TheoryData<string, PropertyNameResolutionStrategy, Filter> ToFilterWithPropertyNameResolutionStrategyCases
-        => new()
-        {
-            {
-                "SnakeCaseProperty=10",
-                PropertyNameResolutionStrategy.SnakeCase,
-                new Filter("snake_case_property", EqualTo, "10")
-            },
-            {
-                "pascal_case_property=10",
-                PropertyNameResolutionStrategy.PascalCase,
-                new Filter("PascalCaseProperty", EqualTo, "10")
-            }
-        };
+        => new() { { "SnakeCaseProperty=10", PropertyNameResolutionStrategy.SnakeCase, new Filter("snake_case_property", EqualTo, "10") }, { "pascal_case_property=10", PropertyNameResolutionStrategy.PascalCase, new Filter("PascalCaseProperty", EqualTo, "10") } };
 
     [Theory]
     [MemberData(nameof(ToFilterWithPropertyNameResolutionStrategyCases))]
@@ -449,43 +346,43 @@ public class FilterExtensionsTests(ITestOutputHelper outputHelper)
             .Be(expected);
     }
 
-        public static TheoryData<string, FilterOptions, MultiFilter> ToFilterWithFilterOptionsCases
+    public static TheoryData<string, FilterOptions, MultiFilter> ToFilterWithFilterOptionsCases
+    {
+        get
         {
-            get
+            FilterLogic[] logics = [And, Or];
+            TheoryData<string, FilterOptions, MultiFilter> cases = [];
+            foreach (FilterLogic logic in logics)
             {
-                FilterLogic[] logics = [And, Or];
-                TheoryData<string, FilterOptions, MultiFilter> cases = [];
-                foreach (FilterLogic logic in logics)
-                {
-                    cases.Add
+                cases.Add
                     (
-                        "snake_case_property=10&PascalCaseProperty=value",
-                        new FilterOptions { Logic = logic },
-                        new MultiFilter
-                        {
-                            Logic = logic,
-                            Filters =
-                        [
-                            new Filter("snake_case_property", EqualTo, "10"),
-                            new Filter("PascalCaseProperty", EqualTo, "value")
-                        ]
-                    }
-                );
+                     "snake_case_property=10&PascalCaseProperty=value",
+                     new FilterOptions { Logic = logic },
+                     new MultiFilter
+                     {
+                         Logic = logic,
+                         Filters =
+                         [
+                             new Filter("snake_case_property", EqualTo, "10"),
+                             new Filter("PascalCaseProperty", EqualTo, "value")
+                         ]
+                     }
+                    );
 
-                    cases.Add
+                cases.Add
                     (
-                        "snake_case_property=10&PascalCaseProperty=value",
-                        new FilterOptions { Logic = logic },
-                        new MultiFilter
-                        {
-                            Logic = logic,
-                            Filters =
-                        [
-                            new Filter("snake_case_property", EqualTo, "10"),
-                            new Filter("PascalCaseProperty", EqualTo, "value")
-                        ]
-                    }
-                );
+                     "snake_case_property=10&PascalCaseProperty=value",
+                     new FilterOptions { Logic = logic },
+                     new MultiFilter
+                     {
+                         Logic = logic,
+                         Filters =
+                         [
+                             new Filter("snake_case_property", EqualTo, "10"),
+                             new Filter("PascalCaseProperty", EqualTo, "value")
+                         ]
+                     }
+                    );
             }
 
             return cases;

--- a/test/DataFilters.UnitTests/FilterTests.cs
+++ b/test/DataFilters.UnitTests/FilterTests.cs
@@ -1,5 +1,4 @@
-﻿namespace DataFilters.UnitTests;
-
+﻿
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
@@ -19,10 +18,11 @@ using Xunit.Categories;
 using static DataFilters.FilterLogic;
 using static DataFilters.FilterOperator;
 
+namespace DataFilters.UnitTests;
 [UnitTest]
 public class FilterTests(ITestOutputHelper output)
 {
-    private static readonly IImmutableDictionary<string, FilterOperator> Operators = new Dictionary<string, FilterOperator>
+    private static readonly IImmutableDictionary<string, FilterOperator> s_operators = new Dictionary<string, FilterOperator>
     {
         ["contains"] = Contains,
         ["endswith"] = EndsWith,
@@ -47,7 +47,7 @@ public class FilterTests(ITestOutputHelper output)
         get
         {
             TheoryData<string, Expression<Func<IFilter, bool>>> cases = [];
-            foreach (KeyValuePair<string, FilterOperator> item in Operators)
+            foreach (KeyValuePair<string, FilterOperator> item in s_operators)
             {
                 cases.Add
                 (

--- a/test/DataFilters.UnitTests/Generators.cs
+++ b/test/DataFilters.UnitTests/Generators.cs
@@ -1,11 +1,11 @@
-﻿namespace DataFilters.UnitTests;
-
+﻿
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using DataFilters.Casing;
 using FsCheck;
 using FsCheck.Fluent;
 
+namespace DataFilters.UnitTests;
 // "Copyright (c) Cyrille NDOUMBE.
 // Licenced under Apache, version 2.0"
 

--- a/test/DataFilters.UnitTests/Grammar/Parsing/FilterTokenParserTests.cs
+++ b/test/DataFilters.UnitTests/Grammar/Parsing/FilterTokenParserTests.cs
@@ -30,7 +30,7 @@ public class FilterTokenParserTests : IClassFixture<CultureSwitcher>, IDisposabl
     private readonly FilterTokenizer _tokenizer;
     private readonly ITestOutputHelper _outputHelper;
     private readonly CultureSwitcher _cultureSwitcher;
-    private static readonly Bogus.Faker Faker = new();
+    private static readonly Bogus.Faker s_faker = new();
 
     public FilterTokenParserTests(ITestOutputHelper outputHelper, CultureSwitcher cultureSwitcher)
     {

--- a/test/DataFilters.UnitTests/Grammar/Syntax/BracketExpressionTests.cs
+++ b/test/DataFilters.UnitTests/Grammar/Syntax/BracketExpressionTests.cs
@@ -1,5 +1,4 @@
-﻿namespace DataFilters.UnitTests.Grammar.Syntax;
-
+﻿
 using System;
 using System.Linq;
 using DataFilters.Grammar.Syntax;
@@ -11,6 +10,7 @@ using FsCheck.Xunit;
 using Xunit;
 using Xunit.Abstractions;
 
+namespace DataFilters.UnitTests.Grammar.Syntax;
 public class BracketExpressionTests(ITestOutputHelper outputHelper)
 {
     [Fact]

--- a/test/DataFilters.UnitTests/Grammar/Syntax/ConstantBracketValueTests.cs
+++ b/test/DataFilters.UnitTests/Grammar/Syntax/ConstantBracketValueTests.cs
@@ -1,5 +1,4 @@
-﻿namespace DataFilters.UnitTests.Grammar.Syntax;
-
+﻿
 using System;
 using System.Linq;
 using DataFilters.Grammar.Syntax;
@@ -9,6 +8,7 @@ using FsCheck;
 using FsCheck.Fluent;
 using FsCheck.Xunit;
 
+namespace DataFilters.UnitTests.Grammar.Syntax;
 public class ConstantBracketValueTests
 {
     [Property]

--- a/test/DataFilters.UnitTests/Grammar/Syntax/ContainsExpressionTests.cs
+++ b/test/DataFilters.UnitTests/Grammar/Syntax/ContainsExpressionTests.cs
@@ -1,10 +1,7 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
 using System.Text;
 using DataFilters.Grammar.Parsing;
-
-namespace DataFilters.UnitTests.Grammar.Syntax;
-
-using System;
 using DataFilters.Grammar.Syntax;
 using DataFilters.UnitTests.Helpers;
 using FluentAssertions;
@@ -13,6 +10,7 @@ using FsCheck.Xunit;
 using Xunit;
 using Xunit.Abstractions;
 
+namespace DataFilters.UnitTests.Grammar.Syntax;
 public class ContainsExpressionTests(ITestOutputHelper outputHelper)
 {
     [Fact]

--- a/test/DataFilters.UnitTests/Grammar/Syntax/DateExpressionTests.cs
+++ b/test/DataFilters.UnitTests/Grammar/Syntax/DateExpressionTests.cs
@@ -1,5 +1,4 @@
-﻿namespace DataFilters.UnitTests.Grammar.Syntax;
-
+﻿
 using System;
 using DataFilters.Grammar.Syntax;
 using DataFilters.UnitTests.Helpers;
@@ -9,6 +8,7 @@ using FsCheck.Fluent;
 using FsCheck.Xunit;
 using Xunit;
 
+namespace DataFilters.UnitTests.Grammar.Syntax;
 public class DateExpressionTests
 {
     [Fact]

--- a/test/DataFilters.UnitTests/Grammar/Syntax/DateTimeExpressionTests.cs
+++ b/test/DataFilters.UnitTests/Grammar/Syntax/DateTimeExpressionTests.cs
@@ -1,5 +1,4 @@
-﻿namespace DataFilters.UnitTests.Grammar.Syntax;
-
+﻿
 using System;
 using DataFilters.Grammar.Syntax;
 using DataFilters.UnitTests.Helpers;
@@ -11,6 +10,7 @@ using Xunit;
 using Xunit.Abstractions;
 using Xunit.Categories;
 
+namespace DataFilters.UnitTests.Grammar.Syntax;
 [Feature(nameof(DataFilters.Grammar.Syntax))]
 public class DateTimeExpressionTests(ITestOutputHelper outputHelper)
 {

--- a/test/DataFilters.UnitTests/Grammar/Syntax/DurationExpressionTests.cs
+++ b/test/DataFilters.UnitTests/Grammar/Syntax/DurationExpressionTests.cs
@@ -1,4 +1,3 @@
-namespace DataFilters.UnitTests.Grammar.Syntax;
 
 using System;
 using DataFilters.Grammar.Syntax;
@@ -10,6 +9,7 @@ using Xunit;
 using Xunit.Abstractions;
 using Xunit.Categories;
 
+namespace DataFilters.UnitTests.Grammar.Syntax;
 [UnitTest]
 public class DurationExpressionTests(ITestOutputHelper outputHelper)
 {
@@ -135,7 +135,7 @@ public class DurationExpressionTests(ITestOutputHelper outputHelper)
         bool first = duration.IsEquivalentTo(other.Item);
         bool second = other.Item.IsEquivalentTo(third.Item);
 
-        // Act 
+        // Act
         bool actual = duration.IsEquivalentTo(third.Item);
 
         // Assert

--- a/test/DataFilters.UnitTests/Grammar/Syntax/EndsWithExpressionTests.cs
+++ b/test/DataFilters.UnitTests/Grammar/Syntax/EndsWithExpressionTests.cs
@@ -1,5 +1,4 @@
-﻿namespace DataFilters.UnitTests.Grammar.Syntax;
-
+﻿
 using System;
 using DataFilters.Grammar.Syntax;
 using DataFilters.UnitTests.Helpers;
@@ -10,6 +9,7 @@ using Xunit;
 using Xunit.Abstractions;
 using Xunit.Categories;
 
+namespace DataFilters.UnitTests.Grammar.Syntax;
 [UnitTest]
 public class EndsWithExpressionTests(ITestOutputHelper outputHelper)
 {

--- a/test/DataFilters.UnitTests/Grammar/Syntax/EscapedStringTests.cs
+++ b/test/DataFilters.UnitTests/Grammar/Syntax/EscapedStringTests.cs
@@ -1,7 +1,6 @@
 using System;
 using DataFilters.Grammar.Syntax;
 using FluentAssertions;
-using FsCheck;
 using Xunit;
 using Xunit.Categories;
 

--- a/test/DataFilters.UnitTests/Grammar/Syntax/IntervalExpressionTests.cs
+++ b/test/DataFilters.UnitTests/Grammar/Syntax/IntervalExpressionTests.cs
@@ -1,5 +1,4 @@
-﻿namespace DataFilters.UnitTests.Grammar.Syntax;
-
+﻿
 using System;
 using DataFilters.Grammar.Exceptions;
 using DataFilters.Grammar.Syntax;
@@ -11,6 +10,7 @@ using FsCheck.Xunit;
 using Xunit;
 using Xunit.Abstractions;
 
+namespace DataFilters.UnitTests.Grammar.Syntax;
 public class IntervalExpressionTests(ITestOutputHelper outputHelper)
 {
     [Fact]

--- a/test/DataFilters.UnitTests/Grammar/Syntax/NotExpressionTests.cs
+++ b/test/DataFilters.UnitTests/Grammar/Syntax/NotExpressionTests.cs
@@ -1,5 +1,4 @@
-﻿namespace DataFilters.UnitTests.Grammar.Syntax;
-
+﻿
 using System;
 using DataFilters.Grammar.Parsing;
 using DataFilters.Grammar.Syntax;
@@ -12,6 +11,7 @@ using Superpower;
 using Superpower.Model;
 using Xunit;
 
+namespace DataFilters.UnitTests.Grammar.Syntax;
 public class NotExpressionTests
 {
     [Fact]

--- a/test/DataFilters.UnitTests/Grammar/Syntax/NumericValueExpressionTests.cs
+++ b/test/DataFilters.UnitTests/Grammar/Syntax/NumericValueExpressionTests.cs
@@ -1,20 +1,15 @@
-﻿using Candoumbe.MiscUtilities.Comparers;
-using DataFilters.Grammar.Syntax;
-using FluentAssertions;
-using Xunit;
-using Xunit.Abstractions;
-
-namespace DataFilters.UnitTests.Grammar.Syntax;
-
-using System;
+﻿using System;
+using Candoumbe.MiscUtilities.Comparers;
 using DataFilters.Grammar.Syntax;
 using DataFilters.UnitTests.Helpers;
 using FluentAssertions;
 using FsCheck;
 using FsCheck.Xunit;
 using Xunit;
+using Xunit.Abstractions;
 using Xunit.Categories;
 
+namespace DataFilters.UnitTests.Grammar.Syntax;
 [UnitTest]
 public class NumericValueExpressionTests(ITestOutputHelper outputHelper)
 {

--- a/test/DataFilters.UnitTests/Grammar/Syntax/OffsetExpressionTests.cs
+++ b/test/DataFilters.UnitTests/Grammar/Syntax/OffsetExpressionTests.cs
@@ -1,5 +1,4 @@
-﻿namespace DataFilters.UnitTests.Grammar.Syntax;
-
+﻿
 using DataFilters.Grammar.Syntax;
 using DataFilters.UnitTests.Helpers;
 
@@ -12,6 +11,7 @@ using FsCheck.Xunit;
 using Xunit;
 using Xunit.Categories;
 
+namespace DataFilters.UnitTests.Grammar.Syntax;
 [UnitTest]
 public class OffsetExpressionTests
 {

--- a/test/DataFilters.UnitTests/Grammar/Syntax/OneOfExpressionTests.cs
+++ b/test/DataFilters.UnitTests/Grammar/Syntax/OneOfExpressionTests.cs
@@ -1,5 +1,4 @@
-﻿namespace DataFilters.UnitTests.Grammar.Syntax;
-
+﻿
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -11,6 +10,7 @@ using FsCheck.Xunit;
 using Xunit;
 using Xunit.Abstractions;
 
+namespace DataFilters.UnitTests.Grammar.Syntax;
 public class OneOfExpressionTests(ITestOutputHelper outputHelper)
 {
     [Fact]

--- a/test/DataFilters.UnitTests/Grammar/Syntax/OrExpressionTests.cs
+++ b/test/DataFilters.UnitTests/Grammar/Syntax/OrExpressionTests.cs
@@ -1,10 +1,9 @@
-﻿namespace DataFilters.UnitTests.Grammar.Syntax;
-
+﻿
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using DataFilters.Grammar.Syntax;
-using Helpers;
+using DataFilters.UnitTests.Helpers;
 using FluentAssertions;
 using FsCheck;
 using FsCheck.Fluent;
@@ -13,6 +12,7 @@ using Xunit;
 using Xunit.Abstractions;
 using Xunit.Categories;
 
+namespace DataFilters.UnitTests.Grammar.Syntax;
 [UnitTest]
 public class OrExpressionTests(ITestOutputHelper outputHelper)
 {

--- a/test/DataFilters.UnitTests/Grammar/Syntax/PropertyNameExpressionTests.cs
+++ b/test/DataFilters.UnitTests/Grammar/Syntax/PropertyNameExpressionTests.cs
@@ -1,11 +1,11 @@
-﻿namespace DataFilters.UnitTests.Grammar.Syntax;
-
+﻿
 using System;
 using DataFilters.Grammar.Syntax;
 using FluentAssertions;
 using Xunit;
 using Xunit.Abstractions;
 
+namespace DataFilters.UnitTests.Grammar.Syntax;
 public class PropertyNameTests(ITestOutputHelper outputHelper)
 {
     [Fact]

--- a/test/DataFilters.UnitTests/Grammar/Syntax/RangeBracketValueTests.cs
+++ b/test/DataFilters.UnitTests/Grammar/Syntax/RangeBracketValueTests.cs
@@ -1,5 +1,4 @@
-﻿namespace DataFilters.UnitTests.Grammar.Syntax;
-
+﻿
 using System;
 using System.Linq;
 using DataFilters.Grammar.Syntax;
@@ -11,6 +10,7 @@ using FsCheck.Xunit;
 using Xunit;
 using Xunit.Abstractions;
 
+namespace DataFilters.UnitTests.Grammar.Syntax;
 public class RangeBracketValueTests(ITestOutputHelper outputHelper)
 {
     [Property]

--- a/test/DataFilters.UnitTests/Grammar/Syntax/StringValueExpressionTests.cs
+++ b/test/DataFilters.UnitTests/Grammar/Syntax/StringValueExpressionTests.cs
@@ -1,8 +1,8 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
 using System.Text;
-using DataFilters.Grammar.Parsing;
-using System;
 using Candoumbe.MiscUtilities.Comparers;
+using DataFilters.Grammar.Parsing;
 using DataFilters.Grammar.Syntax;
 using DataFilters.UnitTests.Helpers;
 using FluentAssertions;

--- a/test/DataFilters.UnitTests/Helpers/CultureSwitcher.cs
+++ b/test/DataFilters.UnitTests/Helpers/CultureSwitcher.cs
@@ -1,9 +1,9 @@
-﻿namespace DataFilters.UnitTests.Helpers;
-
+﻿
 using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 
+namespace DataFilters.UnitTests.Helpers;
 /// <summary>
 /// A helper class to control the <see cref="CultureInfo.CurrentCulture"/> value during tests.
 /// </summary>

--- a/test/DataFilters.UnitTests/Helpers/ExpressionsGenerators.cs
+++ b/test/DataFilters.UnitTests/Helpers/ExpressionsGenerators.cs
@@ -1,4 +1,3 @@
-namespace DataFilters.UnitTests.Helpers;
 
 using System;
 using System.Collections.Generic;
@@ -8,7 +7,9 @@ using DataFilters.Grammar.Parsing;
 using DataFilters.Grammar.Syntax;
 using FsCheck;
 using FsCheck.Fluent;
-using static GeneratorHelper;
+using static DataFilters.UnitTests.Helpers.GeneratorHelper;
+
+namespace DataFilters.UnitTests.Helpers;
 
 public static class ExpressionsGenerators
 {

--- a/test/DataFilters.UnitTests/Helpers/FilterGenerators.cs
+++ b/test/DataFilters.UnitTests/Helpers/FilterGenerators.cs
@@ -2,19 +2,19 @@
 using System.Collections.Generic;
 using System.Linq;
 using Bogus;
+using DataFilters.Grammar.Syntax;
 using FsCheck;
 using FsCheck.Fluent;
 
+using static DataFilters.UnitTests.Helpers.GeneratorHelper;
+
 namespace DataFilters.UnitTests.Helpers;
-
-using static GeneratorHelper;
-
 /// <summary>
 /// Helper class which contains usefull FsCheck generators.
 /// </summary>
 internal static class FilterGenerators
 {
-    private static readonly Faker Faker = new();
+    private static readonly Faker s_faker = new();
 
     /// <summary>
     /// Generates a <see cref="Arbitrary{Filter}"/> where the value of the filter is a string
@@ -30,7 +30,7 @@ internal static class FilterGenerators
 
         return genOperator.Zip(GetArbitraryFor<string>().Generator)
             .Select(tuple => (Op: tuple.Item1, Value: tuple.Item2))
-            .Select(tuple => new Filter(Faker.Hacker.Noun(), tuple.Op, tuple.Value))
+            .Select(tuple => new Filter(s_faker.Hacker.Noun(), tuple.Op, tuple.Value))
             .ToArbitrary();
     }
 
@@ -48,13 +48,13 @@ internal static class FilterGenerators
 
         return Gen.OneOf(genOperator.Zip(GetArbitraryFor<int>().Generator)
                         .Select(tuple => (Op: tuple.Item1, Value: tuple.Item2))
-                        .Select(tuple => new Filter(Faker.Hacker.Noun(), tuple.Op, tuple.Value)),
+                        .Select(tuple => new Filter(s_faker.Hacker.Noun(), tuple.Op, tuple.Value)),
                     genOperator.Zip(GetArbitraryFor<float>().Generator)
                         .Select(tuple => (Op: tuple.Item1, Value: tuple.Item2))
-                        .Select(tuple => new Filter(Faker.Hacker.Noun(), tuple.Op, tuple.Value)),
+                        .Select(tuple => new Filter(s_faker.Hacker.Noun(), tuple.Op, tuple.Value)),
                     genOperator.Zip(GetArbitraryFor<long>().Generator)
                         .Select(tuple => (Op: tuple.Item1, Value: tuple.Item2))
-                        .Select(tuple => new Filter(Faker.Hacker.Noun(), tuple.Op, tuple.Value))
+                        .Select(tuple => new Filter(s_faker.Hacker.Noun(), tuple.Op, tuple.Value))
                 )
                 .ToArbitrary()
             ;
@@ -74,7 +74,7 @@ internal static class FilterGenerators
 
         return genOperator.Zip(GetArbitraryFor<T>().Generator)
             .Select(tuple => (Op: tuple.Item1, Value: tuple.Item2))
-            .Select(tuple => new Filter(Faker.Hacker.Noun(), tuple.Op, tuple.Value))
+            .Select(tuple => new Filter(s_faker.Hacker.Noun(), tuple.Op, tuple.Value))
             .ToArbitrary();
     }
 
@@ -110,7 +110,7 @@ internal static class FilterGenerators
 
     internal static Arbitrary<Filter> GenerateFilterOverStrings(FilterOperator op)
         => GetArbitraryFor<NonEmptyString>().Generator
-            .Select(value => new Filter(field: Faker.Hacker.Noun(), op, value))
+            .Select(value => new Filter(field: s_faker.Hacker.Noun(), op, value))
             .ToArbitrary();
 
     private static Gen<MultiFilter> SafeFilterGenerator(int size)
@@ -159,5 +159,5 @@ internal static class FilterGenerators
 
     private static Gen<IFilter> GenerateFilterWithSpecifiedOperatorAndValue<TValue>(FilterOperator op)
         => GetArbitraryFor<TValue>().Generator
-            .Select(value => (IFilter)new Filter(Faker.Hacker.Noun(), op, value));
+            .Select(IFilter (value) => new Filter(s_faker.Hacker.Noun(), op, value));
 }

--- a/test/DataFilters.UnitTests/MultiFilterTests.cs
+++ b/test/DataFilters.UnitTests/MultiFilterTests.cs
@@ -1,10 +1,4 @@
-﻿#if NETCOREAPP2_1
-using static Newtonsoft.Json.JsonConvert;
-#else
-#endif
-
-namespace DataFilters.UnitTests;
-
+﻿
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -21,6 +15,12 @@ using Xunit.Categories;
 using static DataFilters.FilterLogic;
 using static DataFilters.FilterOperator;
 
+#if NETCOREAPP2_1
+using static Newtonsoft.Json.JsonConvert;
+#else
+#endif
+
+namespace DataFilters.UnitTests;
 [UnitTest]
 public class MultiFilterTests(ITestOutputHelper output)
 {

--- a/test/DataFilters.UnitTests/MultiOrderTests.cs
+++ b/test/DataFilters.UnitTests/MultiOrderTests.cs
@@ -1,11 +1,11 @@
-﻿namespace DataFilters.UnitTests;
-
+﻿
 using DataFilters.TestObjects;
 using FluentAssertions;
 using Xunit;
 using Xunit.Abstractions;
 using static DataFilters.OrderDirection;
 
+namespace DataFilters.UnitTests;
 public class MultiOrderTests(ITestOutputHelper outputHelper)
 {
     public static TheoryData<MultiOrder<SuperHero>, object, bool, string> EqualsCases

--- a/test/DataFilters.UnitTests/OrderTests.cs
+++ b/test/DataFilters.UnitTests/OrderTests.cs
@@ -1,5 +1,4 @@
-﻿namespace DataFilters.UnitTests;
-
+﻿
 using System;
 using DataFilters.TestObjects;
 using FluentAssertions;
@@ -7,6 +6,7 @@ using Xunit;
 using Xunit.Abstractions;
 using static DataFilters.OrderDirection;
 
+namespace DataFilters.UnitTests;
 public class OrderTests(ITestOutputHelper outputHelper)
 {
     [Theory]

--- a/test/DataFilters.UnitTests/StringExtensionsTests.cs
+++ b/test/DataFilters.UnitTests/StringExtensionsTests.cs
@@ -1,5 +1,4 @@
-﻿namespace DataFilters.UnitTests;
-
+﻿
 using System;
 using DataFilters.Casing;
 using DataFilters.TestObjects;
@@ -8,6 +7,7 @@ using Xunit;
 using Xunit.Abstractions;
 using static DataFilters.OrderDirection;
 
+namespace DataFilters.UnitTests;
 public class StringExtensionsTests(ITestOutputHelper outputHelper)
 {
     [Theory]


### PR DESCRIPTION
### 💥 Breaking Changes
• Renamed FilterToken.OpenParenthese to FilterToken.LeftParenthesis
• Renamed FilterToken.CloseParenthese to FilterToken.RightParenthesis
• Renamed FilterToken.LeftBrace to FilterToken.LeftCurlyBrace
• Renamed FilterToken.RightBrace to FilterToken.RightCurlyBrace
• Renamed FilterToken.OpenSquaredBracket to FilterToken.LeftSquaredBrace
• Renamed FilterToken.CloseSquaredBracket to FilterToken.RightSquaredBrace
### 🚨 Fixes
• Fixed incorrect parsing of scientific numeric values (with E symbol).
• Fixed incorrect parsing of some expressions that uses * character
• Fixed incorrect parsing of text expressions when used in combination with contains
### 🧹 Housekeeping
• Pipeline fails to publish NuGet packages to GitHub due to incorrect URL
• Refactoring of ISimplifiable implementations
• Updated GitHub nuget registry URL
• Bumped Candoumbe.Pipelines to 0.13.0
• Bumped Microsoft.NET.Test.Sdk to 17.11.1
• Updated required NET SDK to 9.0.303
• Set Ubuntu 22.04 image for continuous integration

Full changelog at https://github.com/candoumbe/DataFilters/blob/coldfix/code-cleanup/CHANGELOG.md