### PR TITLE
✨ Improve Mutation Coverage

### DIFF
--- a/core.props
+++ b/core.props
@@ -37,9 +37,6 @@
     </When>
   </Choose>
 
-  <ItemGroup>
-    <PackageReference Include="FluentValidation" />
-  </ItemGroup>
   <!-- Set package references based on target framework -->
   <Choose>
     <When Condition="$([System.Text.RegularExpressions.Regex]::IsMatch($(TargetFramework), '^net\d\.0$'))">

--- a/src/DataFilters.Queries/OrderExtensions.cs
+++ b/src/DataFilters.Queries/OrderExtensions.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using Queries.Core.Parts.Sorting;
 
+// ReSharper disable once CheckNamespace
 namespace DataFilters;
 /// <summary>
 /// Extensions method for <see cref="IOrder{T}"/> types
@@ -17,21 +18,14 @@ public static class OrderExtensions
     /// <exception cref="NotSupportedException"><paramref name="order"/> is neither <see cref="Order{T}"/> nor <see cref="MultiOrder{T}"/>.</exception>
     public static IEnumerable<IOrder> ToOrder<T>(this IOrder<T> order)
     {
-        static OrderExpression CreateOrderExpressionFromOrder(in Order<T> instance)
-        {
-            return new OrderExpression(instance.Expression.Field(), direction: instance.Direction == OrderDirection.Ascending
-                ? Queries.Core.Parts.Sorting.OrderDirection.Ascending
-                : Queries.Core.Parts.Sorting.OrderDirection.Descending);
-        }
-
         switch (order)
         {
             case Order<T> expression:
                 yield return CreateOrderExpressionFromOrder(expression);
                 break;
-            case MultiOrder<T> multisort:
+            case MultiOrder<T> multiSort:
             {
-                foreach (Order<T> item in multisort.Orders)
+                foreach (Order<T> item in multiSort.Orders)
                 {
                     yield return CreateOrderExpressionFromOrder(item);
                 }
@@ -41,6 +35,15 @@ public static class OrderExtensions
 
             default:
                 throw new NotSupportedException("Unsupported order type");
+        }
+
+        yield break;
+
+        static OrderExpression CreateOrderExpressionFromOrder(in Order<T> instance)
+        {
+            return new OrderExpression(instance.Expression.Field(), direction: instance.Direction == OrderDirection.Ascending
+                                                                                   ? Queries.Core.Parts.Sorting.OrderDirection.Ascending
+                                                                                   : Queries.Core.Parts.Sorting.OrderDirection.Descending);
         }
     }
 }

--- a/src/DataFilters/Serialization/FilterConverter.cs
+++ b/src/DataFilters/Serialization/FilterConverter.cs
@@ -52,7 +52,7 @@ public class FilterConverter : JsonConverter<Filter>
 
         if (!reader.Read() || reader.TokenType != JsonTokenType.PropertyName || Filter.OperatorJsonPropertyName != reader.GetString())
         {
-            throw new JsonException($@"Missing ""{Filter.OperatorJsonPropertyName}"" property.");
+            throw new JsonException($"""Missing "{Filter.OperatorJsonPropertyName}" property.""");
         }
 
         reader.Read();
@@ -66,13 +66,12 @@ public class FilterConverter : JsonConverter<Filter>
                 {
                     JsonTokenType.Number => reader.GetInt64(),
                     JsonTokenType.String => reader.GetString(),
-                    JsonTokenType.False => reader.GetBoolean(),
-                    JsonTokenType.True => reader.GetBoolean(),
+                    JsonTokenType.False or JsonTokenType.True => reader.GetBoolean(),
                     _ => null
                 };
             }
 
-            if (!reader.Read() || reader.TokenType != JsonTokenType.EndObject)
+            if (!reader.Read() || reader.TokenType is not JsonTokenType.EndObject)
             {
                 throw new JsonException("Filter json must end with '}'.");
             }
