### PR TITLE
🧹 Central Package Management

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,0 +1,39 @@
+<Project>
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+    <CentralPackageTransitivePinningEnabled>false</CentralPackageTransitivePinningEnabled>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageVersion Include="BenchmarkDotNet" Version="0.15.2" />
+    <PackageVersion Include="Candoumbe.Pipelines" Version="0.13.4-fix.4" />
+    <PackageVersion Include="Candoumbe.Types.Strings" Version="0.3.1" />
+    <PackageVersion Include="coverlet.msbuild" Version="6.0.4" />
+    <PackageVersion Include="FluentAssertions" Version="7.2.0" />
+    <PackageVersion Include="FluentValidation" Version="11.11.0" />
+    <PackageVersion Include="FsCheck.XUnit" Version="3.3.0" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.19" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageVersion Include="Newtonsoft.Json.Schema" Version="4.0.1" />
+    <PackageVersion Include="NodaTime.Bogus" Version="3.0.2" />
+    <PackageVersion Include="NodaTime.Testing" Version="3.2.2" />
+    <PackageVersion Include="OneOf.Extended" Version="3.0.271" />
+    <PackageVersion Include="Optional" Version="4.0.0" />
+    <PackageVersion Include="Queries.Core" Version="0.4.0" />
+    <PackageVersion Include="ReportGenerator" Version="5.4.11" />
+    <PackageVersion Include="Roslynator.Analyzers" Version="4.14.0" />
+    <PackageVersion Include="Roslynator.Formatting.Analyzers" Version="4.14.0" />
+    <PackageVersion Include="Superpower" Version="3.1.0" />
+    <PackageVersion Include="System.Collections.Immutable" Version="8.0.0" />
+    <PackageVersion Include="System.Linq.Queryable" Version="4.3.0" />
+    <PackageVersion Include="Ultimately" Version="3.0.0" />
+    <PackageVersion Include="xunit.analyzers" Version="1.23.0" />
+    <PackageVersion Include="xunit.categories" Version="3.0.1" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.3" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(IsTestProject)' == 'false'">
+    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' != 'netstandard1.3'">
+    <PackageVersion Include="Ardalis.GuardClauses" Version="5.0.0" />
+  </ItemGroup>
+</Project>

--- a/build/_build.csproj
+++ b/build/_build.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <Import Project="../core.props" />
   <PropertyGroup>
@@ -12,9 +12,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Candoumbe.Pipelines" Version="0.13.4-fix.4" />
-    <PackageReference Include="ReportGenerator" Version="5.4.11" />
-    <PackageDownload Include="dotnet-stryker" Version="[4.5.1]"/>
+    <PackageReference Include="Candoumbe.Pipelines" />
+    <PackageReference Include="ReportGenerator" />
+    <PackageDownload Include="dotnet-stryker" Version="[4.5.1]" />
     <PackageDownload Include="GitVersion.Tool" Version="[6.1.0]" />
     <PackageDownload Include="CodecovUploader" Version="[0.8.0]" />
   </ItemGroup>

--- a/core.props
+++ b/core.props
@@ -32,7 +32,7 @@
         <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
       </PropertyGroup>
       <ItemGroup Condition="'$(IsTestProject)' == 'false'">
-        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" Condition="'$(GITHUB_ACTIONS)' == 'true'"/>
+        <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" Condition="'$(GITHUB_ACTIONS)' == 'true'" />
       </ItemGroup>
     </When>
   </Choose>
@@ -41,31 +41,31 @@
   <Choose>
     <When Condition="$([System.Text.RegularExpressions.Regex]::IsMatch($(TargetFramework), '^net\d\.0$'))">
       <ItemGroup>
-        <PackageReference Include="FluentValidation" Version="11.11.0" />
-        <PackageReference Include="Ultimately" Version="3.0.0" />
+        <PackageReference Include="FluentValidation" />
+        <PackageReference Include="Ultimately" />
       </ItemGroup>
     </When>
     <Otherwise>
       <ItemGroup>
