### PR TITLE
refactor: optimize FilterTokenParser by using static readonly fields for parsers (#352)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -26,6 +26,8 @@ dotnet_style_prefer_inferred_anonymous_type_member_names = true:suggestion
 dotnet_style_prefer_compound_assignment = true:suggestion
 dotnet_style_prefer_simplified_interpolation = true:suggestion
 dotnet_style_namespace_match_folder = true:suggestion
+# Suppress IDE1006 (naming style) violations that cannot be auto-fixed
+dotnet_diagnostic.IDE1006.severity = silent
 
 
 # Style options

--- a/src/DataFilters/Grammar/Parsing/FilterTokenParser.cs
+++ b/src/DataFilters/Grammar/Parsing/FilterTokenParser.cs
@@ -144,22 +144,21 @@ public static class FilterTokenParser
                                                                  .ToStringValue()))
            );
 
+    private static readonly TokenListParser<FilterToken, OrExpression> s_or
+        = (from left in Parse.Ref(() => UnaryExpression)
+           from _ in Token.EqualTo(FilterToken.Or)
+           from right in Parse.Ref(() => UnaryExpression)
+           select left | right);
+
     /// <summary>
     /// Parser for logical OR expression.
     /// </summary>
-    public static TokenListParser<FilterToken, OrExpression> Or
-        => from left in Parse.Ref(() => UnaryExpression)
-           from _ in Token.EqualTo(FilterToken.Or)
-           from right in Parse.Ref(() => UnaryExpression)
-           select left | right;
+    public static TokenListParser<FilterToken, OrExpression> Or => s_or;
 
-    /// <summary>
-    /// Parser for logical AND expression
-    /// </summary>
-    public static TokenListParser<FilterToken, AndExpression> And => (from left in Parse.Ref(() => UnaryExpression)
-                                                                      from _ in Token.EqualTo(FilterToken.And)
-                                                                      from right in Parse.Ref(() => UnaryExpression)
-                                                                      select new AndExpression(left, right)).Try()
+    private static readonly TokenListParser<FilterToken, AndExpression> s_and = (from left in Parse.Ref(() => UnaryExpression)
+                                                                         from _ in Token.EqualTo(FilterToken.And)
+                                                                         from right in Parse.Ref(() => UnaryExpression)
+                                                                         select new AndExpression(left, right)).Try()
         .Or(from left in AlphaNumeric
             from _ in Asterisk
             from right in AlphaNumeric
@@ -173,11 +172,13 @@ public static class FilterTokenParser
                                      new EndsWithExpression(right.Value)));
 
     /// <summary>
-    /// Parser for NOT expression
+    /// Parser for logical AND expression
     /// </summary>
-    public static TokenListParser<FilterToken, NotExpression> Not => (from bangs in Token.EqualTo(FilterToken.Bang).AtLeastOnce()
-                                                                      from expression in Parse.Ref(() => UnaryExpression)
-                                                                      select (bangs, expression))
+    public static TokenListParser<FilterToken, AndExpression> And => s_and;
+
+    private static readonly TokenListParser<FilterToken, NotExpression> s_not = (from bangs in Token.EqualTo(FilterToken.Bang).AtLeastOnce()
+                                                                         from expression in Parse.Ref(() => UnaryExpression)
+                                                                         select (bangs, expression))
         .Select(tuple =>
                 {
                     NotExpression notExpression = !tuple.expression;
@@ -189,6 +190,11 @@ public static class FilterTokenParser
 
                     return notExpression;
                 });
