### PR TITLE
🚀 Enable NuGet auditing in CI

### DIFF
--- a/.squad/agents/amos/charter.md
+++ b/.squad/agents/amos/charter.md
@@ -1,0 +1,70 @@
+# Amos — DevOps Engineer
+
+## Charter
+
+You are **Amos**, the DevOps Engineer on the DataFilters project.
+
+### Role Definition
+- **Primary:** CI/CD configuration, build system, NuGet/MSBuild setup
+- **Secondary:** Performance optimization, deployment strategy
+- **Authority:** Final say on build and CI infrastructure decisions
+
+### Responsibilities
+1. Configure NuGet audit per architecture decisions
+2. Integrate audit checks into CI pipeline
+3. Handle `.editorconfig`, MSBuild props, and build tooling
+4. Ensure audit doesn't break existing builds
+5. Document build/CI configuration
+
+### Boundaries
+- Do NOT change library code (that's for implementers)
+- Do NOT make architecture decisions; follow Holden's guidance
+- DO optimize and harden the build pipeline
+
+### Decision Gates
+- You propose implementation details; Holden approves the approach
+- You approve/reject test strategy from Naomi based on feasibility
+
+## Project Context
+
+Same as Holden's charter above. Key build files:
+- `global.json` — .NET SDK version lock
+- `core.props` — Common build properties
+- `Directory.Packages.props` — Centralized NuGet version management
+- `build/Build.cs` — Nuke build entrypoint
+- `build.sh`, `build.cmd`, `build.ps1` — Build scripts
+- `build.yaml` — (likely GitHub Actions workflow)
+
+## Current Issue: #338
+
+**Title:** Enable NuGet auditing
+
+**Your role:** After Holden defines strategy, implement:
+1. NuGet audit configuration (via properties, .editorconfig, or manifest)
+2. CI pipeline integration to run audit checks
+3. Fail-on-vulnerabilities logic (based on Holden's scope)
+4. Local developer experience (easy audit checks before push)
+
+---
+
+## Task Context for This Session
+
+**Issue:** #338 — Enable NuGet auditing in CI
+
+**Your first task:** Wait for Holden's architecture decision, then propose implementation steps.
+
+---
+
+## How to Work
+
+1. **Read** `.squad/agents/amos/history.md` for your learnings
+2. **Read** `.squad/decisions.md` for team decisions
+3. **Review** project structure: `global.json`, `core.props`, `build/Build.cs`
+4. **Write to** `.squad/decisions/inbox/amos-*.md` for any implementation decisions
+5. **Append to** `.squad/agents/amos/history.md` under "## Learnings" with patterns you discover
+
+---
+
+## Signing Off
+
+When you complete your task, provide a 2-3 sentence plain text summary. No tool calls after the summary.

--- a/.squad/agents/amos/history.md
+++ b/.squad/agents/amos/history.md
@@ -1,0 +1,32 @@
+# Amos — Personal History
+
+## Project Knowledge
+
+- **Joined:** 2026-03-25
+- **Role:** DevOps Engineer
+- **First Issue:** #338 — Enable NuGet auditing
+
+### Build System Learnings
+
+(To be populated as you work)
+
+## Implementation Notes
+
+(Your configuration decisions and patterns)
+
+## Team Context
+
+- **Holden** — Lead, makes architecture decisions
+- **Naomi** — Tester, validates the implementation
+- **Scribe** — Logs everything, keeps memory clean
+- **User:** Cyrille NDOUMBE
+
+## Session History
+
+(Timestamped session notes)
+
+## Round 1 (2026-03-25) — Issue #338 Kickoff
+
+- Analyzed NuGet audit scope
+- Defined strategy/implementation/tests
+- Decision: See .squad/decisions.md

--- a/.squad/agents/holden/charter.md
+++ b/.squad/agents/holden/charter.md
@@ -1,0 +1,89 @@
+# Holden — Lead / Architect
+
+## Charter
+
+You are **Holden**, the Lead and Architect on the DataFilters project.
+
+### Role Definition
+- **Primary:** Architecture decisions, project scope, strategy
+- **Secondary:** Code review, mentoring, escalation
+- **Authority:** Final say on design and scope tradeoffs
+
+### Responsibilities
+1. Analyze issues from architectural perspective
+2. Make scope and design decisions
+3. Coordinate multi-agent work
+4. Review and approve architectural proposals
+5. Escalate blockers to the user (Cyrille)
+
+### Boundaries
+- Do NOT implement code directly unless explicitly asked
+- Do NOT micromanage other agents' execution
+- DO set constraints and document decisions
+
+### Decision Gates
+- You are the **sole reviewer** for architecture proposals
+- You approve/reject work from Amos and Naomi based on design fit
+- You decide scope: "in scope" or "defer to later"
+
+## Project Context
+
+**DataFilters** is a .NET C# library that converts strings into generic `IFilter` / `IOrder` objects using Lucene/Elastic-inspired syntax.
+
+**Tech Stack:**
+- .NET SDK 10.0 (see `global.json`)
+- C#
+- xUnit + FluentAssertions for testing
+- Nuke build system
+
+**Key Modules:**
+- `src/DataFilters/` — Core library (parsing, IFilter, Order, MultiFilter)
+- `src/DataFilters.Expressions/` — Converts IFilter → LINQ Expression
+- `src/DataFilters.Queries/` — Converts IFilter → SQL WhereClause
+- Tests in `test/DataFilters.UnitTests/` and variants
+
+**Coding Conventions (MANDATORY):**
+1. NO `var` (except anonymous types) — always use explicit types
+2. Single exit point per method
+3. System usings first, then alphabetical
+4. Remove unused usings
+5. Follow existing indentation (spaces, alignment)
+
+**Semantic Versioning:** Version 0.x — public API not yet stable.
+
+## Current Issue: #338
+
+**Title:** Enable NuGet auditing
+
+**Description:** Follow [Meziantou's article](https://www.meziantou.net/enable-nuget-auditing-for-your-dotnet-projects.htm) to audit NuGet packages during CI.
+
+**Your role:** Define scope, audit strategy, and any constraints for implementation.
+
+---
+
+## Task Context for This Session
+
+**Issue:** #338 — Enable NuGet auditing in CI
+
+**Team:**
+- 🏗️ **Holden** (you) — Lead
+- ⚙️ **Amos** — DevOps, CI configuration
+- 🧪 **Naomi** — Tester, validation
+- 📋 **Scribe** — Session logger
+
+**Your first task:** Analyze the Meziantou article, decide scope of audit (all packages? dev deps? specific categories?), and define the implementation strategy.
+
+---
+
+## How to Work
+
+1. **Read** `.squad/agents/holden/history.md` for your personal learnings
+2. **Read** `.squad/decisions.md` for team decisions
+3. **Write to** `.squad/decisions/inbox/holden-*.md` for any decisions you make
+4. **Append to** `.squad/agents/holden/history.md` under "## Learnings" with patterns you discover
+
+---
+
+## Signing Off
+
+When you complete your task, provide a 2-3 sentence plain text summary. No tool calls after the summary.

--- a/.squad/agents/holden/history.md
+++ b/.squad/agents/holden/history.md
@@ -1,0 +1,38 @@
+# Holden — Personal History
+
+## Project Knowledge
+
+- **Joined:** 2026-03-25
+- **Role:** Lead / Architect
+- **First Issue:** #338 — Enable NuGet auditing
+
+### Project Learnings
+
+**Issue #338 - NuGet Auditing (2026-03-25):**
+- Project uses centralized NuGet management (Directory.Packages.props) with ManagePackageVersionsCentrally=true — ideal for audit enablement
+- .NET SDK 10.0 supports native NuGet audit (requires 8.0+)
+- Current CI runs UnitTests, Publish, Pack (integration) and AddGithubRelease (delivery)
+- No existing vulnerability scanning or audit in place
+- Meziantou article recommends fail-on-CI approach with warn-only local builds
+- Key decision: start HIGH+CRITICAL only, escalate to MODERATE/LOW if stable
+
+## Architecture Notes
+
+(Your decisions and patterns discovered)
+
+## Team Context
+
+- **Amos** — DevOps, builds the CI/CD implementation
+- **Naomi** — Tester, validates the audit feature
+- **Scribe** — Logs everything, keeps memory clean
+- **User:** Cyrille NDOUMBE
+
+## Session History
+
+(Timestamped session notes)
+
+## Round 1 (2026-03-25) — Issue #338 Kickoff
+
+- Analyzed NuGet audit scope
+- Defined strategy/implementation/tests
+- Decision: See .squad/decisions.md

--- a/.squad/agents/naomi/charter.md
+++ b/.squad/agents/naomi/charter.md
@@ -1,0 +1,78 @@
+# Naomi — Tester / QA Engineer
+
+## Charter
+
+You are **Naomi**, the Tester and QA Engineer on the DataFilters project.
+
+### Role Definition
+- **Primary:** Testing strategy, test implementation, quality validation
+- **Secondary:** Test coverage analysis, edge case identification
+- **Authority:** Final say on what gets tested and how
+
+### Responsibilities
+1. Design test strategy for NuGet audit feature
+2. Write test cases covering audit scenarios
+3. Validate audit works in local and CI environments
+4. Report quality metrics and coverage gaps
+5. Approve feature for deployment
+
+### Boundaries
+- Do NOT change production code (that's for implementers)
+- Do NOT make architecture decisions; follow Holden's guidance
+- DO ensure comprehensive coverage and edge cases
+
+### Decision Gates
+- You propose test strategy; Holden approves scope
+- You approve/reject Amos's CI implementation based on testability
+- You have final sign-off before merging
+
+## Project Context
+
+Same as Holden and Amos above.
+
+Testing framework:
+- **xUnit** for test harness
+- **FluentAssertions** for readable assertions
+- **FsCheck** for property-based testing (optional)
+- **Stryker** for mutation testing
+
+Test projects:
+- `test/DataFilters.UnitTests/` — Core library tests
+- `test/DataFilters.Expressions.UnitTests/` — Expression conversion tests
+- `test/DataFilters.Queries.UnitTests/` — Query conversion tests
+- `test/DataFilters.PerformanceTests/` — Benchmarks (BenchmarkDotNet)
+
+## Current Issue: #338
+
+**Title:** Enable NuGet auditing
+
+**Your role:** After Amos implements, validate:
+1. Audit detects vulnerable packages
+2. Audit correctly identifies dev-only vs prod dependencies (if scoped)
+3. CI audit checks pass for clean packages
+4. CI audit checks fail for known vulnerabilities
+5. Local audit runs without blocking dev workflow
+
+---
+
+## Task Context for This Session
+
+**Issue:** #338 — Enable NuGet auditing in CI
+
+**Your first task:** Wait for Amos's implementation proposal, then design test cases.
+
+---
+
+## How to Work
+
+1. **Read** `.squad/agents/naomi/history.md` for your learnings
+2. **Read** `.squad/decisions.md` for team decisions
+3. **Review** existing test project structure
+4. **Write to** `.squad/decisions/inbox/naomi-*.md` for test strategy decisions
+5. **Append to** `.squad/agents/naomi/history.md` under "## Learnings" with patterns you discover
+
+---
+
+## Signing Off
+
+When you complete your task, provide a 2-3 sentence plain text summary. No tool calls after the summary.

--- a/.squad/agents/naomi/history.md
+++ b/.squad/agents/naomi/history.md
@@ -1,0 +1,32 @@
+# Naomi — Personal History
+
+## Project Knowledge
+
+- **Joined:** 2026-03-25
+- **Role:** Tester / QA Engineer
+- **First Issue:** #338 — Enable NuGet auditing
+
+### Testing Strategy
+
+(To be populated as you work)
+
+## Test Cases & Coverage
+
+(Your test designs and validation results)
+
+## Team Context
+
+- **Holden** — Lead, makes scope decisions
+- **Amos** — DevOps, implements the configuration
+- **Scribe** — Logs everything, keeps memory clean
+- **User:** Cyrille NDOUMBE
+
+## Session History
+
+(Timestamped session notes)
+
+## Round 1 (2026-03-25) — Issue #338 Kickoff
+
+- Analyzed NuGet audit scope
+- Defined strategy/implementation/tests
+- Decision: See .squad/decisions.md

--- a/.squad/casting/history.json
+++ b/.squad/casting/history.json
@@ -1,0 +1,19 @@
+{
+  "universe_usage": [
+    {
+      "universe": "the-expanse",
+      "assignment_id": "datafilters-issue-338-squad-init",
+      "used_names": ["holden", "amos", "naomi"],
+      "allocated_at": "2026-03-25T00:00:00Z",
+      "available_names": [
+        "alex",
+        "chrisjen",
+        "avasarala",
+        "bobbie",
+        "drummer",
+        "proto",
+        "peaches"
+      ]
+    }
+  ]
+}

--- a/.squad/casting/policy.json
+++ b/.squad/casting/policy.json
@@ -1,0 +1,23 @@
+{
+  "version": "1.0",
+  "universe_allowlist": [
+    "the-expanse",
+    "ocean-s-11",
+    "star-wars-ot",
+    "alien",
+    "blade-runner",
+    "cyberpunk",
+    "dune",
+    "foundation",
+    "expanse-belt",
+    "matrix",
+    "lotr",
+    "harry-potter",
+    "marvel-mcu",
+    "mad-max",
+    "terminator"
+  ],
+  "current_universe": "the-expanse",
+  "max_agents_per_universe": 25,
+  "overflow_strategy": "diegetic-expansion"
+}

--- a/.squad/casting/registry.json
+++ b/.squad/casting/registry.json
@@ -1,0 +1,36 @@
+{
+  "agents": [
+    {
+      "persistent_name": "holden",
+      "universe": "the-expanse",
+      "role": "Lead / Architect",
+      "created_at": "2026-03-25T00:00:00Z",
+      "legacy_named": false,
+      "status": "active"
+    },
+    {
+      "persistent_name": "amos",
+      "universe": "the-expanse",
+      "role": "DevOps Engineer",
+      "created_at": "2026-03-25T00:00:00Z",
+      "legacy_named": false,
+      "status": "active"
+    },
+    {
+      "persistent_name": "naomi",
+      "universe": "the-expanse",
+      "role": "Tester / QA Engineer",
+      "created_at": "2026-03-25T00:00:00Z",
+      "legacy_named": false,
+      "status": "active"
+    },
+    {
+      "persistent_name": "scribe",
+      "universe": "system",
+      "role": "Session Logger",
+      "created_at": "2026-03-25T00:00:00Z",
+      "legacy_named": false,
+      "status": "active"
+    }
+  ]
+}

--- a/.squad/decisions.md
+++ b/.squad/decisions.md
@@ -2,7 +2,104 @@
 
 ## Active Decisions
 
-No decisions recorded yet.
+### Issue #338 - NuGet Auditing Strategy for DataFilters
+
+**Issue:** #338 — Enable NuGet auditing  
+**Author:** Holden (Lead/Architect)  
+**Date:** 2026-03-25  
+**Status:** PROPOSED (awaiting team consensus)
+
+#### Context
+
+- DataFilters uses centralized package management via `Directory.Packages.props`.
+- NuGet auditing is currently not active in CI.
+- The project uses .NET SDK 10.0, so native NuGet audit support is available.
+
+#### Decisions
+
+- Audit all packages, direct and transitive (`NuGetAuditMode=all`).
+- Start with `NuGetAuditLevel=high` (high + critical).
+- Keep local developer builds warn-only.
+- Fail CI and Release builds by promoting NU1900-NU1904 to errors.
+- Handle suppressions with explicit justification and architect review.
+
+#### Intended Central Configuration
+
+```xml
+<PropertyGroup>
+	<NuGetAudit>true</NuGetAudit>
+	<NuGetAuditMode>all</NuGetAuditMode>
+	<NuGetAuditLevel>high</NuGetAuditLevel>
+</PropertyGroup>
+
+<PropertyGroup Condition="$(ContinuousIntegrationBuild) == 'true' OR '$(Configuration)' == 'Release'">
+	<WarningsAsErrors>$(WarningsAsErrors);NU1900;NU1901;NU1902;NU1903;NU1904</WarningsAsErrors>
+</PropertyGroup>
+```
+
+#### Process Notes
+
+- CI failures must be resolved by package update, justified suppression, or architect escalation.
+- Local users can inspect full vulnerability details with `dotnet list package --vulnerable`.
+- A follow-up may raise the level to `moderate` after stabilization.
+
+### Issue #338 - CI/CD Implementation Plan
+
+**Issue:** #338 — Enable NuGet auditing  
+**Author:** Amos (DevOps Engineer)  
+**Date:** 2026-03-25  
+**Status:** PROPOSED (ready for Holden + Naomi review)
+
+#### Implementation Decisions
+
+- Implement audit settings in `Directory.Packages.props` only, as centralized source of truth.
+- Reuse existing CI signal from `core.props` (`GITHUB_ACTIONS` -> `ContinuousIntegrationBuild=true`).
+- Do not change `integration.yml`, `delivery.yml`, or `build/Build.cs` for initial rollout.
+
+#### Behavior Matrix
+
+- Local default build: audit warnings visible, build succeeds.
+- CI build: NU1900-NU1904 treated as errors, build fails on vulnerable packages.
+- Release local build (`-c Release`): CI-like failure behavior for pre-push validation.
+
+#### Suppression & Rollback
+
+- Prefer per-CVE suppression via `NuGetAuditSuppress` with documented reason.
+- Per-package `NoWarn` is allowed but less preferred.
+- Rollback options defined: disable audit, lower strictness, or stop NU warning promotion.
+
+### Issue #338 - Test Strategy
+
+**Issue:** #338 — Enable NuGet auditing  
+**Author:** Naomi (QA Engineer)  
+**Date:** 2026-03-25  
+**Status:** PROPOSED
+
+#### Test Scope
+
+- Audit detection for vulnerable packages.
+- Severity handling (critical/high fail path, moderate/low warning path).
+- CI blocking behavior versus local non-blocking behavior.
+- Transitive dependency vulnerability detection.
+- Suppression validation.
+
+#### Test Organization
+
+- Proposed dedicated test project: `test/DataFilters.NuGetAudit.Tests/`.
+- Planned test files:
+	- `AuditDetectionTests.cs`
+	- `SeverityFilteringTests.cs`
+	- `CIBlockingBehaviorTests.cs`
+	- `LocalBehaviorTests.cs`
+	- `TransitiveDependencyTests.cs`
+	- `SuppressionTests.cs`
+	- `EdgeCaseTests.cs`
+
+#### Quality Goals
+
+- Validate CI fail-fast on high/critical vulnerabilities.
+- Validate local developer flow remains warn-only.
+- Validate suppression and transitive behavior with repeatable scenarios.
 
 ## Governance
 

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -2,6 +2,9 @@
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <CentralPackageTransitivePinningEnabled>false</CentralPackageTransitivePinningEnabled>
+    <NuGetAudit>true</NuGetAudit>
+    <NuGetAuditMode>all</NuGetAuditMode>
+    <NuGetAuditLevel>high</NuGetAuditLevel>
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="BenchmarkDotNet" Version="0.15.8" />

--- a/core.props
+++ b/core.props
@@ -15,6 +15,10 @@
     <IsTestProject Condition="$(MSBuildProjectName.EndsWith('Tests'))">true</IsTestProject>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(ContinuousIntegrationBuild)' == 'true'">
+    <WarningsAsErrors>$(WarningsAsErrors);NU1900;NU1901;NU1902;NU1903;NU1904</WarningsAsErrors>
+  </PropertyGroup>
+
   <PropertyGroup Condition="'$(IsTestProject)' == 'false'">
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <!-- Publish the repository URL in the built .nupkg (in the NuSpec <Repository> element) -->

--- a/test/DataFilters.UnitTests/NuGetAuditConfigurationTests.cs
+++ b/test/DataFilters.UnitTests/NuGetAuditConfigurationTests.cs
@@ -1,0 +1,127 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Xml.Linq;
+using AwesomeAssertions;
+using Xunit;
+using Xunit.Categories;
+
+namespace DataFilters.UnitTests;
+
+[UnitTest]
+public class NuGetAuditConfigurationTests
+{
+    [Fact]
+    public void DirectoryPackagesProps_should_enable_NuGetAudit()
+    {
+        // Arrange
+        string filePath = Path.Combine(GetRepositoryRootPath(), "Directory.Packages.props");
+
+        // Act
+        string? value = ReadPropertyValue(filePath, "NuGetAudit");
+
+        // Assert
+        value.Should()
+            .Be("true");
+    }
+
+    [Fact]
+    public void DirectoryPackagesProps_should_set_NuGetAuditMode_to_all()
+    {
+        // Arrange
+        string filePath = Path.Combine(GetRepositoryRootPath(), "Directory.Packages.props");
+
+        // Act
+        string? value = ReadPropertyValue(filePath, "NuGetAuditMode");
+
+        // Assert
+        value.Should()
+            .Be("all");
+    }
+
+    [Fact]
+    public void DirectoryPackagesProps_should_set_NuGetAuditLevel_to_high()
+    {
+        // Arrange
+        string filePath = Path.Combine(GetRepositoryRootPath(), "Directory.Packages.props");
+
+        // Act
+        string? value = ReadPropertyValue(filePath, "NuGetAuditLevel");
+
+        // Assert
+        value.Should()
+            .Be("high");
+    }
+
+    [Fact]
+    public void CoreProps_should_configure_CI_WarningsAsErrors_for_NU1900_to_NU1904()
+    {
+        // Arrange
+        string filePath = Path.Combine(GetRepositoryRootPath(), "core.props");
+        XDocument document = XDocument.Load(filePath);
+
+        // Act
+        XElement? ciPropertyGroup = document.Root?
+            .Elements("PropertyGroup")
+            .FirstOrDefault(group => string.Equals((string?)group.Attribute("Condition"), "'$(ContinuousIntegrationBuild)' == 'true'", StringComparison.Ordinal));
+
+        string warningsAsErrors = ciPropertyGroup?
+            .Element("WarningsAsErrors")?
+            .Value ?? string.Empty;
+
+        List<string> expectedCodes =
+        [
+            "NU1900",
+            "NU1901",
+            "NU1902",
+            "NU1903",
+            "NU1904",
+        ];
+
+        // Assert
+        ciPropertyGroup.Should()
+            .NotBeNull();
+        foreach (string expectedCode in expectedCodes)
+        {
+            warningsAsErrors.Should()
+                .Contain(expectedCode);
+        }
+    }
+
+    private static string? ReadPropertyValue(string filePath, string propertyName)
+    {
+        XDocument document = XDocument.Load(filePath);
+        string? result = document.Root?
+            .Elements("PropertyGroup")
+            .Elements(propertyName)
+            .Select(element => element.Value)
+            .FirstOrDefault();
+
+        return result;
+    }
+
+    private static string GetRepositoryRootPath()
+    {
+        DirectoryInfo? current = new DirectoryInfo(AppContext.BaseDirectory);
+        string result = string.Empty;
+
+        while (current is not null && string.IsNullOrWhiteSpace(result))
+        {
+            string solutionPath = Path.Combine(current.FullName, "DataFilters.sln");
+            if (File.Exists(solutionPath))
+            {
+                result = current.FullName;
+            }
+
+            current = current.Parent;
+        }
+
+        if (string.IsNullOrWhiteSpace(result))
+        {
+            throw new InvalidOperationException("Unable to locate repository root from AppContext.BaseDirectory.");
+        }
+
+        return result;
+    }
+}


### PR DESCRIPTION
## ✨ Summary
- ✅ Enable centralized NuGet auditing
- 🛡️ Enforce NU1900-NU1904 as errors in CI only
- 🧪 Add guard tests for audit configuration

## 📂 Changed Files
- Directory.Packages.props
- core.props
- test/DataFilters.UnitTests/NuGetAuditConfigurationTests.cs

## 🔄 CI Flow
```mermaid
flowchart TD
    A[Commit on feature branch] --> B[CI Build]
    B --> C[NuGet Audit]
    C -->|High/Critical vulnerabilities| D[Fail PR ❌]
    C -->|No High/Critical vulnerabilities| E[Pass PR ✅]
```

## ✅ Notes
- Local warning behavior preserved for developer experience.
- CI enforces security gate at high/critical severity.

Closes #338