-        <PackageReference Include="FluentValidation" Version="11.11.0" />
-        <PackageReference Include="Optional" Version="4.0.0"/>
+        <PackageReference Include="FluentValidation" />
+        <PackageReference Include="Optional" />
       </ItemGroup>
     </Otherwise>
   </Choose>
   <ItemGroup>
-    <PackageReference Include="Roslynator.Analyzers" Version="4.14.0">
+    <PackageReference Include="Roslynator.Analyzers">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-      <PackageReference Include="Roslynator.Formatting.Analyzers" Version="4.14.0">
+      <PackageReference Include="Roslynator.Formatting.Analyzers">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
       </PackageReference>
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' != 'netstandard1.3'">
-    <PackageReference Include="Ardalis.GuardClauses" Version="5.0.0" />
+    <PackageReference Include="Ardalis.GuardClauses" />
   </ItemGroup>
   <ItemGroup Condition="'$(IsTestProject)' == 'false' and '$(MSBuildProjectName)' != '_build'">
-      <None Include="..\..\README.md" Pack="true" PackagePath="\"/>
+      <None Include="..\..\README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
 </Project>

--- a/src/DataFilters.Queries/DataFilters.Queries.csproj
+++ b/src/DataFilters.Queries/DataFilters.Queries.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\..\core.props" />
   <PropertyGroup>
     <TargetFrameworks>netstandard2.1;net8.0;net9.0</TargetFrameworks>
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Queries.Core" Version="0.4.0"/>
+    <PackageReference Include="Queries.Core" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\DataFilters\DataFilters.csproj" />

--- a/src/DataFilters/DataFilters.csproj
+++ b/src/DataFilters/DataFilters.csproj
@@ -1,6 +1,6 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
-  <Import Project="..\..\core.props"/>
+  <Import Project="..\..\core.props" />
   <PropertyGroup>
     <TargetFrameworks>netstandard2.1;net8.0;net9.0</TargetFrameworks>
     <Description>Sets of classes to convert querystrings to strongly typed expressions.</Description>
@@ -11,10 +11,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Candoumbe.Types.Strings" Version="0.3.1"/>
-    <PackageReference Include="System.Collections.Immutable" Version="8.0.0"/>
-    <PackageReference Include="OneOf.Extended" Version="3.0.271"/>
-    <PackageReference Include="Superpower" Version="3.1.0"/>
-    <PackageReference Include="Newtonsoft.Json.Schema" Version="4.0.1"/>
+    <PackageReference Include="Candoumbe.Types.Strings" />
+    <PackageReference Include="System.Collections.Immutable" />
+    <PackageReference Include="OneOf.Extended" />
+    <PackageReference Include="Superpower" />
+    <PackageReference Include="Newtonsoft.Json.Schema" />
   </ItemGroup>
 </Project>

--- a/src/Datafilters.Expressions/DataFilters.Expressions.csproj
+++ b/src/Datafilters.Expressions/DataFilters.Expressions.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <Import Project="..\..\core.props" />
   <PropertyGroup>
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Linq.Queryable" Version="4.3.0" />
+    <PackageReference Include="System.Linq.Queryable" />
   </ItemGroup>  
   <ItemGroup>
     <ProjectReference Include="..\DataFilters\DataFilters.csproj" />

--- a/test/DataFilters.Expressions.UnitTests/DataFilters.Expressions.UnitTests.csproj
+++ b/test/DataFilters.Expressions.UnitTests/DataFilters.Expressions.UnitTests.csproj
@@ -10,21 +10,21 @@
     </ItemGroup>
 
     <ItemGroup>