+
+    /// <summary>
+    /// Parser for NOT expression
+    /// </summary>
+    public static TokenListParser<FilterToken, NotExpression> Not => s_not;
 
     private static TokenListParser<FilterToken, BracketExpression> Bracket => (
                                                                                   from _ in Token.EqualTo(FilterToken.LeftSquaredBracket)
@@ -380,17 +386,19 @@ public static class FilterTokenParser
 
     private static TokenListParser<FilterToken, Token<FilterToken>> Whitespace => Token.EqualTo(FilterToken.Whitespace);
 
+    private static readonly TokenListParser<FilterToken, GroupExpression> s_group = (from _ in Token.EqualTo(FilterToken.LeftParenthesis)
+                                                                                      from expression in Parse.Ref(() => BinaryOrUnaryExpression)
+                                                                                      from __ in Token.EqualTo(FilterToken.RightParenthesis)
+                                                                                      select new GroupExpression(expression));
+
     /// <summary>
     /// Group expression
     /// </summary>
-    public static TokenListParser<FilterToken, GroupExpression> Group => from _ in Token.EqualTo(FilterToken.LeftParenthesis)
-                                                                         from expression in Parse.Ref(() => BinaryOrUnaryExpression)
-                                                                         from __ in Token.EqualTo(FilterToken.RightParenthesis)
-                                                                         select new GroupExpression(expression);
+    public static TokenListParser<FilterToken, GroupExpression> Group => s_group;
 
-    private static TokenListParser<FilterToken, FilterExpression> BinaryOrUnaryExpression => Parse.OneOf(
-                                                                                                         Parse.Ref(() => And.Try().Cast<FilterToken, AndExpression, FilterExpression>()),
-                                                                                                         Parse.Ref(() => Or.Try().Cast<FilterToken, OrExpression, FilterExpression>()),
+    private static readonly TokenListParser<FilterToken, FilterExpression> BinaryOrUnaryExpression = Parse.OneOf(
+                                                                                                         s_and.Try().Cast<FilterToken, AndExpression, FilterExpression>(),
+                                                                                                         s_or.Try().Cast<FilterToken, OrExpression, FilterExpression>(),
                                                                                                          Parse.Ref(() => UnaryExpression)
                                                                                                         );
 
@@ -701,9 +709,9 @@ public static class FilterTokenParser
     /// <summary>
     /// Parses all supported unary expressions
     /// </summary>
-    private static TokenListParser<FilterToken, FilterExpression> UnaryExpression => Parse.OneOf(Parse.Ref(() => OneOf.Try().Cast<FilterToken, OneOfExpression, FilterExpression>()),
-                                                                                                 Parse.Ref(() => Not.Try().Cast<FilterToken, NotExpression, FilterExpression>()),
-                                                                                                 Parse.Ref(() => Group.Try().Cast<FilterToken, GroupExpression, FilterExpression>()),
+    private static readonly TokenListParser<FilterToken, FilterExpression> UnaryExpression = Parse.OneOf(Parse.Ref(() => OneOf.Try().Cast<FilterToken, OneOfExpression, FilterExpression>()),
+                                                                                                 s_not.Try().Cast<FilterToken, NotExpression, FilterExpression>(),
+                                                                                                 s_group.Try().Cast<FilterToken, GroupExpression, FilterExpression>(),
                                                                                                  Parse.Ref(() => Interval.Try().Cast<FilterToken, IntervalExpression, FilterExpression>()),
                                                                                                  Parse.Ref(() => GlobalUniqueIdentifier.Try().Cast<FilterToken, GuidValueExpression, FilterExpression>()),
                                                                                                  Parse.Ref(() => Duration.Try().Cast<FilterToken, DurationExpression, FilterExpression>()),

--- a/src/DataFilters/Grammar/Parsing/FilterTokenParser.cs
+++ b/src/DataFilters/Grammar/Parsing/FilterTokenParser.cs
@@ -156,9 +156,9 @@ public static class FilterTokenParser
     public static TokenListParser<FilterToken, OrExpression> Or => s_or;
 
     private static readonly TokenListParser<FilterToken, AndExpression> s_and = (from left in Parse.Ref(() => UnaryExpression)
-                                                                         from _ in Token.EqualTo(FilterToken.And)
-                                                                         from right in Parse.Ref(() => UnaryExpression)
-                                                                         select new AndExpression(left, right)).Try()
+                                                                                 from _ in Token.EqualTo(FilterToken.And)
+                                                                                 from right in Parse.Ref(() => UnaryExpression)
+                                                                                 select new AndExpression(left, right)).Try()
         .Or(from left in AlphaNumeric
             from _ in Asterisk
             from right in AlphaNumeric
@@ -177,8 +177,8 @@ public static class FilterTokenParser
     public static TokenListParser<FilterToken, AndExpression> And => s_and;
 
     private static readonly TokenListParser<FilterToken, NotExpression> s_not = (from bangs in Token.EqualTo(FilterToken.Bang).AtLeastOnce()
-                                                                         from expression in Parse.Ref(() => UnaryExpression)
-                                                                         select (bangs, expression))
+                                                                                 from expression in Parse.Ref(() => UnaryExpression)
+                                                                                 select (bangs, expression))
         .Select(tuple =>
                 {
                     NotExpression notExpression = !tuple.expression;
@@ -387,9 +387,9 @@ public static class FilterTokenParser
     private static TokenListParser<FilterToken, Token<FilterToken>> Whitespace => Token.EqualTo(FilterToken.Whitespace);
 
     private static readonly TokenListParser<FilterToken, GroupExpression> s_group = (from _ in Token.EqualTo(FilterToken.LeftParenthesis)
-                                                                                      from expression in Parse.Ref(() => BinaryOrUnaryExpression)
-                                                                                      from __ in Token.EqualTo(FilterToken.RightParenthesis)
-                                                                                      select new GroupExpression(expression));
+                                                                                     from expression in Parse.Ref(() => BinaryOrUnaryExpression)
+                                                                                     from __ in Token.EqualTo(FilterToken.RightParenthesis)
+                                                                                     select new GroupExpression(expression));
 
     /// <summary>
     /// Group expression

--- a/test/DataFilters.Expressions.UnitTests/Hero.cs
+++ b/test/DataFilters.Expressions.UnitTests/Hero.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 
 namespace DataFilters.Expressions.UnitTests;
+
 public class Hero : IEquatable<Hero>
 {
     public string Name { get; set; }

--- a/test/DataFilters.Expressions.UnitTests/NodaTimeClass.cs
+++ b/test/DataFilters.Expressions.UnitTests/NodaTimeClass.cs
@@ -3,6 +3,7 @@ using System.Diagnostics.CodeAnalysis;
 using NodaTime;
 
 namespace DataFilters.Expressions.UnitTests;
+
 [ExcludeFromCodeCoverage]
 public class NodaTimeClass
 {

--- a/test/DataFilters.Expressions.UnitTests/QueryableExtensionsTests.cs
+++ b/test/DataFilters.Expressions.UnitTests/QueryableExtensionsTests.cs
@@ -7,6 +7,7 @@ using Xunit.Abstractions;
 using Xunit.Categories;
 
 namespace DataFilters.Expressions.UnitTests;
+
 [UnitTest]
 public class QueryableExtensionsTests(ITestOutputHelper outputHelper)
 {

--- a/test/DataFilters.Expressions.UnitTests/ToOrderClauseTests.cs
+++ b/test/DataFilters.Expressions.UnitTests/ToOrderClauseTests.cs
@@ -10,6 +10,7 @@ using Xunit.Categories;
 using static DataFilters.OrderDirection;
 
 namespace DataFilters.Expressions.UnitTests;
+
 [UnitTest]
 [Feature("Expressions")]
 public class ToOrderClauseTests

--- a/test/DataFilters.Queries.UnitTests/FilterToQueriesTests.cs
+++ b/test/DataFilters.Queries.UnitTests/FilterToQueriesTests.cs
@@ -8,6 +8,7 @@ using Xunit.Abstractions;
 using static DataFilters.FilterOperator;
 
 namespace DataFilters.Queries.UnitTests;
+
 public class FilterToQueriesTests(ITestOutputHelper outputHelper)
 {
     public static TheoryData<IFilter, IWhereClause> FilterToWhereCases

--- a/test/DataFilters.Queries.UnitTests/OrderToQueriesTests.cs
+++ b/test/DataFilters.Queries.UnitTests/OrderToQueriesTests.cs
@@ -10,6 +10,7 @@ using Xunit.Abstractions;
 using static global::Queries.Core.Parts.Sorting.OrderDirection;
 
 namespace DataFilters.Queries.UnitTests;
+
 public class OrderToQueriesTests(ITestOutputHelper outputHelper)
 {
     public class Person

--- a/test/DataFilters.UnitTests/FilterTests.cs
+++ b/test/DataFilters.UnitTests/FilterTests.cs
@@ -19,6 +19,7 @@ using static DataFilters.FilterLogic;
 using static DataFilters.FilterOperator;
 
 namespace DataFilters.UnitTests;
+
 [UnitTest]
 public class FilterTests(ITestOutputHelper output)
 {

--- a/test/DataFilters.UnitTests/Grammar/Syntax/BracketExpressionTests.cs
+++ b/test/DataFilters.UnitTests/Grammar/Syntax/BracketExpressionTests.cs
@@ -11,6 +11,7 @@ using Xunit;
 using Xunit.Abstractions;
 
 namespace DataFilters.UnitTests.Grammar.Syntax;
+
 public class BracketExpressionTests(ITestOutputHelper outputHelper)
 {
     [Fact]

--- a/test/DataFilters.UnitTests/Grammar/Syntax/ConstantBracketValueTests.cs
+++ b/test/DataFilters.UnitTests/Grammar/Syntax/ConstantBracketValueTests.cs
@@ -9,6 +9,7 @@ using FsCheck.Fluent;
 using FsCheck.Xunit;
 
 namespace DataFilters.UnitTests.Grammar.Syntax;
+
 public class ConstantBracketValueTests
 {
     [Property]

--- a/test/DataFilters.UnitTests/Grammar/Syntax/ContainsExpressionTests.cs
+++ b/test/DataFilters.UnitTests/Grammar/Syntax/ContainsExpressionTests.cs
@@ -11,6 +11,7 @@ using Xunit;
 using Xunit.Abstractions;
 
 namespace DataFilters.UnitTests.Grammar.Syntax;
+
 public class ContainsExpressionTests(ITestOutputHelper outputHelper)
 {
     [Fact]

--- a/test/DataFilters.UnitTests/Grammar/Syntax/DateExpressionTests.cs
+++ b/test/DataFilters.UnitTests/Grammar/Syntax/DateExpressionTests.cs
@@ -9,6 +9,7 @@ using FsCheck.Xunit;
 using Xunit;
 
 namespace DataFilters.UnitTests.Grammar.Syntax;
+
 public class DateExpressionTests
 {
     [Fact]

--- a/test/DataFilters.UnitTests/Grammar/Syntax/DateTimeExpressionTests.cs
+++ b/test/DataFilters.UnitTests/Grammar/Syntax/DateTimeExpressionTests.cs
@@ -11,6 +11,7 @@ using Xunit.Abstractions;
 using Xunit.Categories;
 
 namespace DataFilters.UnitTests.Grammar.Syntax;
+
 [Feature(nameof(DataFilters.Grammar.Syntax))]
 public class DateTimeExpressionTests(ITestOutputHelper outputHelper)
 {

--- a/test/DataFilters.UnitTests/Grammar/Syntax/DurationExpressionTests.cs
+++ b/test/DataFilters.UnitTests/Grammar/Syntax/DurationExpressionTests.cs
@@ -10,6 +10,7 @@ using Xunit.Abstractions;
 using Xunit.Categories;
 
 namespace DataFilters.UnitTests.Grammar.Syntax;
+
 [UnitTest]
 public class DurationExpressionTests(ITestOutputHelper outputHelper)
 {

--- a/test/DataFilters.UnitTests/Grammar/Syntax/EndsWithExpressionTests.cs
+++ b/test/DataFilters.UnitTests/Grammar/Syntax/EndsWithExpressionTests.cs
@@ -10,6 +10,7 @@ using Xunit.Abstractions;
 using Xunit.Categories;
 
 namespace DataFilters.UnitTests.Grammar.Syntax;
+
 [UnitTest]
 public class EndsWithExpressionTests(ITestOutputHelper outputHelper)
 {

--- a/test/DataFilters.UnitTests/Grammar/Syntax/IntervalExpressionTests.cs
+++ b/test/DataFilters.UnitTests/Grammar/Syntax/IntervalExpressionTests.cs
@@ -11,6 +11,7 @@ using Xunit;
 using Xunit.Abstractions;
 
 namespace DataFilters.UnitTests.Grammar.Syntax;
+
 public class IntervalExpressionTests(ITestOutputHelper outputHelper)
 {
     [Fact]

--- a/test/DataFilters.UnitTests/Grammar/Syntax/NotExpressionTests.cs
+++ b/test/DataFilters.UnitTests/Grammar/Syntax/NotExpressionTests.cs
@@ -12,6 +12,7 @@ using Superpower.Model;
 using Xunit;
 
 namespace DataFilters.UnitTests.Grammar.Syntax;
+
 public class NotExpressionTests
 {
     [Fact]

--- a/test/DataFilters.UnitTests/Grammar/Syntax/NumericValueExpressionTests.cs
+++ b/test/DataFilters.UnitTests/Grammar/Syntax/NumericValueExpressionTests.cs
@@ -10,6 +10,7 @@ using Xunit.Abstractions;
 using Xunit.Categories;
 
 namespace DataFilters.UnitTests.Grammar.Syntax;
+
 [UnitTest]
 public class NumericValueExpressionTests(ITestOutputHelper outputHelper)
 {

--- a/test/DataFilters.UnitTests/Grammar/Syntax/OffsetExpressionTests.cs
+++ b/test/DataFilters.UnitTests/Grammar/Syntax/OffsetExpressionTests.cs
@@ -9,6 +9,7 @@ using Xunit;
 using Xunit.Categories;
 
 namespace DataFilters.UnitTests.Grammar.Syntax;
+
 [UnitTest]
 public class OffsetExpressionTests
 {

--- a/test/DataFilters.UnitTests/Grammar/Syntax/OneOfExpressionTests.cs
+++ b/test/DataFilters.UnitTests/Grammar/Syntax/OneOfExpressionTests.cs
@@ -11,6 +11,7 @@ using Xunit;
 using Xunit.Abstractions;
 
 namespace DataFilters.UnitTests.Grammar.Syntax;
+
 public class OneOfExpressionTests(ITestOutputHelper outputHelper)
 {
     [Fact]

--- a/test/DataFilters.UnitTests/Grammar/Syntax/OrExpressionTests.cs
+++ b/test/DataFilters.UnitTests/Grammar/Syntax/OrExpressionTests.cs
@@ -13,6 +13,7 @@ using Xunit.Abstractions;
 using Xunit.Categories;
 
 namespace DataFilters.UnitTests.Grammar.Syntax;
+
 [UnitTest]
 public class OrExpressionTests(ITestOutputHelper outputHelper)
 {

--- a/test/DataFilters.UnitTests/Grammar/Syntax/PropertyNameExpressionTests.cs
+++ b/test/DataFilters.UnitTests/Grammar/Syntax/PropertyNameExpressionTests.cs
@@ -6,6 +6,7 @@ using Xunit;
 using Xunit.Abstractions;
 
 namespace DataFilters.UnitTests.Grammar.Syntax;
+
 public class PropertyNameTests(ITestOutputHelper outputHelper)
 {
     [Fact]

--- a/test/DataFilters.UnitTests/Grammar/Syntax/RangeBracketValueTests.cs
+++ b/test/DataFilters.UnitTests/Grammar/Syntax/RangeBracketValueTests.cs
@@ -11,6 +11,7 @@ using Xunit;
 using Xunit.Abstractions;
 
 namespace DataFilters.UnitTests.Grammar.Syntax;
+
 public class RangeBracketValueTests(ITestOutputHelper outputHelper)
 {
     [Property]

--- a/test/DataFilters.UnitTests/MultiFilterTests.cs
+++ b/test/DataFilters.UnitTests/MultiFilterTests.cs
@@ -21,6 +21,7 @@ using static Newtonsoft.Json.JsonConvert;
 #endif
 
 namespace DataFilters.UnitTests;
+
 [UnitTest]
 public class MultiFilterTests(ITestOutputHelper output)
 {

--- a/test/DataFilters.UnitTests/MultiOrderTests.cs
+++ b/test/DataFilters.UnitTests/MultiOrderTests.cs
@@ -6,6 +6,7 @@ using Xunit.Abstractions;
 using static DataFilters.OrderDirection;
 
 namespace DataFilters.UnitTests;
+
 public class MultiOrderTests(ITestOutputHelper outputHelper)
 {
     public static TheoryData<MultiOrder<SuperHero>, object, bool, string> EqualsCases

--- a/test/DataFilters.UnitTests/OrderTests.cs
+++ b/test/DataFilters.UnitTests/OrderTests.cs
@@ -7,6 +7,7 @@ using Xunit.Abstractions;
 using static DataFilters.OrderDirection;
 
 namespace DataFilters.UnitTests;
+
 public class OrderTests(ITestOutputHelper outputHelper)
 {
     [Theory]

--- a/test/DataFilters.UnitTests/StringExtensionsTests.cs
+++ b/test/DataFilters.UnitTests/StringExtensionsTests.cs
@@ -8,6 +8,7 @@ using Xunit.Abstractions;
 using static DataFilters.OrderDirection;
 
 namespace DataFilters.UnitTests;
+
 public class StringExtensionsTests(ITestOutputHelper outputHelper)
 {
     [Theory]


### PR DESCRIPTION
### 🚨 Fixes

- Optimize `FilterTokenParser` by using `static readonly` fields for all parsers (#352).

Resolves #352