@@ -80,7 +79,7 @@ public class FilterConverter : JsonConverter<Filter>
         }
         else
         {
-            while (reader.Read() && reader.TokenType != JsonTokenType.EndObject)
+            while (reader.Read() && reader.TokenType is not JsonTokenType.EndObject)
             {
                 // empty loop to get to the end of the current JSON object
             }
@@ -105,7 +104,7 @@ public class FilterConverter : JsonConverter<Filter>
 
         writer.WriteStringValue(kv.Key);
 
-        // value (only if the operator is not an unary operator)
+        // value (only if the operator is not a unary operator)
         if (!Filter.UnaryOperators.Contains(filter.Operator))
         {
             writer.WritePropertyName(Filter.ValueJsonPropertyName);

--- a/test/DataFilters.Queries.UnitTests/FilterToQueriesTests.cs
+++ b/test/DataFilters.Queries.UnitTests/FilterToQueriesTests.cs
@@ -41,18 +41,40 @@ public class FilterToQueriesTests(ITestOutputHelper outputHelper)
                 new MultiFilter
                 {
                     Logic = FilterLogic.Or,
-                    Filters = new []{
+                    Filters =
+                    [
                         new Filter(field: "Name",@operator: EndsWith, value: "man"),
                         new Filter(field: "Name",@operator: StartsWith, value: "Bat")
-                    }
+                    ]
                 },
                 new CompositeWhereClause
                 {
                     Logic = ClauseLogic.Or,
-                    Clauses = new []{
+                    Clauses =
+                    [
                         new WhereClause("Name".Field(),@operator: ClauseOperator.Like, constraint: "%man"),
                         new WhereClause("Name".Field(),@operator: ClauseOperator.Like, constraint: "Bat%")
-                    }
+                    ]
+                }
+            },
+            {
+                new MultiFilter
+                {
+                    Logic = FilterLogic.And,
+                    Filters =
+                    [
+                        new Filter(field: "Name",@operator: EndsWith, value: "man"),
+                        new Filter(field: "Name",@operator: StartsWith, value: "Bat")
+                    ]
+                },
+                new CompositeWhereClause
+                {
+                    Logic = ClauseLogic.And,
+                    Clauses =
+                    [
+                        new WhereClause("Name".Field(),@operator: ClauseOperator.Like, constraint: "%man"),
+                        new WhereClause("Name".Field(),@operator: ClauseOperator.Like, constraint: "Bat%")
+                    ]
                 }
             },
 
@@ -110,8 +132,6 @@ public class FilterToQueriesTests(ITestOutputHelper outputHelper)
                 new Filter("BirthDate", GreaterThan, 18.January(1983)),
                 new WhereClause("BirthDate".Field(), ClauseOperator.GreaterThan, 18.January(1983))
             },
-
-#if NET6_0_OR_GREATER
             {
                 new Filter("BirthDate", GreaterThan, DateOnly.FromDateTime(18.January(1983))),
                 new WhereClause("BirthDate".Field(), ClauseOperator.GreaterThan, DateOnly.FromDateTime(18.January(1983)))
@@ -121,7 +141,6 @@ public class FilterToQueriesTests(ITestOutputHelper outputHelper)
                 new Filter("Time", GreaterThan, TimeOnly.FromDateTime(18.January(1983).Add(15.Hours().And(47.Minutes())))),
                 new WhereClause("Time".Field(), ClauseOperator.GreaterThan, TimeOnly.FromDateTime(18.January(1983).Add(15.Hours().And(47.Minutes()))))
             }
-#endif
         };
 
     [Theory]


### PR DESCRIPTION
### 💥 Breaking Changes
• Renamed FilterToken.OpenParenthese to FilterToken.LeftParenthesis
• Renamed FilterToken.CloseParenthese to FilterToken.RightParenthesis
• Renamed FilterToken.LeftBrace to FilterToken.LeftCurlyBrace
• Renamed FilterToken.RightBrace to FilterToken.RightCurlyBrace
• Renamed FilterToken.OpenSquaredBracket to FilterToken.LeftSquaredBrace
• Renamed FilterToken.CloseSquaredBracket to FilterToken.RightSquaredBrace
### 🚨 Fixes
• Fixed incorrect parsing of scientific numeric values (with E symbol).
• Fixed incorrect parsing of some expressions that uses * character
• Fixed incorrect parsing of text expressions when used in combination with contains
### 🧹 Housekeeping
• Pipeline fails to publish NuGet packages to GitHub due to incorrect URL
• Refactoring of ISimplifiable implementations
• Updated GitHub nuget registry URL
• Bumped Candoumbe.Pipelines to 0.13.0
• Bumped Microsoft.NET.Test.Sdk to 17.11.1
• Updated required NET SDK to 9.0.303
• Set Ubuntu 22.04 image for continuous integration

Full changelog at https://github.com/candoumbe/DataFilters/blob/feature/improve-mutation-coverage/CHANGELOG.md