-        <Compile Include="..\DataFilters.TestObjects\Appointment.cs" Link="TestsObjects\Appointment.cs"/>
-        <Compile Include="..\DataFilters.TestObjects\Henchman.cs" Link="TestsObjects\Henchman.cs"/>
-        <Compile Include="..\DataFilters.TestObjects\Model.cs" Link="TestsObjects\Model.cs"/>
-        <Compile Include="..\DataFilters.TestObjects\Person.cs" Link="TestsObjects\Person.cs"/>
-        <Compile Include="..\DataFilters.TestObjects\SuperHero.cs" Link="TestsObjects\SuperHero.cs"/>
-        <Compile Include="..\DataFilters.TestObjects\Weapon.cs" Link="TestsObjects\Weapon.cs"/>
+        <Compile Include="..\DataFilters.TestObjects\Appointment.cs" Link="TestsObjects\Appointment.cs" />
+        <Compile Include="..\DataFilters.TestObjects\Henchman.cs" Link="TestsObjects\Henchman.cs" />
+        <Compile Include="..\DataFilters.TestObjects\Model.cs" Link="TestsObjects\Model.cs" />
+        <Compile Include="..\DataFilters.TestObjects\Person.cs" Link="TestsObjects\Person.cs" />
+        <Compile Include="..\DataFilters.TestObjects\SuperHero.cs" Link="TestsObjects\SuperHero.cs" />
+        <Compile Include="..\DataFilters.TestObjects\Weapon.cs" Link="TestsObjects\Weapon.cs" />
     </ItemGroup>
 
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.19"/>
-        <PackageReference Include="NodaTime.Testing" Version="3.2.2"/>
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" />
+        <PackageReference Include="NodaTime.Testing" />
     </ItemGroup>
     <ItemGroup>
-        <ProjectReference Include="..\..\src\Datafilters.Expressions\DataFilters.Expressions.csproj"/>
+        <ProjectReference Include="..\..\src\Datafilters.Expressions\DataFilters.Expressions.csproj" />
     </ItemGroup>
 
 </Project>

--- a/test/DataFilters.PerformanceTests/DataFilters.PerformanceTests.csproj
+++ b/test/DataFilters.PerformanceTests/DataFilters.PerformanceTests.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.15.2" />
+    <PackageReference Include="BenchmarkDotNet" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests.props
+++ b/tests.props
@@ -1,16 +1,16 @@
 <Project>
-  <Import Project=".\core.props"/>
+  <Import Project=".\core.props" />
   <PropertyGroup>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.3" />
-    <PackageReference Include="xunit.analyzers" Version="1.23.0" />
-    <PackageReference Include="xunit.categories" Version="3.0.1" />
-    <PackageReference Include="FluentAssertions" Version="7.2.0" />
-    <PackageReference Include="FsCheck.XUnit" Version="3.3.0" />
-    <PackageReference Include="coverlet.msbuild" Version="6.0.4" />
-    <PackageReference Include="NodaTime.Bogus" Version="3.0.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+    <PackageReference Include="xunit.analyzers" />
+    <PackageReference Include="xunit.categories" />
+    <PackageReference Include="FluentAssertions" />
+    <PackageReference Include="FsCheck.XUnit" />
+    <PackageReference Include="coverlet.msbuild" />
+    <PackageReference Include="NodaTime.Bogus" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
### 💥 Breaking Changes
• Renamed FilterToken.OpenParenthese to FilterToken.LeftParenthesis
• Renamed FilterToken.CloseParenthese to FilterToken.RightParenthesis
• Renamed FilterToken.LeftBrace to FilterToken.LeftCurlyBrace
• Renamed FilterToken.RightBrace to FilterToken.RightCurlyBrace
• Renamed FilterToken.OpenSquaredBracket to FilterToken.LeftSquaredBrace
• Renamed FilterToken.CloseSquaredBracket to FilterToken.RightSquaredBrace
### 🚨 Fixes
• Fixed incorrect parsing of scientific numeric values (with E symbol).
• Fixed incorrect parsing of some expressions that uses * character
• Fixed incorrect parsing of text expressions when used in combination with contains
### 🧹 Housekeeping
• Pipeline fails to publish NuGet packages to GitHub due to incorrect URL
• Refactoring of ISimplifiable implementations
• Updated GitHub nuget registry URL
• Bumped Candoumbe.Pipelines to 0.13.0
• Bumped Microsoft.NET.Test.Sdk to 17.11.1
• Updated required NET SDK to 9.0.303
• Set Ubuntu 22.04 image for continuous integration

Full changelog at https://github.com/candoumbe/DataFilters/blob/coldfix/central-package-management/CHANGELOG.md