### PR TITLE
chore: re-enable mutation testing on nightly pipeline

### DIFF
--- a/.fallout/build.schema.json
+++ b/.fallout/build.schema.json
@@ -34,6 +34,7 @@
         "Feature",
         "Format",
         "Hotfix",
+        "MutationTests",
         "Pack",
         "Publish",
         "RegenerateWorkflow",
@@ -203,6 +204,11 @@
         "Solution": {
           "type": "string",
           "description": "Path to a solution file that is automatically loaded"
+        },
+        "StrykerDashboardApiKey": {
+          "type": "string",
+          "description": "API KEY used to submit mutation report to a stryker dashboard",
+          "default": "Secrets must be entered via 'nuke :secrets [profile]'"
         },
         "Title": {
           "type": "string",

--- a/.gitattributes
+++ b/.gitattributes
@@ -68,3 +68,5 @@
 .squad/orchestration-log/** merge=union
 # Squad: union merge for append-only team state files
 .squad/rai/audit-trail.md merge=union
+# Squad: union merge for append-only team state files
+.squad/fact-checker/audit-trail.md merge=union

--- a/.github/agents/squad.agent.md
+++ b/.github/agents/squad.agent.md
@@ -3,14 +3,14 @@ name: Squad
 description: "Your AI team. Describe what you're building, get a team of specialists that live in your repo."
 ---
 
-<!-- version: 0.10.0 -->
+<!-- version: 0.13.0 -->
 
 You are **Squad (Coordinator)** — the orchestrator for this project's AI team.
 
 ### Coordinator Identity
 
 - **Name:** Squad (Coordinator)
-- **Version:** 0.10.0 (see HTML comment above — this value is stamped during install/upgrade). Include it as `Squad v0.9.1` in your first response of each session (e.g., in the acknowledgment or greeting).
+- **Version:** 0.13.0 (see HTML comment above — this value is stamped during install/upgrade). Include it as `Squad v0.9.1` in your first response of each session (e.g., in the acknowledgment or greeting).
 - **Role:** Agent orchestration, handoff enforcement, reviewer gating
 - **Inputs:** User request, repository state, `.squad/decisions.md`
 - **Outputs owned:** Final assembled artifacts, orchestration log (via Scribe)

--- a/.github/skills/agent-collaboration/SKILL.md
+++ b/.github/skills/agent-collaboration/SKILL.md
@@ -1,0 +1,42 @@
+---
+name: "agent-collaboration"
+description: "Standard collaboration patterns for all squad agents — worktree awareness, decisions, cross-agent communication"
+domain: "team-workflow"
+confidence: "high"
+source: "extracted from charter boilerplate — identical content in 18+ agent charters"
+---
+
+## Context
+
+Every agent on the team follows identical collaboration patterns for worktree awareness, decision recording, and cross-agent communication. These were previously duplicated in every charter's Collaboration section (~300 bytes × 18 agents = ~5.4KB of redundant context). Now centralized here.
+
+The coordinator's spawn prompt already instructs agents to read decisions.md and their history.md. This skill adds the patterns for WRITING decisions and requesting help.
+
+## Patterns
+
+### Worktree Awareness
+Use the `TEAM ROOT` path provided in your spawn prompt. All `.squad/` paths are relative to this root. If TEAM ROOT is not provided (rare), run `git rev-parse --show-toplevel` as fallback. Never assume CWD is the repo root.
+
+### Decision Recording
+After making a decision that affects other team members, write it to:
+`.squad/decisions/inbox/{your-name}-{brief-slug}.md`
+
+Format:
+```
+### {date}: {decision title}
+**By:** {Your Name}
+**What:** {the decision}
+**Why:** {rationale}
+```
+
+### Cross-Agent Communication
+If you need another team member's input, say so in your response. The coordinator will bring them in. Don't try to do work outside your domain.
+
+### Reviewer Protocol
+If you have reviewer authority and reject work: the original author is locked out from revising that artifact. A different agent must own the revision. State who should revise in your rejection response.
+
+## Anti-Patterns
+- Don't read all agent charters — you only need your own context + decisions.md
+- Don't write directly to `.squad/decisions.md` — always use the inbox drop-box
+- Don't modify other agents' history.md files — that's Scribe's job
+- Don't assume CWD is the repo root — always use TEAM ROOT

--- a/.github/skills/coordinator-init-mode/SKILL.md
+++ b/.github/skills/coordinator-init-mode/SKILL.md
@@ -1,0 +1,99 @@
+---
+name: "coordinator-init-mode"
+description: "The complete two-phase Init Mode protocol the Squad coordinator runs when no team exists yet in the current repo. Phase 1 = propose the team (no files created, wait for user confirm). Phase 2 = create .squad/ scaffolding, casting state, .gitattributes for merge drivers, and the always-on built-ins (Scribe, Ralph, Rai, Fact Checker). Loaded on demand when the coordinator detects no .squad/team.md exists."
+allowedTools: []
+confidence: high
+domain: squad-internals
+source: "Extracted from squad.agent.md as part of the slimming effort (bradygaster/squad#1308). Behaviour unchanged — coordinator loads this satellite skill when init mode is detected (no .squad/team.md present)."
+---
+
+> **Load this skill when:** you detect that no `.squad/team.md` exists in the resolved team root — that means this is a fresh repo or a repo that has never been squadified, and Init Mode is the right path. The short stub in `squad.agent.md` tells you to load this skill; the full two-phase protocol lives here.
+>
+> **⚠️ Eager-execution exception:** Init Mode is the ONE exception to the eager-execution / parallel-fan-out doctrine. Phase 1 MUST end with a user confirmation before any file is created. Do not bypass.
+
+## Phase 1: Propose the Team
+
+No team exists yet. **Propose one — but DO NOT create any files until the user confirms.**
+
+1. **Identify the user.** Run `git config user.name` to learn who you're working with. Use their name in conversation (e.g., *"Hey {user}, what are you building?"*). Store their name (NOT email) in `team.md` under Project Context. **Never read or store `git config user.email`** — email addresses are PII and must not be written to committed files.
+2. Ask: *"What are you building? (language, stack, what it does)"*
+3. **Cast the team.** Before proposing names, run the Casting & Persistent Naming algorithm (see the canonical Casting reference at `.squad/templates/casting-reference.md`):
+   - Determine team size: pick **4–5 cast (user-domain) agents**, then add the **4 always-on built-ins** (Scribe + Ralph + Rai + Fact Checker — see their dedicated sections in `squad.agent.md`). A typical fresh squad has **8–9 total roster entries**, not 4–5.
+   - Determine assignment shape from the user's project description.
+   - Derive resonance signals from the session and repo context.
+   - Select a universe. Allocate character names from that universe.
+   - Scribe is always "Scribe" — exempt from casting.
+   - Ralph is always "Ralph" — exempt from casting.
+   - Rai is always "Rai" — exempt from casting.
+   - Fact Checker is always "Fact Checker" — exempt from casting (same pattern as Scribe / Ralph / Rai).
+4. Propose the team with their cast names. Example (names will vary per cast):
+
+```
+🏗️  {CastName1}  — Lead          Scope, decisions, code review
+⚛️  {CastName2}  — Frontend Dev  React, UI, components
+🔧  {CastName3}  — Backend Dev   APIs, database, services
+🧪  {CastName4}  — Tester        Tests, quality, edge cases
+📋  Scribe       — (silent)      Memory, decisions, session logs
+🔄  Ralph        — (monitor)     Work queue, backlog, keep-alive
+🛡️  Rai         — (background)  RAI awareness, content safety
+🔍  Fact Checker — (verifier)    Verification + Devil's Advocate
+```
+
+5. Use the `ask_user` tool to confirm the roster. Provide choices so the user sees a selectable menu.
+
+   The `question` must be **self-contained** because the client may render the blocking input request without the assistant text that preceded it.
+
+   The `question` must reuse every roster line from the exact proposal emitted in step 4, in the same order. Do not regenerate, summarize, truncate, omit, or replace any roster row with an ellipsis. Every proposed member must appear with their emoji, cast name, role, and concise responsibility/scope — including all four always-on built-ins (Scribe, Ralph, Rai, Fact Checker).
+
+   Shape:
+
+   ```
+   Confirm this team (universe: {ActualUniverse}):
+
+   {Every roster line from step 4, copied in full and in order}
+
+   Look right?
+   ```
+
+   Never use a bare "Look right?" question and never rely on preceding assistant output to identify the team being confirmed.
+
+   - **choices:** `["Yes, hire this team", "Add someone", "Change a role"]`
+
+**⚠️ STOP. Your response ENDS here. Do NOT proceed to Phase 2. Do NOT create any files or directories. Wait for the user's reply.**
+
+---
+
+## Phase 2: Create the Team
+
+**Trigger:** The user replied to Phase 1 with confirmation ("yes", "looks good", or similar affirmative), OR the user's reply to Phase 1 is a task (treat as implicit "yes").
+
+> If the user said "add someone" or "change a role," go back to Phase 1 step 3 and re-propose. **Do NOT enter Phase 2 until the user confirms.**
+
+6. Create the `.squad/` directory structure (see `.squad/templates/` for format guides or use the standard structure: `team.md`, `routing.md`, `ceremonies.md`, `decisions.md`, `decisions/inbox/`, `casting/`, `agents/`, `orchestration-log/`, `skills/`, `log/`, `rai/`).
+
+**Casting state initialization:** Copy `.squad/templates/casting-policy.json` to `.squad/casting/policy.json` (or create from defaults). Create `registry.json` (entries: persistent_name, universe, created_at, legacy_named: false, status: "active") and `history.json` (first assignment snapshot with unique assignment_id).
+
+**Seeding:** Each agent's `history.md` starts with the project description, tech stack, and the user's name so they have day-1 context. Agent folder names are the cast name in lowercase (e.g., `.squad/agents/ripley/`). The Scribe's charter includes maintaining `decisions.md` and cross-agent context sharing. Rai's charter is seeded from the `Rai-charter.md` template, and `.squad/rai/policy.md` is seeded from `rai-policy.md`. Fact Checker's charter is seeded from `fact-checker-charter.md` and `.squad/fact-checker/policy.md` is seeded from `fact-checker-policy.md`.
+
+**Team.md structure:** `team.md` MUST contain a section titled exactly `## Members` (not "## Team Roster" or other variations) containing the roster table. This header is hard-coded in GitHub workflows (`squad-heartbeat.yml`, `squad-issue-assign.yml`, `squad-triage.yml`, `sync-squad-labels.yml`) for label automation. If the header is missing or titled differently, label routing breaks.
+
+**Merge driver for append-only files:** Create or update `.gitattributes` at the repo root to enable conflict-free merging of `.squad/` state across branches:
+
+```
+.squad/decisions.md merge=union
+.squad/agents/*/history.md merge=union
+.squad/log/** merge=union
+.squad/orchestration-log/** merge=union
+.squad/rai/audit-trail.md merge=union
+```
+
+The `union` merge driver keeps all lines from both sides, which is correct for append-only files. This makes worktree-local strategy work seamlessly when branches merge — decisions, memories, and logs from all branches combine automatically.
+
+7. Say: *"✅ Team hired. Try: '{FirstCastName}, set up the project structure'"*
+
+8. **Post-setup input sources** (optional — ask after team is created, not during casting):
+   - **PRD/spec:** *"Do you have a PRD or spec document? (file path, paste it, or skip)"* → If provided, follow PRD Mode flow.
+   - **GitHub issues:** *"Is there a GitHub repo with issues I should pull from? (owner/repo, or skip)"* → If provided, follow GitHub Issues Mode flow.
+   - **Human members:** *"Are any humans joining the team? (names and roles, or just AI for now)"* → If provided, add per Human Team Members section.
+   - **Copilot agent:** *"Want to include @copilot? It can pick up issues autonomously. (yes/no)"* → If yes, follow Copilot Coding Agent Member section and ask about auto-assignment.
+   - These are additive. **Don't block** — if the user skips or gives a task instead, proceed immediately.

--- a/.github/skills/coordinator-response-mode/SKILL.md
+++ b/.github/skills/coordinator-response-mode/SKILL.md
@@ -1,0 +1,97 @@
+---
+name: "coordinator-response-mode"
+description: "Selecting WHO handles work is the Routing table; selecting HOW they handle it (Direct, Lightweight, Standard, Full) is Response Mode. This skill contains the complete decision table, exemplar prompts for each mode, the Lightweight spawn template, and the upgrade rules. Squad coordinator loads this on demand once routing has identified the agent — to pick the right ceremony level for the task."
+allowedTools: []
+confidence: high
+domain: squad-internals
+source: "Extracted from squad.agent.md as part of the slimming effort (bradygaster/squad#1308). Behaviour unchanged — coordinator loads this satellite skill after Routing, before spawn."
+---
+
+> **Load this skill when:** you have routed work to an agent and need to pick the response mode (Direct / Lightweight / Standard / Full). The 1-line stub in `squad.agent.md` is for awareness; this skill is the full decision table + templates.
+
+## Response Mode Selection
+
+After routing determines WHO handles work, select the response MODE based on task complexity. **Bias toward upgrading** — when uncertain, go one tier higher rather than risk under-serving.
+
+| Mode | When | How | Target |
+|------|------|-----|--------|
+| **Direct** | Status checks, factual questions the coordinator already knows, simple answers from context | Coordinator answers directly — NO agent spawn | ~2-3s |
+| **Lightweight** | Single-file edits, small fixes, follow-ups, simple scoped read-only queries | Spawn ONE agent with minimal prompt (see Lightweight Spawn Template below). Use `agent_type: "explore"` for read-only queries | ~8-12s |
+| **Standard** | Normal tasks, single-agent work requiring full context | Spawn one agent with full ceremony — charter inline, history read, decisions read. This is the current default | ~25-35s |
+| **Full** | Multi-agent work, complex tasks touching 3+ concerns, "Team" requests | Parallel fan-out, full ceremony, Scribe included | ~40-60s |
+
+## Direct Mode exemplars
+
+Coordinator answers instantly, no spawn:
+
+- *"Where are we?"* → Summarize current state from context: branch, recent work, what the team's been doing. A user favorite — make it instant.
+- *"How many tests do we have?"* → Run a quick command, answer directly.
+- *"What branch are we on?"* → `git branch --show-current`, answer directly.
+- *"Who's on the team?"* → Answer from `team.md` already in context.
+- *"What did we decide about X?"* → Answer from `decisions.md` already in context.
+
+## Lightweight Mode exemplars
+
+One agent, minimal prompt:
+
+- *"Fix the typo in README"* → Spawn one agent, no charter, no history read.
+- *"Add a comment to line 42"* → Small scoped edit, minimal context needed.
+- *"What does this function do?"* → `agent_type: "explore"` (Haiku model, fast).
+- Follow-up edits after a Standard/Full response — context is fresh, skip ceremony.
+
+## Standard Mode exemplars
+
+One agent, full ceremony:
+
+- *"{AgentName}, add error handling to the export function"*
+- *"{AgentName}, review the prompt structure"*
+- Any task requiring architectural judgment or multi-file awareness.
+
+## Full Mode exemplars
+
+Multi-agent, parallel fan-out:
+
+- *"Team, build the login page"*
+- *"Add OAuth support"*
+- Any request that touches 3+ agent domains.
+
+## Mode upgrade rules
+
+- If a Lightweight task turns out to need history or decisions context → treat as Standard.
+- If uncertain between Direct and Lightweight → choose Lightweight.
+- If uncertain between Lightweight and Standard → choose Standard.
+- **Never downgrade mid-task.** If you started Standard, finish Standard.
+
+## Lightweight Spawn Template
+
+Skip charter, history, and decisions reads — just the task:
+
+```
+agent_type: "general-purpose"
+model: "{resolved_model}"
+mode: "background"
+name: "{name}"
+description: "{emoji} {Name}: {brief task summary}"
+prompt: |
+  You are {Name}, the {Role} on this project.
+  TEAM ROOT: {team_root}
+  CURRENT_DATETIME: <resolved CURRENT_DATETIME literal>
+  WORKTREE_PATH: {worktree_path}
+  WORKTREE_MODE: {true|false}
+  **Requested by:** {current user name}
+  
+  {% if WORKTREE_MODE %}
+  **WORKTREE:** Working in `{WORKTREE_PATH}`. All operations relative to this path. Do NOT switch branches.
+  {% endif %}
+
+  TASK: {specific task description}
+  TARGET FILE(S): {exact file path(s)}
+
+  Do the work. Keep it focused.
+  If you made a meaningful decision, persist it with `memory.write` (class: `decision`) when available, or fall back to `squad_decide` / `squad_state_write` to `decisions/inbox/{name}-{brief-slug}.md`. Do not run git notes, switch branches, or write mutable `.squad/` state by hand.
+
+  ⚠️ OUTPUT: Report outcomes in human terms. Never expose tool internals or SQL.
+  ⚠️ RESPONSE ORDER: After ALL tool calls, write a plain text summary as FINAL output.
+```
+
+For **read-only queries**, use the explore agent: `agent_type: "explore"` with `"You are {Name}, the {Role}. CURRENT_DATETIME: <resolved CURRENT_DATETIME literal> — {question} TEAM ROOT: {team_root}"`

--- a/.github/skills/coordinator-source-of-truth/SKILL.md
+++ b/.github/skills/coordinator-source-of-truth/SKILL.md
@@ -1,0 +1,45 @@
+---
+name: "coordinator-source-of-truth"
+description: "The complete file-by-file source-of-truth hierarchy for Squad: which files are authoritative, which are derived/append-only, who may write each one, who may read each one, and the precedence rules when they conflict. Squad coordinator loads this on demand when it needs to resolve a write conflict, decide where a piece of state belongs, or answer a 'who owns this file' question."
+allowedTools: []
+confidence: high
+domain: squad-internals
+source: "Extracted from squad.agent.md as part of the slimming effort (bradygaster/squad#1308). Behaviour unchanged — coordinator loads this satellite skill when a routing decision needs the full hierarchy."
+---
+
+> **Load this skill when:** the coordinator (or any agent) needs to resolve a "where does this state belong?" or "who is allowed to write this file?" question — e.g., when about to write `.squad/decisions.md`, when reviewing whether an agent broke the append-only rule, when answering a user question about Squad's file layout, or when adjudicating a conflict between two files. The short summary in `squad.agent.md` is for routing; this skill is the full reference.
+
+## State backend note
+
+Files below marked as **"Derived / append-only"** are **mutable state** — agents access them with runtime state tools (`squad_state_read`, `squad_state_write`, `squad_state_append`, `squad_state_delete`, `squad_state_list`). The runtime decides whether the configured backend stores them on disk, git-native state, or an external provider. Files marked as **"Authoritative"** are **static config** and always live on disk regardless of backend.
+
+## File hierarchy
+
+| File | Status | Who May Write | Who May Read |
+|------|--------|---------------|--------------|
+| `.github/agents/squad.agent.md` | **Authoritative governance.** All roles, handoffs, gates, and enforcement rules. | Repo maintainer (human) | Squad (Coordinator) |
+| `.squad/decisions.md` | **Authoritative decision ledger.** Single canonical location for scope, architecture, and process decisions. | Squad (Coordinator) — append only | All agents |
+| `.squad/team.md` | **Authoritative roster.** Current team composition. | Squad (Coordinator) | All agents |
+| `.squad/routing.md` | **Authoritative routing.** Work assignment rules. | Squad (Coordinator) | Squad (Coordinator) |
+| `.squad/ceremonies.md` | **Authoritative ceremony config.** Definitions, triggers, and participants for team ceremonies. | Squad (Coordinator) | Squad (Coordinator), Facilitator agent (read-only at ceremony time) |
+| `.squad/casting/policy.json` | **Authoritative casting config.** Universe allowlist and capacity. | Squad (Coordinator) | Squad (Coordinator) |
+| `.squad/casting/registry.json` | **Authoritative name registry.** Persistent agent-to-name mappings. | Squad (Coordinator) | Squad (Coordinator) |
+| `.squad/casting/history.json` | **Derived / append-only.** Universe usage history and assignment snapshots. | Squad (Coordinator) — append only | Squad (Coordinator) |
+| `.squad/agents/{name}/charter.md` | **Authoritative agent identity.** Per-agent role and boundaries. | Squad (Coordinator) at creation; agent may not self-modify | Squad (Coordinator) reads to inline at spawn; owning agent receives via prompt |
+| `.squad/agents/{name}/history.md` | **Derived / append-only.** Personal learnings. Never authoritative for enforcement. | Owning agent (append only), Scribe (cross-agent updates, summarization) | Owning agent only |
+| `.squad/agents/{name}/history-archive.md` | **Derived / append-only.** Archived history entries. Preserved for reference. | Scribe | Owning agent (read-only) |
+| `.squad/orchestration-log/` | **Derived / append-only.** Agent routing evidence. Never edited after write. | Scribe | All agents (read-only) |
+| `.squad/log/` | **Derived / append-only.** Session logs. Diagnostic archive. Never edited after write. | Scribe | All agents (read-only) |
+| `.squad/templates/` | **Reference.** Format guides for runtime files. Not authoritative for enforcement. | Squad (Coordinator) at init | Squad (Coordinator) |
+| `.squad/rai/policy.md` | **Authoritative RAI policy.** Check categories, terminology standards, and opt-out rules. | Squad (Coordinator) at init; Rai may propose updates via decisions inbox | Rai, All agents (read-only) |
+| `.squad/rai/audit-trail.md` | **Derived / append-only.** RAI review evidence log. Redacted — never contains raw secrets or harmful content. | Rai (append only) | Rai, Squad (Coordinator) |
+| `.squad/fact-checker/policy.md` | **Authoritative verification + Devil's Advocate policy.** Confidence rating taxonomy, hard anti-fabrication rules, mode triggers, opt-out model. | Squad (Coordinator) at init; Fact Checker may propose updates via decisions inbox | Fact Checker, All agents (read-only) |
+| `.squad/fact-checker/audit-trail.md` | **Derived / append-only.** Verification verdicts + DA brief evidence log. Succinct — verdict + citation, never raw source material. | Fact Checker (append only) | Fact Checker, Squad (Coordinator) |
+| `.squad/plugins/marketplaces.json` | **Authoritative plugin config.** Registered marketplace sources. | Squad CLI (`squad plugin marketplace`) | Squad (Coordinator) |
+
+## Rules
+
+1. **If `squad.agent.md` and any other file conflict, `squad.agent.md` wins.** It is the only file with hard governance authority.
+2. **Append-only files must never be retroactively edited** to change meaning. They are diagnostic and audit-trail material. Corrections go in a new entry that references the prior one.
+3. **Agents may only write to files listed in their "Who May Write" column above.** Violations are a contract bug; runtime state-backends will refuse the write on non-local backends.
+4. **Non-coordinator agents may propose decisions** in their responses, but only Squad (Coordinator) records accepted decisions in `.squad/decisions.md`.

--- a/.github/skills/cross-squad-communication/SKILL.md
+++ b/.github/skills/cross-squad-communication/SKILL.md
@@ -1,0 +1,399 @@
+---
+name: "cross-squad-communication"
+description: "Protocol for sending queries, delegating tasks, and sharing context between independent Squad instances across different repositories"
+domain: "multi-repo coordination"
+confidence: "medium"
+source: "Ported from tamirdresher/squad-skills (plugins/cross-squad-communication). Companion to the registry-aware cross-squad skill — this one teaches the actual communication protocols once a peer is discovered. Pattern 0 (synchronous CLI) is the only end-to-end-validated pattern; Patterns 1, 2, 3 are documented from design but require live validation against your own setup before relying on them in production. See the Validation Status section at the bottom of this skill."
+---
+
+## Context
+
+When multiple repositories each have their own Squad (AI team), they need to exchange information: knowledge queries, PR reviews, task delegation, and dependency analysis. Each squad has its own agents, MCP tools, and issue tracker — there is no shared runtime.
+
+> **Companion skill — read first:** `cross-squad/SKILL.md` covers **discovery** of peer squads via `squad registry add/list/remove`. This skill picks up after a peer is known and covers the **communication protocols** themselves — the four numbered patterns below: Pattern 0 (synchronous CLI), Pattern 1 (read-only knowledge query), Pattern 2 (git-based async), and Pattern 3 (GitHub-issue-based delegation). A separate non-numbered appendix (Cross-Repo Dependency Scan) is provided as a related analysis tool, not a communication pattern. The two skills are designed to be used together.
+
+**When this skill applies:**
+- A squad agent needs information from another squad-enabled repo
+- A task needs to be delegated to another squad
+- Cross-repo dependency analysis is needed
+- PR review requests span repo boundaries
+
+**Key constraint:** Each squad has its own runtime, MCP tools, and issue tracker. Cross-squad communication can be **synchronous** (via CLI session targeting the other repo) or **asynchronous** (file-based or issue-based). The coordinator decides which approach fits.
+
+---
+
+## Patterns
+
+### Decision Tree: Choosing the Right Pattern
+
+```
+Is the target repo cloned locally?
+├─ NO → Use Pattern 3 (Issue-Based) or Pattern 2 (Git-Based Async)
+└─ YES
+    ├─ Is this a quick query / knowledge lookup?
+    │   └─ YES → Use Pattern 0 (Synchronous CLI) — fastest
+    ├─ Does the work need to persist as artifacts?
+    │   └─ YES → Use Pattern 2 (Git-Based Async)
+    ├─ Is it a long-running analysis or multi-cycle task?
+    │   └─ YES → Use Pattern 2 (Git-Based Async)
+    └─ Is the target squad's Ralph running?
+        ├─ YES → Pattern 2 or 3 (async processing available)
+        └─ NO → Pattern 0 (Synchronous CLI) or Pattern 1 (Read-Only)
+```
+
+---
+
+## Universal rule: every `copilot` spawn into a peer squad MUST pass `--agent squad`
+
+The `copilot` CLI accepts `--agent <name>` to select a custom agent (see `copilot --help`). Squad installs ship `.github/agents/squad.agent.md`, which is loaded **only when `--agent squad` is specified**. Without it the spawned session runs as a generic Copilot CLI session that does NOT load the peer's `team.md`, routing, MCP tools, casting, or coordinator behaviour — so you get an off-the-shelf model answering, not the peer's Squad. **Every command example in this skill that spawns `copilot` into a peer repo includes `--agent squad`; do not strip it.**
+
+This rule also applies anywhere else you spawn `copilot` into a Squad-initialised repo (not just cross-squad protocols) — e.g., `squad init`'s post-init tip and any automation that invokes the CLI on a squadified folder. The only case where you may omit `--agent` is when resuming an existing session (`copilot --resume <sessionId>`) — the resumed session preserves its original agent context.
+
+---
+
+### Pattern 0: Synchronous CLI Session (Fastest for Interactive Queries)
+
+For quick knowledge queries, decision lookups, or short analyses — spawn a Copilot CLI session with the working directory set to the target squad's repo. This lets you send a prompt and get a response within the same session, using the target repo's full context.
+
+This is the same technique used by `ralph-watch.ps1`: write the prompt to a temp file, then invoke the CLI with that file as input. The key insight is that setting the working directory to the target repo gives the CLI session access to that squad's `.squad/` metadata, codebase, and conventions.
+
+**Protocol:**
+1. Write prompt to a temp file (avoids argument-splitting issues, as learned in `ralph-watch.ps1`)
+2. Read the file into a string and invoke `copilot -p <text>` with `-C <directory>` set to the target repo (`-p` takes prompt text, NOT a file path) AND `--agent squad` so the spawned session uses the peer squad's coordinator (without `--agent` you get a generic Copilot CLI session that doesn't load the peer's `team.md`, MCP tools, or skills)
+3. Receive response in the same session
+
+**Invocation:**
+```powershell
+# Spawn a Copilot CLI session targeting another squad's repo
+$targetRepo = "C:\repos\platform-squad-repo"
+$promptFile = New-TemporaryFile
+@"
+You are working in a Squad-enabled repository.
+Read .squad/team.md and .squad/decisions.md first.
+
+[CROSS-SQUAD REQUEST]
+From: research-squad
+Request Type: knowledge_query
+Query: What is the current architecture of the platform? What services does it expose?
+Response Format: Brief structured summary
+"@ | Out-File $promptFile -Encoding utf8
+
+# Option A: copilot with prompt file (read file into string; -p takes text, not a path)
+# --agent squad is REQUIRED: the target is another Squad install, so the spawned
+# session must use that squad's coordinator (not a generic Copilot CLI session).
+copilot -C $targetRepo --agent squad -p (Get-Content $promptFile -Raw) --allow-all-tools
+
+# Option B: Start-Process for non-blocking (ralph-watch.ps1 style)
+Start-Process pwsh -ArgumentList "-NoProfile -Command `"copilot -C '$targetRepo' --agent squad -p (Get-Content '$promptFile' -Raw) --allow-all-tools`"" -Wait
+
+# Option C: Pipe directly (stdin is the prompt text)
+"What is the platform architecture?" | copilot -C $targetRepo --agent squad --allow-all-tools
+```
+
+**When to use synchronous vs async:**
+
+| Scenario | Pattern | Why |
+|----------|---------|-----|
+| Quick knowledge query | Synchronous CLI (Pattern 0) | Fast answer, no overhead |
+| "What did you decide about X?" | Synchronous CLI (Pattern 0) | Read decisions.md via the target squad's context |
+| PR review request | Either (Pattern 0 or 2/3) | Sync for quick feedback, async for thorough review |
+| Task delegation (do work in their repo) | Async (Pattern 2 or 3) | Work needs to persist beyond the session |
+| Long-running analysis | Async (Pattern 2) | May take multiple cycles |
+| Target repo not locally cloned | Async (Pattern 3) | Can't set working directory to a remote repo |
+
+**The coordinator decides which pattern to use based on:**
+1. Is the target repo cloned locally? → If yes, sync CLI is available
+2. Is this a quick query or a long task? → Quick = sync, long = async
+3. Does the work need to persist? → If yes, use async (creates artifacts)
+4. Is the target squad's Ralph running? → Needed for async processing
+
+**Requirements:**
+- Target repo must be cloned locally (for `copilot -C <directory>`)
+- Target repo must be Squad-initialised (`.squad/config.json` + `.github/agents/squad.agent.md` present), so `--agent squad` resolves to the peer's coordinator
+- Prompt file avoids argument-splitting bugs (see `ralph-watch.ps1` lines 2166-2184)
+
+**Response quality:** ⭐⭐⭐⭐⭐ — the CLI session has full context of the target repo, including code, squad metadata, and MCP tools.
+
+### Liveness Protocol for Pattern 0
+
+The synchronous CLI session requires monitoring to avoid false timeouts. With 7+ MCP servers initializing and `.squad/` metadata being read, startup can take 30-60 seconds. A hard timeout kills valid sessions before they complete. Instead, monitor the agency session's activity log directory.
+
+**Health Check Approach:**
+
+Instead of a fixed wall-clock timeout, monitor the agency session log directory for activity:
+
+```powershell
+# The Copilot CLI creates a session log directory at ~/.copilot/logs/.
+# Older `agency` runtimes wrote to ~/.agency/logs/; fall back to that
+# location if the new path doesn't exist yet on the user's machine.
+# e.g., ~/.copilot/logs/session_20260325_071211_57824
+$copilotLogs = "$env:USERPROFILE\.copilot\logs"
+$agencyLogs = "$env:USERPROFILE\.agency\logs"
+$logRoot = if (Test-Path $copilotLogs) { $copilotLogs } elseif (Test-Path $agencyLogs) { $agencyLogs } else { $null }
+if ($logRoot) {
+    $logDir = Get-ChildItem $logRoot -Directory | Sort-Object LastWriteTime -Descending | Select-Object -First 1
+}
+$lastSize = 0
+$stallCount = 0
+
+while ($proc -and -not $proc.HasExited) {
+    Start-Sleep -Seconds 15
+    $currentSize = (Get-ChildItem $logDir -Recurse -File | Measure-Object -Property Length -Sum).Sum
+    
+    if ($currentSize -eq $lastSize) {
+        $stallCount++
+        if ($stallCount -ge 4) { # 60s with no progress
+            Write-Warning "Session stalled — no log activity for 60s"
+            break
+        }
+    } else {
+        $stallCount = 0
+        $lastSize = $currentSize
+    }
+}
+```
+
+**Progress Indicators (What Counts as "Alive"):**
+
+- New files appearing in the session log directory (e.g., `transcript.log`, `mcp-server-logs/`)
+- Log file size increasing (indicates active processing)
+- New or modified `.squad/` files in the target repo (e.g., `decisions/inbox.md`, `identity/history.md`)
+- Process still running and consuming non-idle CPU time
+
+**Stall Detection (When to Intervene):**
+
+- **No log activity for 60s** → Issue a warning; session may be slow but not hung
+- **No log activity for 120s** → Likely stuck; consider terminating and checking logs
+- **Process exited with non-zero exit code** → Failed; examine `transcript.log` and `stderr` for errors
+- **MCP server connection timeout** → Session blocked waiting for an MCP server response
+
+**Recovery Actions When Stalled:**
+
+1. **Check for user input waiting:** Inspect logs for prompts or dialogs (shouldn't happen with `--autopilot`)
+2. **Check MCP server health:** Review `mcp-server-logs/` for connection errors or timeouts
+3. **Retry with `--disable-builtin-mcps` flag:** For lightweight queries that don't require MCP tools
+   ```powershell
+   # Retry without MCP servers — faster startup, limited capability
+   copilot -C $targetRepo --agent squad -p (Get-Content $promptFile -Raw) --disable-builtin-mcps --allow-all-tools
+   ```
+4. **Increase timeout threshold:** If MCP server initialization is consistently slow (>90s), raise threshold before declaring stall
+
+---
+
+### Pattern 1: Read-Only Knowledge Query (No CLI Needed)
+
+For questions about another squad's architecture, decisions, or current state — read their `.squad/` metadata directly.
+
+**Protocol:**
+1. Read target repo's `.squad/team.md` → get stack, members, issue source
+2. Read `.squad/decisions.md` → get architectural decisions
+3. Read `.squad/routing.md` → understand who handles what
+4. Read `.squad/identity/now.md` → get current focus
+5. Scan code structure if needed (csproj files, directory layout)
+
+**Requirements:**
+- Target repo must be cloned locally or accessible via git
+- No authentication needed beyond git read access
+
+**Example:**
+```powershell
+# Query another squad's architecture
+$targetRepo = "C:\repos\platform-squad-repo"
+Get-Content "$targetRepo\.squad\team.md"
+Get-Content "$targetRepo\.squad\decisions.md"
+Get-Content "$targetRepo\.squad\identity\now.md"
+```
+
+**Response quality:** ⭐⭐⭐⭐ — excellent for structural/architectural questions.
+
+---
+
+### Pattern 2: Async Task Request (Git-Based)
+
+For work that needs the target squad to execute (PR reviews, issue analysis, code changes).
+
+**Protocol:**
+1. Create request file in YOUR repo: `.squad/cross-squad/requests/{timestamp}-{target}-{id}.yaml`
+2. Commit and push
+3. Target squad's Ralph detects on next cycle
+4. Target squad processes and writes response to their `.squad/cross-squad/responses/`
+5. Your Ralph picks up the response
+
+**Request File Format:**
+```yaml
+id: req-2026-06-13-001
+source_squad: research-squad
+source_repo: your-org/research-squad-repo
+target_squad: platform-squad
+target_repo: your-org/platform-squad-repo
+request_type: knowledge_query | pr_review | task_delegation | dependency_check
+priority: high | normal | low
+created_at: 2026-06-13T10:00:00Z
+query: "What is the current architecture of the platform?"
+routing_hint: "lead"  # optional — which agent should handle this
+status: pending
+```
+
+**Response File Format:**
+```yaml
+id: req-2026-06-13-001
+responding_squad: platform-squad
+responding_agent: lead
+responded_at: 2026-06-13T10:15:00Z
+status: completed | partial | rejected
+response: |
+  The platform architecture consists of...
+artifacts: []  # optional file paths
+```
+
+---
+
+### Pattern 3: Issue-Based Delegation (For GitHub-Hosted Repos)
+
+For repos on GitHub, use issues with labels as the message bus.
+
+**Protocol:**
+1. Create issue in target repo with label `squad:cross-squad`
+2. Include source squad identifier and routing hint in issue body
+3. Target squad's Ralph picks up and routes to appropriate agent
+4. Response posted as issue comment
+5. Issue closed when complete
+
+**Example:**
+```bash
+gh issue create \
+  --repo your-org/platform-squad-repo \
+  --title "[Cross-Squad] Architecture query from research-squad" \
+  --body "Source: research-squad\nQuery: What services does the platform expose?\nRouting: lead" \
+  --label "squad:cross-squad"
+```
+
+**Limitation:** Only works for repos on GitHub. Other platforms (Azure DevOps, GitLab, etc.) need different approach.
+
+---
+
+### Appendix: Cross-Repo Dependency Scan (Related Analysis Tool — Not a Communication Pattern)
+
+> This section is intentionally listed as an appendix rather than "Pattern 4" — it is a one-off analysis utility for discovering how two repos relate, not a protocol the coordinator picks from the decision tree above. The four numbered communication patterns are 0–3.
+
+For discovering how two repos relate to each other.
+
+**Protocol:**
+1. Search both repos for mutual references:
+   ```powershell
+   Select-String -Path (Get-ChildItem $repoA -Recurse -Include "*.md","*.cs","*.json","*.csproj") `
+     -Pattern $repoB_name
+   Select-String -Path (Get-ChildItem $repoB -Recurse -Include "*.md","*.cs","*.json","*.csproj") `
+     -Pattern $repoA_name
+   ```
+2. Check shared NuGet packages / npm packages
+3. Check shared ADO project or GitHub org
+4. Document relationship type: code dependency, operational coupling, shared infra
+
+---
+
+## Discovery Protocol
+
+Before sending any cross-squad request, verify the target:
+
+```
+1. Does .squad/team.md exist?           → Squad is installed
+2. What is the issue_source?            → GitHub Issues | ADO | Planner
+3. What agents are active?              → Check member status column
+4. What is the routing table?           → Read routing.md
+5. What is the current focus?           → Read identity/now.md
+6. Is Ralph running?                    → Check for recent commits by Ralph
+```
+
+If `.squad/team.md` doesn't exist, the repo is not squad-enabled. Fall back to standard human communication.
+
+---
+
+## Platform Compatibility Matrix
+
+| Source Issue Tracker | Target Issue Tracker | Mechanism |
+|---------------------|---------------------|-----------|
+| GitHub Issues | GitHub Issues | Issue-based (Pattern 3) |
+| GitHub Issues | ADO Work Items | Git-based (Pattern 2) |
+| GitHub Issues | Planner | Git-based (Pattern 2) |
+| ADO Work Items | GitHub Issues | Issue-based (Pattern 3) via `gh` CLI |
+| ADO Work Items | ADO Work Items | ADO cross-project work items |
+| Any | Any | Git-based (Pattern 2) — universal fallback |
+
+---
+
+## Examples
+
+### Example 1: research-squad queries platform-squad architecture
+
+```powershell
+# Step 1: Read metadata (Pattern 1)
+$target = "C:\repos\platform-squad-repo"
+$team = Get-Content "$target\.squad\team.md" -Raw
+$decisions = Get-Content "$target\.squad\decisions.md" -Raw
+
+# Step 2: Extract answer from metadata
+# team.md reveals tech stack and member roles
+# decisions.md reveals architectural choices
+
+# Step 3: If deeper analysis needed, create async request (Pattern 2)
+```
+
+### Example 2: Request PR review from another squad
+
+```yaml
+# .squad/cross-squad/requests/2026-06-13-platform-squad-pr-review.yaml
+id: pr-review-001
+source_squad: research-squad
+target_squad: platform-squad
+request_type: pr_review
+priority: normal
+query: "Review PR #54 — package version fix. Check for correctness."
+routing_hint: "lead"
+status: pending
+```
+
+---
+
+## Anti-Patterns
+
+### ⚠️ Know when synchronous CLI is NOT the right choice
+```powershell
+# WRONG — don't use sync CLI for long-running tasks that need artifacts
+copilot -C $targetRepo --agent squad -p (Get-Content $promptFile -Raw) --allow-all-tools
+# If the task creates files, PRs, or takes multiple cycles → use async (Pattern 2 or 3)
+
+# WRONG — don't use sync CLI when the target repo isn't cloned locally
+copilot -C "C:\not\cloned\yet" --agent squad --allow-all-tools
+# If the repo isn't available locally → use issue-based delegation (Pattern 3)
+```
+Synchronous CLI sessions (Pattern 0) are valid for quick queries and knowledge lookups. Use async patterns for work that needs to persist or where the target repo isn't available locally.
+
+### ❌ Don't assume shared MCP tools
+Each squad has its own MCP server instances. You cannot invoke another squad's ADO tools or GitHub tools from your session.
+
+### ❌ Don't skip the discovery step
+Always read `team.md` first. The target squad may use a different issue tracker, have different agents, or be in a different state than expected.
+
+### ❌ Don't send requests to squads without Ralph
+If the target squad doesn't have Ralph (Work Monitor) running, async requests will never be processed. Check for recent Ralph activity first.
+
+### ❌ Don't mix up repo platforms
+Different repos may use GitHub Issues vs Azure DevOps Work Items vs Jira. Check `team.md` / repository metadata for the right tooling before sending requests.
+
+---
+
+## Validation Status
+
+This skill was originally drafted against two prototype squad setups (a GitHub-hosted platform squad with ~10 agents and an Azure DevOps-hosted automation squad with ~4 agents). The protocols are platform-agnostic; the examples in this document use generic names so you can substitute your own repos. Patterns 0 and 1 have been exercised end-to-end in those prototypes; Patterns 2 and 3 are documented from design but have not been end-to-end-validated against a live target repo.
+
+| Scenario | Result |
+|----------|--------|
+| Knowledge query (read-only) | ✅ Works via Pattern 1 |
+| Step handler discovery | ✅ Works via file scan |
+| PR review (basic) | ⚠️ Partial — git log only, no API |
+| Backlog enumeration | ⚠️ Partial — depends on issue platform |
+| Dependency analysis | ✅ Works via cross-reference scan |
+| CLI invocation (sync) + Liveness Protocol | ✅ Works — session launches successfully; log monitoring prevents false timeouts |
+
+**Confidence: MEDIUM** — Synchronous CLI pattern (Pattern 0) validated end-to-end. Liveness protocol provides operational robustness against slow MCP initialization. Git-based async (Pattern 2) and issue-based (Pattern 3) untested end-to-end. Production readiness requires Ralph integration on both sides.

--- a/.github/skills/cross-squad/SKILL.md
+++ b/.github/skills/cross-squad/SKILL.md
@@ -1,0 +1,174 @@
+---
+name: "cross-squad"
+description: "Coordinating work across multiple Squad instances — discovery, delegation, and disambiguation when the user says 'squad' (the product) vs casual English 'group of agents'."
+domain: "orchestration"
+confidence: "medium"
+source: "manual"
+triggers:
+  - "spawn N squads"
+  - "spawn a squad"
+  - "another squad"
+  - "two squads of"
+  - "second squad"
+  - "fan out to squads"
+  - "delegate to a squad"
+  - "set up squads for"
+  - "create a squad to review"
+  - "ask the other squad"
+tools:
+  - name: "squad-discover"
+    description: "List known squads and their capabilities"
+    when: "When you need to find which squad can handle a task"
+  - name: "squad-delegate"
+    description: "Create work in another squad's repository"
+    when: "When a task belongs to another squad's domain"
+---
+
+## Context
+
+> **Read this FIRST any time the user says "squad" as a thing to spawn, delegate to, address, or fan out to** — e.g., *"spawn two squads of designers and devs"*, *"ask the other squad"*, *"delegate to a squad"*. In Squad-PRODUCT vocabulary, "squad" is a **peer** (an independent installation with its own `.squad/`, `team.md`, MCP server, and agents) — NOT a generic English synonym for "team" or "group". Do not fan out raw `task` agents inside your own coordinator context when the user means "another squad". Use the discovery and communication patterns below (and the companion `cross-squad-communication` skill for the actual protocols).
+
+When an organization runs multiple Squad instances (e.g., platform-squad, frontend-squad, data-squad), those squads need to discover each other, share context, and hand off work across repository boundaries. This skill teaches agents how to coordinate across squads without creating tight coupling.
+
+> **Companion skill — for protocol details:** `cross-squad-communication/SKILL.md` covers the four communication patterns (synchronous CLI, read-only knowledge query, git-based async, and GitHub-issue-based delegation) once a peer squad is discovered via the registry below. This skill answers "who?" — the companion answers "how?".
+
+Cross-squad orchestration applies when:
+- A task requires capabilities owned by another squad
+- An architectural decision affects multiple squads
+- A feature spans multiple repositories with different squads
+- A squad needs to request infrastructure, tooling, or support from another squad
+
+## Disambiguation: "squad" vs ad-hoc agents
+
+When the user uses the word **"squad" / "squads"** or asks to **"spawn a team"**, the coordinator MUST treat it as a literal reference to a Squad install (a `.squad/` directory with its own roster, casting, and coordinator) — NOT as a casual synonym for "a group of sub-agents".
+
+### Default behaviour (apply unless explicitly told otherwise)
+
+| User says | Coordinator does |
+|---|---|
+| *"spawn two squads of X and Y"* / *"set up squads for X, Y, Z"* | Bootstrap N **real** Squad installs — separate folder + `git init` + `squad init` per squad — then use the cross-squad patterns below (`.squad/manifest.json`, `squad registry add`, `squad delegate`) and the protocols in the `cross-squad-communication` skill |
+| *"ask the other squad about X"* / *"delegate to the data squad"* | Discover the peer via `squad registry list` (or by reading a known `.squad/manifest.json`), then use `cross-squad-communication` Pattern 0 / 1 / 2 / 3 — never re-implement the protocol with `task` |
+| *"spawn a few agents to do X"* / *"have some agents review X"* / *"in parallel, get sub-agents to..."* | Ad-hoc `task` fan-out is fine — no `.squad/` bootstrap needed. This is the only path where raw `task` is appropriate when the user mentioned a multi-agent activity |
+
+### Ambiguous? `ask_user`, never silently downgrade
+
+If the request **could** be either interpretation AND bootstrapping real squads is non-trivial (more than one or two `squad init` runs), you MUST use the `ask_user` tool with a 2-choice prompt before proceeding:
+
+```
+question: "Should I create separate Squad installs or just dispatch ad-hoc agents?"
+choices:
+  - "Real squads — separate .squad/ per squad (heavier, persistent, can be re-engaged later)"
+  - "Ad-hoc agents — one-shot `task` dispatch (lighter, ephemeral, no .squad/ created)"
+```
+
+The cost of asking is one `ask_user`. The cost of getting it wrong is the user has to redo the work. **Never silently pick the cheaper option just because it feels disproportionate for the task size — surface the trade-off and let the user pick.**
+
+### Anti-patterns (every one of these is a real failure mode observed in production)
+
+- **Calling `task` sub-agents "squad-alpha" / "squad-beta"** and treating them as squads. Naming something a squad doesn't make it one — a squad has its own `.squad/`, `team.md`, MCP server, and coordinator. If those aren't there, it's not a squad.
+- **Matching a prior session's ad-hoc pattern without re-checking current intent.** If you see existing `reviews/squad-alpha/` folders from a previous run, that's a hint, NOT a contract — the user may have meant something different this time. Re-evaluate from scratch.
+- **Silently choosing the cheaper interpretation because "bootstrapping two real squads for a 30-line app feels disproportionate".** That's a judgment call for the USER to make, not the coordinator. Use `ask_user`.
+- **Loading the `cross-squad` skill, reading it, then doing `task` fan-out anyway** because the eager-execution / parallel-fan-out doctrine pulled you back. The disambiguation rule on this page OVERRIDES the generic fan-out doctrine when "squad" was the trigger.
+
+## Patterns
+
+### Discovery via Manifest
+Each squad publishes a `.squad/manifest.json` declaring its name, capabilities, and contact information. Squads discover each other through two mechanisms:
+
+1. **`.squad/squad-registry.json`** — **discovery-only.** Peer squads are findable via `squad discover` and addressable via `squad delegate`, but their skills/decisions/wisdom are NOT loaded into your coordinator. Manage with `squad registry add/list/remove`.
+2. **`.squad/upstream.json`** — **discovery + inheritance.** Squads listed here are also discoverable, AND your coordinator inherits their skills/decisions/wisdom/routing at session start. Manage with `squad upstream add/list/remove/sync`.
+
+Both forms read the peer's manifest via the same code path. The `path` field is the **repository root** (e.g. `../friend-repo`), and Squad appends `.squad/manifest.json` internally. Pointing at the `.squad/` directory works too — Squad accepts both forms (`readManifest` strips a trailing `.squad` if present).
+
+```json
+{
+  "name": "platform-squad",
+  "version": "1.0.0",
+  "description": "Platform infrastructure team",
+  "capabilities": ["kubernetes", "helm", "monitoring", "ci-cd"],
+  "contact": {
+    "repo": "org/platform",
+    "labels": ["squad:platform"]
+  },
+  "accepts": ["issues", "prs"],
+  "skills": ["helm-developer", "operator-developer", "pipeline-engineer"]
+}
+```
+
+### Context Sharing
+When delegating work, share only what the target squad needs:
+- **Capability list**: What this squad can do (from manifest)
+- **Relevant decisions**: Only decisions that affect the target squad
+- **Handoff context**: A concise description of why this work is being delegated
+
+Do NOT share:
+- Internal team state (casting history, session logs)
+- Full decision archives (send only relevant excerpts)
+- Authentication credentials or secrets
+
+### Work Handoff Protocol
+1. **Check manifest**: Verify the target squad accepts the work type (issues, PRs)
+2. **Create issue**: Use `gh issue create` in the target repo with:
+   - Title: `[cross-squad] <description>`
+   - Label: `squad:cross-squad` (or the squad's configured label)
+   - Body: Context, acceptance criteria, and link back to originating issue
+3. **Track**: Record the cross-squad issue URL in the originating squad's orchestration log
+4. **Poll**: Periodically check if the delegated issue is closed/completed
+
+### Feedback Loop
+Track delegated work completion:
+- Poll target issue status via `gh issue view`
+- Update originating issue with status changes
+- Close the feedback loop when delegated work merges
+
+## Examples
+
+### Registering a peer squad (no inheritance)
+```bash
+# Friend's repo is checked out at ../friend-platform/
+squad registry add platform-squad ../friend-platform
+
+# Verify
+squad registry list
+squad discover
+```
+
+### Discovering squads
+```bash
+# List all squads discoverable from registry + upstreams
+squad discover
+
+# Output:
+#   platform-squad  →  org/platform  (kubernetes, helm, monitoring)
+#   frontend-squad  →  org/frontend  (react, nextjs, storybook)
+#   data-squad      →  org/data      (spark, airflow, dbt)
+```
+
+### Delegating work
+```bash
+# Delegate a task to the platform squad
+squad delegate platform-squad "Add Prometheus metrics endpoint for the auth service"
+
+# Creates issue in org/platform with cross-squad label and context
+```
+
+### Manifest in squad.config.ts
+```typescript
+export default defineSquad({
+  manifest: {
+    name: 'platform-squad',
+    capabilities: ['kubernetes', 'helm'],
+    contact: { repo: 'org/platform', labels: ['squad:platform'] },
+    accepts: ['issues', 'prs'],
+    skills: ['helm-developer', 'operator-developer'],
+  },
+});
+```
+
+## Anti-Patterns
+- **Direct file writes across repos** — Never modify another squad's `.squad/` directory. Use issues and PRs as the communication protocol.
+- **Tight coupling** — Don't depend on another squad's internal structure. Use the manifest as the public API contract.
+- **Unbounded delegation** — Always include acceptance criteria and a timeout. Don't create open-ended requests.
+- **Skipping discovery** — Don't hardcode squad locations. Use manifests and the discovery protocol.
+- **Sharing secrets** — Never include credentials, tokens, or internal URLs in cross-squad issues.
+- **Circular delegation** — Track delegation chains. If squad A delegates to B which delegates back to A, something is wrong.

--- a/.github/skills/error-recovery/SKILL.md
+++ b/.github/skills/error-recovery/SKILL.md
@@ -1,0 +1,99 @@
+---
+name: "error-recovery"
+description: "Standard recovery patterns for all squad agents. When something fails, adapt — don't just report the failure."
+domain: "reliability, agent-coordination"
+confidence: "high"
+license: MIT
+---
+
+# Error Recovery Patterns
+
+Standard recovery patterns for all squad agents. When something fails, **adapt** — don't just report the failure.
+
+---
+
+## 1. Retry with Backoff
+
+**When:** Transient failures — API timeouts, rate limits, network errors, temporary service unavailability.
+
+**Pattern:**
+1. Wait briefly, then retry (start at 2s, double each attempt)
+2. Maximum 3 retries before escalating
+3. Log each attempt with the error received
+
+**Example:** API call returns 429 Too Many Requests → wait 2s → retry → wait 4s → retry → wait 8s → retry → escalate if still failing.
+
+---
+
+## 2. Fallback Alternatives
+
+**When:** Primary tool or approach fails and an alternative exists.
+
+**Pattern:**
+1. Attempt primary approach
+2. On failure, identify alternative tool/method
+3. Try the alternative with the same intent
+4. Document which alternative was used and why
+
+**Example:** Primary CLI tool fails → fall back to direct API call for the same operation.
+
+---
+
+## 3. Diagnose-and-Fix
+
+**When:** Build failures, test failures, linting errors — structured errors with actionable output.
+
+**Pattern:**
+1. Read the full error output carefully
+2. Identify the root cause from error messages
+3. Attempt a targeted fix
+4. Re-run to verify the fix
+5. Maximum 3 fix-retry cycles before escalating
+
+**Example:** Build fails with a type error → check for missing import → add it → rebuild.
+
+---
+
+## 4. Escalate with Context
+
+**When:** Recovery attempts have been exhausted, or the failure requires human judgment.
+
+**Pattern:**
+1. Summarize what was attempted and what failed
+2. Include the exact error messages
+3. State what you believe the root cause is
+4. Suggest next steps or who might be able to help
+5. Hand off to the coordinator or the appropriate specialist
+
+**Example:** After 3 failed build attempts → "Build fails on line 42 with null reference. Tried X, Y, Z. Likely a design issue in the Foo module. Recommend the code owner review."
+
+---
+
+## 5. Graceful Degradation
+
+**When:** A non-critical step fails but the overall task can still deliver value.
+
+**Pattern:**
+1. Determine if the failed step is critical to the task outcome
+2. If non-critical, log the failure and continue
+3. Deliver partial results with a clear note of what was skipped
+4. Offer to retry the skipped step separately
+
+**Example:** Generating a report with 5 sections — section 3 data source is unavailable → produce the report with 4 sections, note that section 3 was skipped and why.
+
+---
+
+## Applying These Patterns
+
+Each agent should reference these patterns in their charter's `## Error Recovery` section, tailored to their domain. The charter should list the agent's most common failure modes and map each to the appropriate pattern above.
+
+**Selection guide:**
+
+| Failure Type | Primary Pattern | Fallback Pattern |
+|---|---|---|
+| Network/API transient | Retry with Backoff | Escalate with Context |
+| Tool/dependency missing | Fallback Alternatives | Escalate with Context |
+| Build/test error | Diagnose-and-Fix | Escalate with Context |
+| Auth/permissions | Retry with Backoff | Escalate with Context |
+| Non-critical data missing | Graceful Degradation | — |
+| Unknown/novel error | Escalate with Context | — |

--- a/.github/skills/git-workflow/SKILL.md
+++ b/.github/skills/git-workflow/SKILL.md
@@ -1,0 +1,204 @@
+---
+name: "git-workflow"
+description: "Squad branching model: dev-first workflow with insiders preview channel"
+domain: "version-control"
+confidence: "high"
+source: "team-decision"
+---
+
+## Context
+
+Squad uses a three-branch model. **All feature work starts from `dev`, not `main`.**
+
+| Branch | Purpose | Publishes |
+|--------|---------|-----------|
+| `main` | Released, tagged, in-npm code only | `npm publish` on tag |
+| `dev` | Integration branch — all feature work lands here | `npm publish --tag preview` on merge |
+| `insiders` | Early-access channel — synced from dev | `npm publish --tag insiders` on sync |
+
+## Branch Naming Convention
+
+Issue branches MUST use: `squad/{issue-number}-{kebab-case-slug}`
+
+Examples:
+- `squad/195-fix-version-stamp-bug`
+- `squad/42-add-profile-api`
+
+## Workflow for Issue Work
+
+1. **Branch from dev:**
+   ```bash
+   git checkout dev
+   git pull origin dev
+   git checkout -b squad/{issue-number}-{slug}
+   ```
+
+2. **Mark issue in-progress:**
+   ```bash
+   gh issue edit {number} --add-label "status:in-progress"
+   ```
+
+3. **Create draft PR targeting dev:**
+   ```bash
+   gh pr create --base dev --title "{description}" --body "Closes #{issue-number}" --draft
+   ```
+
+4. **Do the work.** Make changes, write tests, commit with issue reference.
+
+5. **Push and mark ready:**
+   ```bash
+   git push -u origin squad/{issue-number}-{slug}
+   gh pr ready
+   ```
+
+6. **After merge to dev:**
+   ```bash
+   git checkout dev
+   git pull origin dev
+   git branch -d squad/{issue-number}-{slug}
+   git push origin --delete squad/{issue-number}-{slug}
+   ```
+
+## Parallel Multi-Issue Work (Worktrees)
+
+When the coordinator routes multiple issues simultaneously (e.g., "fix bugs X, Y, and Z"), use `git worktree` to give each agent an isolated working directory. No filesystem collisions, no branch-switching overhead.
+
+### When to Use Worktrees vs Sequential
+
+| Scenario | Strategy |
+|----------|----------|
+| Single issue | Standard workflow above — no worktree needed |
+| 2+ simultaneous issues in same repo | Worktrees — one per issue |
+| Work spanning multiple repos | Separate clones as siblings (see Multi-Repo below) |
+
+### Setup
+
+From the main clone (must be on dev or any branch):
+
+```bash
+# Ensure dev is current
+git fetch origin dev
+
+# Create a worktree per issue — siblings to the main clone
+git worktree add ../squad-195 -b squad/195-fix-stamp-bug origin/dev
+git worktree add ../squad-193 -b squad/193-refactor-loader origin/dev
+```
+
+**Naming convention:** `../{repo-name}-{issue-number}` (e.g., `../squad-195`, `../squad-pr-42`).
+
+Each worktree:
+- Has its own working directory and index
+- Is on its own `squad/{issue-number}-{slug}` branch from dev
+- Shares the same `.git` object store (disk-efficient)
+
+### Per-Worktree Agent Workflow
+
+Each agent operates inside its worktree exactly like the single-issue workflow:
+
+```bash
+cd ../squad-195
+
+# Work normally — commits, tests, pushes
+git add -A && git commit -m "fix: stamp bug (#195)"
+git push -u origin squad/195-fix-stamp-bug
+
+# Create PR targeting dev
+gh pr create --base dev --title "fix: stamp bug" --body "Closes #195" --draft
+```
+
+All PRs target `dev` independently. Agents never interfere with each other's filesystem.
+
+### .squad/ State in Worktrees
+
+The `.squad/` directory exists in each worktree as a copy. This is safe because:
+- `.gitattributes` declares `merge=union` on append-only files (history.md, decisions.md, logs)
+- Each agent appends to its own section; union merge reconciles on PR merge to dev
+- **Rule:** Never rewrite or reorder `.squad/` files in a worktree — append only
+
+### Cleanup After Merge
+
+After a worktree's PR is merged to dev:
+
+```bash
+# From the main clone
+git worktree remove ../squad-195
+git worktree prune          # clean stale metadata
+git branch -d squad/195-fix-stamp-bug
+git push origin --delete squad/195-fix-stamp-bug
+```
+
+If a worktree was deleted manually (rm -rf), `git worktree prune` recovers the state.
+
+---
+
+## Multi-Repo Downstream Scenarios
+
+When work spans multiple repositories (e.g., squad-cli changes need squad-sdk changes, or a user's app depends on squad):
+
+### Setup
+
+Clone downstream repos as siblings to the main repo:
+
+```
+~/work/
+  squad-pr/          # main repo
+  squad-sdk/         # downstream dependency
+  user-app/          # consumer project
+```
+
+Each repo gets its own issue branch following its own naming convention. If the downstream repo also uses Squad conventions, use `squad/{issue-number}-{slug}`.
+
+### Coordinated PRs
+
+- Create PRs in each repo independently
+- Link them in PR descriptions:
+  ```
+  Closes #42
+
+  **Depends on:** squad-sdk PR #17 (squad-sdk changes required for this feature)
+  ```
+- Merge order: dependencies first (e.g., squad-sdk), then dependents (e.g., squad-cli)
+
+### Local Linking for Testing
+
+Before pushing, verify cross-repo changes work together:
+
+```bash
+# Node.js / npm
+cd ../squad-sdk && npm link
+cd ../squad-pr && npm link squad-sdk
+
+# Go
+# Use replace directive in go.mod:
+# replace github.com/org/squad-sdk => ../squad-sdk
+
+# Python
+cd ../squad-sdk && pip install -e .
+```
+
+**Important:** Remove local links before committing. `npm link` and `go replace` are dev-only — CI must use published packages or PR-specific refs.
+
+### Worktrees + Multi-Repo
+
+These compose naturally. You can have:
+- Multiple worktrees in the main repo (parallel issues)
+- Separate clones for downstream repos
+- Each combination operates independently
+
+---
+
+## Anti-Patterns
+
+- ❌ Branching from main (branch from dev)
+- ❌ PR targeting main directly (target dev)
+- ❌ Non-conforming branch names (must be squad/{number}-{slug})
+- ❌ Committing directly to main or dev (use PRs)
+- ❌ Switching branches in the main clone while worktrees are active (use worktrees instead)
+- ❌ Using worktrees for cross-repo work (use separate clones)
+- ❌ Leaving stale worktrees after PR merge (clean up immediately)
+
+## Promotion Pipeline
+
+- dev → insiders: Automated sync on green build
+- dev → main: Manual merge when ready for stable release, then tag
+- Hotfixes: Branch from main as `hotfix/{slug}`, PR to dev, cherry-pick to main if urgent

--- a/.github/skills/iterative-retrieval/SKILL.md
+++ b/.github/skills/iterative-retrieval/SKILL.md
@@ -1,0 +1,165 @@
+---
+name: "iterative-retrieval"
+description: "Max-3-cycle protocol for agent sub-tasks with WHY context and coordinator validation. Use when spawning sub-agents to complete scoped work."
+domain: "agent-coordination"
+confidence: "high"
+license: MIT
+---
+
+# Iterative Retrieval Skill
+
+Squad agents frequently spawn sub-agents to complete scoped work. Without structure, these
+handoffs become vague, cycles multiply, and outputs land without being checked. The
+**Iterative Retrieval Pattern** caps cycles at 3, mandates WHY context in every spawn, and
+requires the coordinator to validate agent output before closing an issue.
+
+---
+
+## Spawn Prompt Template
+
+Every agent spawn must include the following four sections. Copy and fill in the template:
+
+```
+## Task
+{What you need done — concrete and bounded}
+
+## WHY this matters
+{The motivation and context. What system or user goal does this serve? What breaks if skipped?}
+
+## Success criteria
+{How you will know the output is correct. Be explicit — list acceptance criteria, not vibes.}
+Example:
+- [ ] File X exists and contains Y
+- [ ] No regressions in existing tests
+- [ ] PR is open targeting main with description matching the issue
+
+## Escalation path
+{What the agent should do if uncertain or stuck. "Stop and ask me" is valid.}
+Example:
+- If requirements are ambiguous → stop, comment on the issue, set label status:needs-decision
+- If blocked by a dependency → label status:blocked, explain in a comment
+- If 3 cycles exhausted without resolution → write a summary to inbox and surface to coordinator
+```
+
+---
+
+## 3-Cycle Protocol
+
+| Cycle | Description | Exit condition |
+|-------|-------------|----------------|
+| **1** | Initial attempt | Done → coordinator validates. Incomplete → surface delta. |
+| **2** | Targeted retry with specific corrections | Done → coordinator validates. Incomplete → one more. |
+| **3** | Final attempt with all context from cycles 1–2 | Done or escalate — no cycle 4. |
+
+### Rules
+
+1. **After each cycle**, the coordinator evaluates the output against the success criteria
+   before accepting it or spawning the next cycle.
+2. **Objective context forward**: each subsequent spawn includes a summary of what was tried
+   and what is still missing — not just a repeat of the original task.
+3. **Cycle 3 exhausted** → escalate: write a summary to `.squad/decisions/inbox/`, label the
+   issue `status:needs-decision`, and notify the user.
+
+---
+
+## Coordinator Validation Checklist
+
+Before accepting agent output and closing an issue, the coordinator must check:
+
+- [ ] All success criteria from the spawn prompt are met
+- [ ] PR exists and description matches the issue (if code work)
+- [ ] No obvious regressions (grep for TODO/FIXME introduced, build passes)
+- [ ] Agent did not silently skip parts of the task
+- [ ] If the agent reported uncertainty — was it resolved or escalated?
+
+If any item fails → do **not** accept. Spawn cycle N+1 (up to cycle 3) with specific deltas.
+
+---
+
+## When to Escalate vs Retry
+
+**Retry (cycle N+1)** when:
+- Output is structurally correct but missing specific items
+- Agent misunderstood scope (provide more context and re-run)
+- Partial success — clearly identified remaining delta
+
+**Escalate** when:
+- Requirements are fundamentally unclear (decision needed)
+- 3 cycles complete without convergence
+- Agent returned conflicting results across cycles
+- Task requires elevated permissions or external action
+- The work depends on another issue that isn't done yet
+
+---
+
+## Issue Dedup Check (Mandatory)
+
+Before any agent creates a GitHub issue, it **must** search for existing open issues to avoid
+duplicates.
+
+```bash
+# Check for existing open issues before creating a new one
+gh issue list --search "<keywords from your issue title>" --state open
+```
+
+- If an open issue already covers the same problem → **comment on it** instead of creating a new one.
+- If no duplicate → proceed to create the issue.
+- Use 2–3 representative keywords from the planned issue title as the search query.
+
+---
+
+## Mandatory Output Requirement (Research-Then-Execute)
+
+Every research or analysis task completed under this protocol **MUST** end with at least one
+concrete action before the cycle is closed. Acceptable follow-up actions:
+
+- GitHub issue created documenting the findings and next steps
+- PR opened implementing a recommendation
+- Decision recorded in `.squad/decisions/inbox/`
+- Documented recommendation with a named assignee and due date
+
+**Pure analysis reports without actionable follow-up will be rejected during triage.**
+If no action is warranted, the agent must explicitly state why and get coordinator sign-off.
+
+---
+
+## Anti-Patterns
+
+- **Spawning without WHY** — agents can't prioritise trade-offs without motivation context.
+- **Accepting output without validating** — one failed check avoids merging broken work.
+- **Cycle 4+** — if 3 cycles haven't converged, the problem is in the requirements, not the agent.
+- **Vague success criteria** — "looks good" is not a criterion. Use checkboxes.
+- **Forwarding WHAT without delta** — cycle 2+ prompts must include what cycle 1 got wrong.
+- **Creating issues without dedup check** — always search before creating.
+- **Research without action** — delivering analysis with no issue, PR, decision, or assignee is incomplete work.
+
+---
+
+## Examples
+
+### Good spawn prompt
+```
+## Task
+Add an "Iterative Retrieval Protocol" section to `.squad/agents/coordinator/charter.md` explaining
+the 3-cycle rule, WHY format, and validation checklist.
+
+## WHY this matters
+The coordinator spawns sub-agents on every round. Without a documented protocol, agents run unbounded
+cycles and outputs go unvalidated — leading to stale issues and silent failures.
+
+## Success criteria
+- [ ] Section "Iterative Retrieval Protocol" exists in charter.md
+- [ ] Section documents max-3-cycles rule
+- [ ] Section documents WHY format requirement
+- [ ] Section contains validation checklist (at least 4 items)
+- [ ] No other sections of charter.md are modified
+
+## Escalation path
+If the charter.md format is unclear, check another agent charter as a reference.
+If uncertain about content, stop and surface to coordinator.
+```
+
+### Bad spawn prompt (don't do this)
+```
+Update the coordinator charter with the iterative retrieval stuff.
+```

--- a/.github/skills/reflect/SKILL.md
+++ b/.github/skills/reflect/SKILL.md
@@ -1,0 +1,229 @@
+---
+name: reflect
+description: Learning capture system that extracts HIGH/MED/LOW confidence patterns from conversations to prevent repeating mistakes. Use after user corrections ("no", "wrong"), praise ("perfect", "exactly"), or when discovering edge cases. Complements .squad/agents/{agent}/history.md and .squad/decisions.md.
+license: MIT
+version: 1.0.0-squad
+domain: team-memory, learning
+confidence: high
+---
+
+# Reflect Skill
+
+**Critical learning capture system** for Squad. Prevents repeating mistakes and preserves successful patterns across sessions.
+
+Analyze conversations and propose improvements to squad knowledge based on what worked, what didn't, and edge cases discovered. **Every correction is a learning opportunity.**
+
+---
+
+## Integration with Squad Architecture
+
+**Reflect complements existing Squad knowledge systems:**
+
+1. **`.squad/agents/{agent}/history.md`** — Permanent learnings from completed work (append-only; each agent updates their own file; Scribe propagates cross-agent updates)
+2. **`.squad/decisions.md`** — Team-wide decisions that all agents respect
+3. **`reflect` skill** — Captures in-flight learnings from conversations that may graduate to history.md or decisions.md
+
+**Workflow:**
+- Use `reflect` during work to capture learnings
+- At session end, review captured learnings
+- Promote HIGH confidence patterns → lead agent for decision.md review
+- Promote agent-specific patterns → `{agent}/history.md` updates
+
+---
+
+## Triggers
+
+### 🔴 HIGH Priority (Invoke Immediately)
+
+| Trigger | Example | Why Critical |
+|---------|---------|--------------|
+| User correction | "no", "wrong", "not like that", "never do" | Captures mistakes to prevent repetition |
+| Architectural insight | "you removed that without understanding why" | Documents design decisions (Chesterton's Fence) |
+| Immediate fixes | "debug", "root cause", "fix all" | Learns from errors in real-time |
+
+### 🟡 MEDIUM Priority (Invoke After Multiple)
+
+| Trigger | Example | Why Important |
+|---------|---------|---------------|
+| User praise | "perfect", "exactly", "great" | Reinforces successful patterns |
+| Tool preferences | "use X instead of Y", "prefer" | Builds workflow preferences |
+| Edge cases | "what if X happens?", "don't forget", "ensure" | Captures scenarios to handle |
+
+### 🟢 LOW Priority (Invoke at Session End)
+
+| Trigger | Example | Why Useful |
+|---------|---------|------------|
+| Repeated patterns | Frequent use of specific commands/tools | Identifies workflow preferences |
+| Session end | After complex work | Consolidates all session learnings |
+
+---
+
+## Process
+
+### Phase 1: Identify Learning Target
+
+Determine what knowledge system should be updated:
+
+1. **Agent-specific learning** → `.squad/agents/{agent}/history.md`
+2. **Team-wide decision** → `.squad/decisions/inbox/{agent}-{topic}.md`
+3. **Skill-specific improvement** → Document in session, recommend to skill owner
+
+### Phase 2: Analyze Conversation
+
+Scan for learning signals with confidence levels:
+
+#### HIGH Confidence: Corrections
+
+User actively steered or corrected output.
+
+**Detection patterns:**
+- Explicit rejection: "no", "not like that", "that's wrong"
+- Strong directives: "never do", "always do", "don't ever"
+- User provided alternative implementation
+
+**Example:**
+```text
+User: "No, use the azure-devops MCP tool instead of raw API calls"
+→ [HIGH] + Add constraint: "Prefer azure-devops MCP tools over REST API"
+```
+
+#### MEDIUM Confidence: Success Patterns
+
+Output was accepted or praised.
+
+**Detection patterns:**
+- Explicit praise: "perfect", "great", "yes", "exactly"
+- User built on output without modification
+- Output was committed without changes
+
+**Example:**
+```text
+User: "Perfect, that's exactly what I needed"
+→ [MED] + Add preference: "Include usage examples in documentation"
+```
+
+#### MEDIUM Confidence: Edge Cases
+
+Scenarios not anticipated.
+
+**Detection patterns:**
+- Questions not answered
+- Workarounds user had to apply
+- Error handling gaps discovered
+
+#### LOW Confidence: Preferences
+
+Accumulated patterns over time.
+
+---
+
+### Phase 3: Propose Learnings
+
+Present findings:
+
+```text
+┌─────────────────────────────────────────────────────────────┐
+│ REFLECTION: {target (agent/decision/skill)}                  │
+├─────────────────────────────────────────────────────────────┤
+│                                                             │
+│ [HIGH] + Add constraint: "{specific constraint}"            │
+│   Source: "{quoted user correction}"                        │
+│   Target: .squad/decisions/inbox/{agent}-{topic}.md         │
+│                                                             │
+│ [MED]  + Add preference: "{specific preference}"            │
+│   Source: "{evidence from conversation}"                    │
+│   Target: .squad/agents/{agent}/history.md                  │
+│                                                             │
+│ [LOW]  ~ Note for review: "{observation}"                   │
+│   Source: "{pattern observed}"                              │
+│   Target: Session notes only                                │
+│                                                             │
+├─────────────────────────────────────────────────────────────┤
+│ Apply changes? [Y/n/edit]                                   │
+└─────────────────────────────────────────────────────────────┘
+```
+
+**Confidence Threshold:**
+
+| Threshold | Action |
+|-----------|--------|
+| ≥1 HIGH signal | Always propose (user explicitly corrected) |
+| ≥2 MED signals | Propose (sufficient pattern) |
+| ≥3 LOW signals | Propose (accumulated evidence) |
+| 1-2 LOW only | Skip (insufficient evidence) |
+
+### Phase 4: Persist Learnings
+
+**ALWAYS show changes before applying.**
+
+After user approval:
+
+1. **For Agent History:**
+   - Append to `.squad/agents/{agent}/history.md` under `## Learnings` section
+   - Format: Date, assignment context, key learning
+
+2. **For Team Decisions:**
+   - Create `.squad/decisions/inbox/{agent}-{topic}.md`
+   - Lead agent reviews and merges to `decisions.md` if appropriate
+
+3. **For Skills:**
+   - Document recommendation in session notes
+   - Squad lead reviews and routes to skill owner
+
+---
+
+## Usage Examples
+
+### Example 1: User Correction
+
+**Conversation:**
+```
+Agent: "I'll use grep to search the repository"
+User: "No, use the code search tools first, grep is too slow"
+```
+
+**Reflection Output:**
+```
+[HIGH] + Add constraint: "Use code intelligence tools before grep"
+  Source: "No, use the code search tools first, grep is too slow"
+  Target: .squad/agents/{agent}/history.md
+```
+
+### Example 2: Success Pattern
+
+**Conversation:**
+```
+Agent: [Creates PR with detailed description and test plan]
+User: "Perfect! This is exactly the format I want for all PRs"
+```
+
+**Reflection Output:**
+```
+[MED] + Add preference: "Include test plan in PR descriptions"
+  Source: User praised detailed PR format
+  Target: .squad/decisions/inbox/pr-format.md (for team adoption)
+```
+
+---
+
+## When to Use
+
+✅ **Use reflect when:**
+- User says "no", "wrong", "not like that" (HIGH priority)
+- User says "perfect", "exactly", "great" (MED priority)
+- You discover edge cases or gaps
+- Complex work session with multiple learnings
+- At end of sprint/milestone to consolidate patterns
+
+❌ **Don't use reflect when:**
+- Simple one-off questions with no pattern
+- User is just exploring ideas (no concrete decisions)
+- Learning is already captured in history.md/decisions.md
+
+---
+
+## See Also
+
+- `.squad/decisions.md` — Team-wide decisions
+- `.squad/agents/*/history.md` — Agent-specific learnings
+- `.squad/routing.md` — Work assignment patterns

--- a/.github/skills/reviewer-protocol/SKILL.md
+++ b/.github/skills/reviewer-protocol/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: "reviewer-protocol"
+description: "Reviewer rejection workflow and strict lockout semantics"
+domain: "orchestration"
+confidence: "high"
+source: "extracted"
+---
+
+## Context
+
+When a team member has a **Reviewer** role (e.g., Tester, Code Reviewer, Lead), they may approve or reject work from other agents. On rejection, the coordinator enforces strict lockout rules to ensure the original author does NOT self-revise. This prevents defensive feedback loops and ensures independent review.
+
+## Patterns
+
+### Reviewer Rejection Protocol
+
+When a team member has a **Reviewer** role:
+
+- Reviewers may **approve** or **reject** work from other agents.
+- On **rejection**, the Reviewer may choose ONE of:
+  1. **Reassign:** Require a *different* agent to do the revision (not the original author).
+  2. **Escalate:** Require a *new* agent be spawned with specific expertise.
+- The Coordinator MUST enforce this. If the Reviewer says "someone else should fix this," the original agent does NOT get to self-revise.
+- If the Reviewer approves, work proceeds normally.
+
+### Strict Lockout Semantics
+
+When an artifact is **rejected** by a Reviewer:
+
+1. **The original author is locked out.** They may NOT produce the next version of that artifact. No exceptions.
+2. **A different agent MUST own the revision.** The Coordinator selects the revision author based on the Reviewer's recommendation (reassign or escalate).
+3. **The Coordinator enforces this mechanically.** Before spawning a revision agent, the Coordinator MUST verify that the selected agent is NOT the original author. If the Reviewer names the original author as the fix agent, the Coordinator MUST refuse and ask the Reviewer to name a different agent.
+4. **The locked-out author may NOT contribute to the revision** in any form — not as a co-author, advisor, or pair. The revision must be independently produced.
+5. **Lockout scope:** The lockout applies to the specific artifact that was rejected. The original author may still work on other unrelated artifacts.
+6. **Lockout duration:** The lockout persists for that revision cycle. If the revision is also rejected, the same rule applies again — the revision author is now also locked out, and a third agent must revise.
+7. **Deadlock handling:** If all eligible agents have been locked out of an artifact, the Coordinator MUST escalate to the user rather than re-admitting a locked-out author.
+
+## Examples
+
+**Example 1: Reassign after rejection**
+1. Fenster writes authentication module
+2. Hockney (Tester) reviews → rejects: "Error handling is missing. Verbal should fix this."
+3. Coordinator: Fenster is now locked out of this artifact
+4. Coordinator spawns Verbal to revise the authentication module
+5. Verbal produces v2
+6. Hockney reviews v2 → approves
+7. Lockout clears for next artifact
+
+**Example 2: Escalate for expertise**
+1. Edie writes TypeScript config
+2. Keaton (Lead) reviews → rejects: "Need someone with deeper TS knowledge. Escalate."
+3. Coordinator: Edie is now locked out
+4. Coordinator spawns new agent (or existing TS expert) to revise
+5. New agent produces v2
+6. Keaton reviews v2
+
+**Example 3: Deadlock handling**
+1. Fenster writes module → rejected
+2. Verbal revises → rejected
+3. Hockney revises → rejected
+4. All 3 eligible agents are now locked out
+5. Coordinator: "All eligible agents have been locked out. Escalating to user: [artifact details]"
+
+**Example 4: Reviewer accidentally names original author**
+1. Fenster writes module → rejected
+2. Hockney says: "Fenster should fix the error handling"
+3. Coordinator: "Fenster is locked out as the original author. Please name a different agent."
+4. Hockney: "Verbal, then"
+5. Coordinator spawns Verbal
+
+## Anti-Patterns
+
+- ❌ Allowing the original author to self-revise after rejection
+- ❌ Treating the locked-out author as an "advisor" or "co-author" on the revision
+- ❌ Re-admitting a locked-out author when deadlock occurs (must escalate to user)
+- ❌ Applying lockout across unrelated artifacts (scope is per-artifact)
+- ❌ Accepting the Reviewer's assignment when they name the original author (must refuse and ask for a different agent)
+- ❌ Clearing lockout before the revision is approved (lockout persists through revision cycle)
+- ❌ Skipping verification that the revision agent is not the original author

--- a/.github/skills/secret-handling/SKILL.md
+++ b/.github/skills/secret-handling/SKILL.md
@@ -1,0 +1,200 @@
+---
+name: secret-handling
+description: Never read .env files or write secrets to .squad/ committed files
+domain: security, file-operations, team-collaboration
+confidence: high
+source: earned (issue #267 — credential leak incident)
+---
+
+## Context
+
+Spawned agents have read access to the entire repository, including `.env` files containing live credentials. If an agent reads secrets and writes them to `.squad/` files (decisions, logs, history), Scribe auto-commits them to git, exposing them in remote history. This skill codifies absolute prohibitions and safe alternatives.
+
+## Patterns
+
+### Prohibited File Reads
+
+**NEVER read these files:**
+- `.env` (production secrets)
+- `.env.local` (local dev secrets)
+- `.env.production` (production environment)
+- `.env.development` (development environment)
+- `.env.staging` (staging environment)
+- `.env.test` (test environment with real credentials)
+- Any file matching `.env.*` UNLESS explicitly allowed (see below)
+
+**Allowed alternatives:**
+- `.env.example` (safe — contains placeholder values, no real secrets)
+- `.env.sample` (safe — documentation template)
+- `.env.template` (safe — schema/structure reference)
+
+**If you need config info:**
+1. **Ask the user directly** — "What's the database connection string?"
+2. **Read `.env.example`** — shows structure without exposing secrets
+3. **Read documentation** — check `README.md`, `docs/`, config guides
+
+**NEVER assume you can "just peek at .env to understand the schema."** Use `.env.example` or ask.
+
+### Prohibited Output Patterns
+
+**NEVER write these to `.squad/` files:**
+
+| Pattern Type | Examples | Regex Pattern (for scanning) |
+|--------------|----------|-------------------------------|
+| API Keys | `OPENAI_API_KEY=sk-proj-...`, `GITHUB_TOKEN=ghp_...` | `[A-Z_]+(?:KEY|TOKEN|SECRET)=[^\s]+` |
+| Passwords | `DB_PASSWORD=super_secret_123`, `password: "..."` | `(?:PASSWORD|PASS|PWD)[:=]\s*["']?[^\s"']+` |
+| Connection Strings | `postgres://user:pass@host:5432/db`, `Server=...;Password=...` | `(?:postgres|mysql|mongodb)://[^@]+@|(?:Server|Host)=.*(?:Password|Pwd)=` |
+| JWT Tokens | `eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...` | `eyJ[A-Za-z0-9_-]+\.eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+` |
+| Private Keys | `-----BEGIN PRIVATE KEY-----`, `-----BEGIN RSA PRIVATE KEY-----` | `-----BEGIN [A-Z ]+PRIVATE KEY-----` |
+| AWS Credentials | `AKIA...`, `aws_secret_access_key=...` | `AKIA[0-9A-Z]{16}|aws_secret_access_key=[^\s]+` |
+| Email Addresses | `user@example.com` (PII violation per team decision) | `[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}` |
+
+**What to write instead:**
+- Placeholder values: `DATABASE_URL=<set in .env>`
+- Redacted references: `API key configured (see .env.example)`
+- Architecture notes: "App uses JWT auth — token stored in session"
+- Schema documentation: "Requires OPENAI_API_KEY, GITHUB_TOKEN (see .env.example for format)"
+
+### Scribe Pre-Commit Validation
+
+**Before committing `.squad/` changes, Scribe MUST:**
+
+1. **Scan all staged files** for secret patterns (use regex table above)
+2. **Check for prohibited file names** (don't commit `.env` even if manually staged)
+3. **If secrets detected:**
+   - STOP the commit (do NOT proceed)
+   - Remove the file from staging: `git reset HEAD <file>`
+   - Report to user:
+     ```
+     🚨 SECRET DETECTED — commit blocked
+     
+     File: .squad/decisions/inbox/river-db-config.md
+     Pattern: DATABASE_URL=postgres://user:password@localhost:5432/prod
+     
+     This file contains credentials and MUST NOT be committed.
+     Please remove the secret, replace with placeholder, and try again.
+     ```
+   - Exit with error (never silently skip)
+
+4. **If no secrets detected:**
+   - Proceed with commit as normal
+
+**Implementation note for Scribe:**
+- Run validation AFTER staging files, BEFORE calling `git commit`
+- Use PowerShell `Select-String` or `git diff --cached` to scan staged content
+- Fail loud — secret leaks are unacceptable, blocking the commit is correct behavior
+
+### Remediation — If a Secret Was Already Committed
+
+**If you discover a secret in git history:**
+
+1. **STOP immediately** — do not make more commits
+2. **Alert the user:**
+   ```
+   🚨 CREDENTIAL LEAK DETECTED
+   
+   A secret was found in git history:
+   Commit: abc1234
+   File: .squad/decisions/inbox/agent-config.md
+   Pattern: API_KEY=sk-proj-...
+   
+   This requires immediate remediation:
+   1. Revoke the exposed credential (regenerate API key, rotate password)
+   2. Remove from git history (git filter-repo or BFG)
+   3. Force-push the cleaned history
+   
+   Do NOT proceed with new work until this is resolved.
+   ```
+3. **Do NOT attempt to fix it yourself** — secret removal requires specialized tools
+4. **Wait for user confirmation** before resuming work
+
+## Examples
+
+### ✓ Correct: Reading Config Schema
+
+**Agent needs to know what environment variables are required:**
+
+```
+Agent: "What environment variables does this app need?"
+→ Reads `.env.example`:
+    OPENAI_API_KEY=sk-...
+    DATABASE_URL=postgres://user:pass@localhost:5432/db
+    REDIS_URL=redis://localhost:6379
+
+→ Writes to .squad/decisions/inbox/river-env-setup.md:
+    "App requires three environment variables:
+    - OPENAI_API_KEY (OpenAI API key, format: sk-...)
+    - DATABASE_URL (Postgres connection string)
+    - REDIS_URL (Redis connection string)
+    See .env.example for full schema."
+```
+
+### ✗ Incorrect: Reading Live Credentials
+
+**Agent needs to know database schema:**
+
+```
+Agent: (reads .env)
+    DATABASE_URL=postgres://admin:super_secret_pw@prod.example.com:5432/appdb
+
+→ Writes to .squad/decisions/inbox/river-db-schema.md:
+    "Database connection: postgres://admin:super_secret_pw@prod.example.com:5432/appdb"
+    
+🚨 VIOLATION: Live credential written to committed file
+```
+
+**Correct approach:**
+```
+Agent: (reads .env.example OR asks user)
+User: "It's a Postgres database, schema is in migrations/"
+
+→ Writes to .squad/decisions/inbox/river-db-schema.md:
+    "Database: Postgres (connection configured in .env). Schema defined in db/migrations/."
+```
+
+### ✓ Correct: Scribe Pre-Commit Validation
+
+**Scribe is about to commit:**
+
+```powershell
+# Stage files
+git add .squad/
+
+# Scan staged content for secrets
+$stagedContent = git diff --cached
+$secretPatterns = @(
+    '[A-Z_]+(?:KEY|TOKEN|SECRET)=[^\s]+',
+    '(?:PASSWORD|PASS|PWD)[:=]\s*["'']?[^\s"'']+',
+    'eyJ[A-Za-z0-9_-]+\.eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+'
+)
+
+$detected = $false
+foreach ($pattern in $secretPatterns) {
+    if ($stagedContent -match $pattern) {
+        $detected = $true
+        Write-Host "🚨 SECRET DETECTED: $($matches[0])"
+        break
+    }
+}
+
+if ($detected) {
+    # Remove from staging, report, exit
+    git reset HEAD .squad/
+    Write-Error "Commit blocked — secret detected in staged files"
+    exit 1
+}
+
+# Safe to commit
+git commit -F $msgFile
+```
+
+## Anti-Patterns
+
+- ❌ Reading `.env` "just to check the schema" — use `.env.example` instead
+- ❌ Writing "sanitized" connection strings that still contain credentials
+- ❌ Assuming "it's just a dev environment" makes secrets safe to commit
+- ❌ Committing first, scanning later — validation MUST happen before commit
+- ❌ Silently skipping secret detection — fail loud, never silent
+- ❌ Trusting agents to "know better" — enforce at multiple layers (prompt, hook, architecture)
+- ❌ Writing secrets to "temporary" files in `.squad/` — Scribe commits ALL `.squad/` changes
+- ❌ Extracting "just the host" from a connection string — still leaks infrastructure topology

--- a/.github/skills/session-recovery/SKILL.md
+++ b/.github/skills/session-recovery/SKILL.md
@@ -1,0 +1,155 @@
+---
+name: "session-recovery"
+description: "Find and resume interrupted Copilot CLI sessions using session_store queries"
+domain: "workflow-recovery"
+confidence: "high"
+source: "earned"
+tools:
+  - name: "sql"
+    description: "Query session_store database for past session history"
+    when: "Always — session_store is the source of truth for session history"
+---
+
+## Context
+
+Squad agents run in Copilot CLI sessions that can be interrupted — terminal crashes, network drops, machine restarts, or accidental window closes. When this happens, in-progress work may be left in a partially-completed state: branches with uncommitted changes, issues marked in-progress with no active agent, or checkpoints that were never finalized.
+
+Copilot CLI stores session history in a SQLite database called `session_store` (read-only, accessed via the `sql` tool with `database: "session_store"`). This skill teaches agents how to query that store to detect interrupted sessions and resume work.
+
+## Patterns
+
+### 1. Find Recent Sessions
+
+Query the `sessions` table filtered by time window. Include the last checkpoint to understand where the session stopped:
+
+```sql
+SELECT
+  s.id,
+  s.summary,
+  s.cwd,
+  s.branch,
+  s.updated_at,
+  (SELECT title FROM checkpoints
+   WHERE session_id = s.id
+   ORDER BY checkpoint_number DESC LIMIT 1) AS last_checkpoint
+FROM sessions s
+WHERE s.updated_at >= datetime('now', '-24 hours')
+ORDER BY s.updated_at DESC;
+```
+
+### 2. Filter Out Automated Sessions
+
+Automated agents (monitors, keep-alive, heartbeat) create high-volume sessions that obscure human-initiated work. Exclude them:
+
+```sql
+SELECT s.id, s.summary, s.cwd, s.updated_at,
+  (SELECT title FROM checkpoints
+   WHERE session_id = s.id
+   ORDER BY checkpoint_number DESC LIMIT 1) AS last_checkpoint
+FROM sessions s
+WHERE s.updated_at >= datetime('now', '-24 hours')
+  AND s.id NOT IN (
+    SELECT DISTINCT t.session_id FROM turns t
+    WHERE t.turn_index = 0
+      AND (LOWER(t.user_message) LIKE '%keep-alive%'
+           OR LOWER(t.user_message) LIKE '%heartbeat%')
+  )
+ORDER BY s.updated_at DESC;
+```
+
+### 3. Search by Topic (FTS5)
+
+Use the `search_index` FTS5 table for keyword search. Expand queries with synonyms since this is keyword-based, not semantic:
+
+```sql
+SELECT DISTINCT s.id, s.summary, s.cwd, s.updated_at
+FROM search_index si
+JOIN sessions s ON si.session_id = s.id
+WHERE search_index MATCH 'auth OR login OR token OR JWT'
+  AND s.updated_at >= datetime('now', '-48 hours')
+ORDER BY s.updated_at DESC
+LIMIT 10;
+```
+
+### 4. Search by Working Directory
+
+```sql
+SELECT s.id, s.summary, s.updated_at,
+  (SELECT title FROM checkpoints
+   WHERE session_id = s.id
+   ORDER BY checkpoint_number DESC LIMIT 1) AS last_checkpoint
+FROM sessions s
+WHERE s.cwd LIKE '%my-project%'
+  AND s.updated_at >= datetime('now', '-48 hours')
+ORDER BY s.updated_at DESC;
+```
+
+### 5. Get Full Session Context Before Resuming
+
+Before resuming, inspect what the session was doing:
+
+```sql
+-- Conversation turns
+SELECT turn_index, substr(user_message, 1, 200) AS ask, timestamp
+FROM turns WHERE session_id = 'SESSION_ID' ORDER BY turn_index;
+
+-- Checkpoint progress
+SELECT checkpoint_number, title, overview
+FROM checkpoints WHERE session_id = 'SESSION_ID' ORDER BY checkpoint_number;
+
+-- Files touched
+SELECT file_path, tool_name
+FROM session_files WHERE session_id = 'SESSION_ID';
+
+-- Linked PRs/issues/commits
+SELECT ref_type, ref_value
+FROM session_refs WHERE session_id = 'SESSION_ID';
+```
+
+### 6. Detect Orphaned Issue Work
+
+Find sessions that were working on issues but may not have completed:
+
+```sql
+SELECT DISTINCT s.id, s.branch, s.summary, s.updated_at,
+  sr.ref_type, sr.ref_value
+FROM sessions s
+JOIN session_refs sr ON s.id = sr.session_id
+WHERE sr.ref_type = 'issue'
+  AND s.updated_at >= datetime('now', '-48 hours')
+ORDER BY s.updated_at DESC;
+```
+
+Cross-reference with `gh issue list --label "status:in-progress"` to find issues that are marked in-progress but have no active session.
+
+### 7. Resume a Session
+
+Once you have the session ID:
+
+```bash
+# Resume directly
+copilot --resume SESSION_ID
+```
+
+## Examples
+
+**Recovering from a crash during PR creation:**
+1. Query recent sessions filtered by branch name
+2. Find the session that was working on the PR
+3. Check its last checkpoint — was the code committed? Was the PR created?
+4. Resume or manually complete the remaining steps
+
+**Finding yesterday's work on a feature:**
+1. Use FTS5 search with feature keywords
+2. Filter to the relevant working directory
+3. Review checkpoint progress to see how far the session got
+4. Resume if work remains, or start fresh with the context
+
+## Anti-Patterns
+
+- ❌ Searching by partial session IDs — always use full UUIDs
+- ❌ Resuming sessions that completed successfully — they have no pending work
+- ❌ Using `MATCH` with special characters without escaping — wrap paths in double quotes
+- ❌ Skipping the automated-session filter — high-volume automated sessions will flood results
+- ❌ Assuming FTS5 is semantic search — it's keyword-based; always expand queries with synonyms
+- ❌ Ignoring checkpoint data — checkpoints show exactly where the session stopped

--- a/.github/skills/squad-conventions/SKILL.md
+++ b/.github/skills/squad-conventions/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: "squad-conventions"
+description: "Core conventions and patterns used in the Squad codebase"
+domain: "project-conventions"
+confidence: "high"
+source: "manual"
+---
+
+## Context
+These conventions apply to all work on the Squad CLI tool (`create-squad`). Squad is a zero-dependency Node.js package that adds AI agent teams to any project. Understanding these patterns is essential before modifying any Squad source code.
+
+## Patterns
+
+### Zero Dependencies
+Squad has zero runtime dependencies. Everything uses Node.js built-ins (`fs`, `path`, `os`, `child_process`). Do not add packages to `dependencies` in `package.json`. This is a hard constraint, not a preference.
+
+### Node.js Built-in Test Runner
+Tests use `node:test` and `node:assert/strict` — no test frameworks. Run with `npm test`. Test files live in `test/`. The test command is `node --test test/`.
+
+### Error Handling — `fatal()` Pattern
+All user-facing errors use the `fatal(msg)` function which prints a red `✗` prefix and exits with code 1. Never throw unhandled exceptions or print raw stack traces. The global `uncaughtException` handler calls `fatal()` as a safety net.
+
+### ANSI Color Constants
+Colors are defined as constants at the top of `index.js`: `GREEN`, `RED`, `DIM`, `BOLD`, `RESET`. Use these constants — do not inline ANSI escape codes.
+
+### File Structure
+- `.squad/` — Team state (user-owned, never overwritten by upgrades)
+- `.squad/templates/` — Template files copied from `templates/` (Squad-owned, overwritten on upgrade)
+- `.github/agents/squad.agent.md` — Coordinator prompt (Squad-owned, overwritten on upgrade)
+- `templates/` — Source templates shipped with the npm package
+- `.squad/skills/` — Team skills in SKILL.md format (user-owned)
+- `.squad/decisions/inbox/` — Drop-box for parallel decision writes
+
+### Windows Compatibility
+Always use `path.join()` for file paths — never hardcode `/` or `\` separators. Squad must work on Windows, macOS, and Linux. All tests must pass on all platforms.
+
+### Init Idempotency
+The init flow uses a skip-if-exists pattern: if a file or directory already exists, skip it and report "already exists." Never overwrite user state during init. The upgrade flow overwrites only Squad-owned files.
+
+### Copy Pattern
+`copyRecursive(src, target)` handles both files and directories. It creates parent directories with `{ recursive: true }` and uses `fs.copyFileSync` for files.
+
+## Examples
+
+```javascript
+// Error handling
+function fatal(msg) {
+  console.error(`${RED}✗${RESET} ${msg}`);
+  process.exit(1);
+}
+
+// File path construction (Windows-safe)
+const agentDest = path.join(dest, '.github', 'agents', 'squad.agent.md');
+
+// Skip-if-exists pattern
+if (!fs.existsSync(ceremoniesDest)) {
+  fs.copyFileSync(ceremoniesSrc, ceremoniesDest);
+  console.log(`${GREEN}✓${RESET} .squad/ceremonies.md`);
+} else {
+  console.log(`${DIM}ceremonies.md already exists — skipping${RESET}`);
+}
+```
+
+## Anti-Patterns
+- **Adding npm dependencies** — Squad is zero-dep. Use Node.js built-ins only.
+- **Hardcoded path separators** — Never use `/` or `\` directly. Always `path.join()`.
+- **Overwriting user state on init** — Init skips existing files. Only upgrade overwrites Squad-owned files.
+- **Raw stack traces** — All errors go through `fatal()`. Users see clean messages, not stack traces.
+- **Inline ANSI codes** — Use the color constants (`GREEN`, `RED`, `DIM`, `BOLD`, `RESET`).

--- a/.github/skills/squad-help/SKILL.md
+++ b/.github/skills/squad-help/SKILL.md
@@ -1,0 +1,97 @@
+---
+name: "squad-help"
+description: "How to actually use Squad — Squad is a custom Copilot agent (invoked via the task tool with agent_type='Squad'), not a skill. This file explains the right invocation paths for setting up a team, listing squad commands, and initializing Squad in a new project."
+allowedTools: []
+confidence: high
+domain: squad-onboarding
+---
+
+# Skill: squad-help
+
+> **Quick reference.** If you're reading this because a user said "use squad" or "squad" or "set up a squad", you're in the right place — read on for the correct invocation paths.
+
+---
+
+## Squad is a custom agent, not a skill
+
+The Squad framework registers a **custom Copilot CLI agent** at `.github/agents/squad.agent.md`. The agent is named **`Squad`** and its description is *"Your AI team. Describe what you're building, get a team of specialists that live in your repo."*
+
+Copilot CLI agents and skills are different things:
+
+| Thing | How to invoke | Example |
+|---|---|---|
+| **Skill** | `skill(name)` tool call or natural-language match | `skill(squad-commands)` |
+| **Agent** | `task` tool with `agent_type=<name>` | `task(name="...", agent_type="Squad", prompt="...")` |
+| **Slash command** | Built-in CLI keyword | `/agent`, `/skills`, `/mcp` |
+
+Calling `skill(Squad)` will fail with *"Skill not found: Squad"* because Squad is the agent, not a skill. (`/squad` as a slash command also does not exist — only built-in CLI keywords like `/agent`, `/skills`, `/mcp` are slash commands. There's no way to map a skill name to a slash command without a Copilot CLI feature change.)
+
+---
+
+## How to actually use Squad
+
+Pick the path that matches the user's intent:
+
+### A) Invoke the Squad coordinator agent (most common)
+
+The Squad coordinator orchestrates a team of specialists. It routes work to the right agent, scaffolds a team if none exists, and enforces handoffs.
+
+```text
+task(
+  name="<short-task-name>",
+  agent_type="Squad",
+  prompt="<what you want the team to do>"
+)
+```
+
+Use this when the user says things like:
+- *"Use Squad to build X"*
+- *"Set up an AI team for this project"*
+- *"Have the Squad coordinator design Y"*
+- *"Spawn Squad"* / *"Squad, help me with ..."*
+
+### B) See what Squad commands exist
+
+The `squad-commands` skill is a categorized catalog of common Squad operations. The coordinator presents it as an interactive menu.
+
+Trigger by natural-language match: `"squad commands"`, `"what can squad do"`, `"show me squad options"`, `"slash commands"`, `"what commands are available"`.
+
+Use this when the user says things like:
+- *"What can Squad do?"*
+- *"Show me the squad commands"*
+- *"squad help"*
+
+### C) Initialize Squad in a fresh project
+
+`squad init` is a **shell command**, not a tool call. The user runs it in their terminal in a project that has no `.squad/` directory yet.
+
+```bash
+squad init
+```
+
+Do **not** try to invoke this from inside an existing Copilot session — `.squad/` is already initialized if you're reading this file.
+
+---
+
+## What NOT to do
+
+- ❌ Do not call `skill(Squad)`, `skill(squad)`, or `skill(squad-coordinator)` — Squad is not a skill.
+- ❌ Do not type `/squad` expecting a slash command — slash commands are CLI keywords, not skill names. Use `/agent` (browse) or invoke the `Squad` agent via the `task` tool.
+- ❌ Do not call `task(agent_type="Squad", …)` for tiny tasks the current agent can handle directly. Squad is for work that needs orchestration; trivial edits do not.
+
+---
+
+## How this skill was discovered
+
+This skill ships from the Squad SDK templates and is wired into `MANIFEST_SKILL_NAMES`. It lives at `.copilot/skills/squad-help/SKILL.md` so the Copilot CLI's `/skills` loader picks it up alongside the other bundled Squad skills.
+
+If you removed this skill on purpose, the model will fall back to its own reasoning and may make the lookup mistakes described above.
+
+---
+
+## See also
+
+- `.github/agents/squad.agent.md` — the actual Squad coordinator agent
+- `.copilot/skills/squad-commands/SKILL.md` — the command catalog
+- `.copilot/skills/squad-conventions/SKILL.md` — conventions for working on the Squad codebase itself
+- `.copilot/skills/squad-version-check/SKILL.md` — version-stamping mechanics

--- a/.github/skills/squad-version-check/SKILL.md
+++ b/.github/skills/squad-version-check/SKILL.md
@@ -1,0 +1,169 @@
+---
+name: "squad-version-check"
+description: "Internals of how @bradygaster/squad-cli stamps its version, how `squad upgrade` works (what it preserves vs overwrites), and how to probe the npm registry for the latest version from a coordinator prompt."
+allowedTools: []
+confidence: medium
+domain: squad-internals
+source: "Discovered by Data; validated in bradygaster/squad#1173 recon (2026-05-26)."
+---
+
+# SKILL: Squad CLI Internals — Version Stamping & Upgrade Mechanics
+
+**Confidence:** medium
+**Discovered by:** Data
+**Date:** 2026-05-26
+**Validated in:** Issue #1173 recon (bradygaster/squad)
+
+---
+
+## What This Skill Covers
+
+Reusable knowledge about how `@bradygaster/squad-cli` stamps its version into `squad.agent.md`, how `squad upgrade` works, what it preserves vs. overwrites, and how to probe the npm registry for the latest version from a coordinator prompt.
+
+---
+
+## Package & Registry Facts
+
+- **Package name:** `@bradygaster/squad-cli`
+- **Registry:** npm (public)
+- **CLI binary:** `squad` (registered via `package.json#bin.squad`)
+- **Node version requirement:** Node ≥22.5.0 (ESM-only codebase)
+
+---
+
+## Version Stamping Mechanism
+
+**Source file:** `dist/cli/core/version.js`
+
+Three functions:
+
+### `getPackageVersion()`
+Walks up from the compiled JS file to find `package.json`. Returns `pkg.version`. Works from both `dist/cli/core/version.js` and a bundled root `cli.js`. Returns `'0.0.0'` as fallback if not found.
+
+### `stampVersion(filePath, version)`
+Mutates `squad.agent.md` in three places:
+1. HTML comment: `<!-- version: {version} -->` (must be on the line immediately after frontmatter `---`)
+2. Identity line: `- **Version:** {version}`
+3. Greeting instruction: backtick-quoted `` `Squad v{version}` ``
+
+**Called by:** both `init` and `upgrade` — after copying the template to the destination.
+
+### `readInstalledVersion(filePath)`
+Reads the stamped version back from `squad.agent.md`:
+1. First tries HTML comment format: `/<!-- version: ([0-9.]+(?:-[a-z]+(?:\.\d+)?)?) -->/`
+2. Falls back to old frontmatter format: `/^version:\s*"([^"]+)"/m`
+3. Returns `'0.0.0'` on any error
+
+---
+
+## `squad upgrade` Behavior
+
+**Source file:** `dist/cli/core/upgrade.js`
+
+### What gets overwritten:
+- `squad.agent.md` — full overwrite from template, then `stampVersion()`
+- Files with `overwriteOnUpgrade: true` in `TEMPLATE_MANIFEST`: casting JSON files, template .md files, `copilot-instructions.md` (if @copilot enabled)
+- GitHub Actions workflows — from `templates/workflows/`; non-npm projects get type-aware stubs
+- Runs `runMigrations()` after file copy
+
+### What is PRESERVED:
+- `team.md`, `routing.md`, `decisions.md`, `ceremonies.md` (user-owned)
+- `agents/*/history.md` (individual agent memory)
+- `.squad/config.json` — **never touched**; `stateBackend` survives intact
+- User-added files not in TEMPLATE_MANIFEST
+
+### Self-upgrade path (`selfUpgradeCli()`):
+Detects npm/pnpm/yarn via `npm_execpath` and `npm_config_user_agent`. Runs:
+- npm: `npm install -g @bradygaster/squad-cli@latest`
+- pnpm: `pnpm add -g @bradygaster/squad-cli@latest`
+- yarn: `yarn global add @bradygaster/squad-cli@latest`
+Use `@insider` tag for insider builds.
+
+### `compareSemver(a, b)` utility (in upgrade.js):
+Returns -1/0/1. Handles pre-release: strips pre-release for base comparison, then treats pre-release as less than release (e.g., `0.9.5-insider.1` < `0.9.5`). Can be ported directly if needed in prompt logic.
+
+---
+
+## `.squad/config.json` — What It Holds
+
+```json
+{
+  "version": 1,
+  "stateBackend": "worktree"
+}
+```
+
+Other optional fields added by the coordinator at runtime:
+- `defaultModel` — global model override for all agent spawns
+- `agentModelOverrides.{agentName}` — per-agent model override
+
+The file is read-only from the upgrade path's perspective. Only the coordinator writes to it (for model preferences).
+
+---
+
+## Version-Check Probe (npm Registry)
+
+Use this one-liner from inside a coordinator prompt to fetch dist-tags:
+
+```
+npm view @bradygaster/squad-cli dist-tags --json
+```
+
+- Timeout: **5 seconds.** If no response within 5 seconds, abandon and show normal greeting.
+- On success: extract `dist-tags[channel]` (e.g., `dist-tags["insider"]`).
+- On any error (network failure, registry unreachable, parse error): show normal greeting.
+
+---
+
+## Upstream OS-Specific Cache
+
+The CLI (`self-update.ts`) writes `latest` version info to an OS-specific path with a 24h TTL.
+
+**One-liner to read the upstream cache:**
+```
+node -e "const p=require('path'),o=require('os');const b=process.env.APPDATA||(process.platform==='darwin'?p.join(o.homedir(),'Library','Application Support'):p.join(o.homedir(),'.config'));const f=p.join(b,'squad-cli','update-check.json');try{const d=JSON.parse(require('fs').readFileSync(f,'utf8'));const age=Date.now()-d.checkedAt;if(age<86400000)console.log(JSON.stringify(d));else console.log('STALE')}catch{console.log('MISS')}"
+```
+
+Output semantics:
+- Valid JSON `{"latestVersion":"X.Y.Z","checkedAt":N}` → cache hit; use `latestVersion`
+- `STALE` → cache expired (older than 24h); treat as no data
+- `MISS` → cache missing or corrupt; treat as no data
+
+**OS-specific cache path:**
+- Windows: `%APPDATA%\squad-cli\update-check.json`
+- Linux: `~/.config/squad-cli/update-check.json`
+- macOS: `~/Library/Application Support/squad-cli/update-check.json`
+
+---
+
+## Repo-Local Cache Convention: `.squad/.cache/version-check.json`
+
+Used by coordinator for `insider`/`preview` channels (the upstream cache only stores `latest`).
+
+**Schema:**
+```json
+{
+  "checkedAt": "2026-05-26T14:13:28.492Z",
+  "currentVersion": "0.9.6-insider.2",
+  "channel": "insider",
+  "channelVersion": "0.9.7-insider.1"
+}
+```
+
+**TTL:** 24 hours from `checkedAt`.
+**Gitignore:** `.squad/.cache/` is listed in `.gitignore` — cache files are never committed.
+
+---
+
+## Key File Paths (installed CLI)
+
+| Purpose | Path |
+|---|---|
+| Version utilities | `dist/cli/core/version.js` |
+| Upgrade logic | `dist/cli/core/upgrade.js` |
+| Init logic | `dist/cli/core/init.js` |
+| Template manifest | `dist/cli/core/templates.js` |
+| Copilot install helper | `dist/cli/copilot-install.js` |
+| squad.agent.md template | `templates/squad.agent.md.template` |
+| Session init reference | `templates/session-init-reference.md` |
+| All templates | `templates/` |

--- a/.github/skills/squad/SKILL.md
+++ b/.github/skills/squad/SKILL.md
@@ -1,0 +1,299 @@
+---
+name: squad
+description: >-
+  Squad's command catalog and interactive menu. Invoke via /squad (slash command) or natural language ("squad commands", "what can squad do", "show me squad options"). Presents categorized operations (Install & Upgrade, Team Management, Issues & PRs, Plugins & Skills, Model & Cost, Sessions & State) as an interactive picker. Routes to the right squad CLI command or the Squad coordinator agent.
+user-invocable: true
+allowedTools: []
+---
+
+## Menu Presentation Rules
+
+When the user triggers this skill (via `/squad` slash command, "squad commands", "help", "what can squad do", etc.):
+
+1. **Category-level menu first.** Present category names as an `ask_user` choice list:
+   ```
+   📋 Squad Commands — pick a category:
+   1. Install & Upgrade
+   2. Team Management
+   3. Issues & PRs
+   4. Plugins & Skills
+   5. Model & Cost
+   6. Sessions & State
+   ```
+2. **Drill-down.** After selection, show operation titles in that category as a second `ask_user` list.
+3. **Direct match skips the menu.** If the user says "how do I upgrade with state backend," match to the specific entry and go straight to argument collection.
+4. **Compact fallback.** If `ask_user` is unavailable, render as a markdown table instead.
+5. **Back / Cancel.** Include "← Back to categories" in sub-menus. Include "Cancel" in confirmation prompts. Respect "never mind" / "cancel" at any point.
+
+**Argument collection:** For entries with `args`, iterate the list sequentially. Use `ask_user` with choices when `choices` is provided; free-text prompt otherwise. If the user says "just do it" or "defaults are fine," skip remaining args and use their defaults.
+
+**Confirmation template:**
+```
+⚠️ This will {action-description}.
+{what will change}
+Proceed? (yes / no)
+```
+
+---
+
+## Install & Upgrade
+
+### Upgrade Squad CLI
+
+- **intent:** upgrade squad, update squad, install latest version, get new version
+- **summary:** Upgrade Squad CLI to the latest version for your channel
+- **action:** shell
+- **command:** squad upgrade
+- **args:**
+  - `state-backend`: Which state backend? | choices: {worktree, git-notes, orphan, two-layer} | default: (keep current)
+- **confirm:** false
+- **platform_caveats:** Requires terminal. In VS Code, open the integrated terminal and run the command directly.
+
+### Initialize Squad
+
+- **intent:** set up squad, initialize squad, create team, start squad in this project
+- **summary:** Scaffold Squad in the current directory (idempotent)
+- **action:** shell
+- **command:** squad init
+- **args:** (none)
+- **confirm:** false
+- **platform_caveats:** Requires terminal. Recommend a standalone terminal for best results.
+
+### Switch State Backend
+
+- **intent:** switch state backend, change state storage, use git-notes, use orphan branch
+- **summary:** Change where Squad stores mutable state (config.json)
+- **action:** file-edit
+- **command:** .squad/config.json → stateBackend
+- **args:**
+  - `stateBackend`: Which state backend? | choices: {worktree, git-notes, orphan, two-layer} | default: (keep current)
+- **confirm:** true
+- **platform_caveats:** May require migration if switching away from worktree. Show current value and new value before confirming.
+
+---
+
+## Team Management
+
+### Add Team Member
+
+- **intent:** add team member, hire agent, add agent, add developer, recruit
+- **summary:** Add a new agent to the team roster
+- **action:** coordinator
+- **command:** Add Team Member flow (Init Mode / Team Mode)
+- **args:**
+  - `role`: What role should this agent fill? (e.g., Frontend Dev, Backend Dev, QA Engineer)
+  - `name`: Preferred name or casting universe? | default: (auto-cast from active universe)
+- **confirm:** false
+
+### Remove Team Member
+
+- **intent:** remove team member, fire agent, delete agent, remove developer
+- **summary:** Remove an agent and delete their charter and history files
+- **action:** coordinator
+- **command:** Remove Team Member flow
+- **args:**
+  - `member`: Which team member to remove? (name or role)
+- **confirm:** true
+
+### Reassign Roles
+
+- **intent:** reassign role, change role, swap roles, update team member role
+- **summary:** Update a team member's role in team.md and their charter
+- **action:** coordinator
+- **command:** Update team.md roster + charter.md
+- **args:**
+  - `member`: Which team member?
+  - `newRole`: New role?
+- **confirm:** false
+
+### Show Roster
+
+- **intent:** show roster, who is on the team, list team members, show team, capability profile
+- **summary:** Display the current team roster and capability profile
+- **action:** coordinator
+- **command:** Direct Mode — read team.md, answer
+- **args:** (none)
+- **confirm:** false
+
+---
+
+## Issues & PRs
+
+### Connect GitHub Repo
+
+- **intent:** connect github, enable issues, set up issues, link repository, github issues mode
+- **summary:** Connect this project to GitHub Issues via gh auth
+- **action:** coordinator
+- **command:** GitHub Issues Mode (connection flow)
+- **args:** (none)
+- **confirm:** false
+- **platform_caveats:** Requires `gh auth login` to have been run in the terminal.
+
+### Triage Issues
+
+- **intent:** triage issues, review issues, assign issues, label issues
+- **summary:** Run the Lead triage flow on open GitHub issues
+- **action:** coordinator
+- **command:** GitHub Issues Mode → Lead triage
+- **args:** (none)
+- **confirm:** false
+
+### Activate Ralph
+
+- **intent:** activate ralph, start ralph, ralph go, start work monitor, start auto-work
+- **summary:** Activate Ralph — Work Monitor — to pick up and run queued issues
+- **action:** coordinator
+- **command:** Ralph — Work Monitor triggers
+- **args:** (none)
+- **confirm:** false
+
+### Set Ralph Polling Interval
+
+- **intent:** set ralph interval, change ralph timing, how often does ralph check, ralph every N minutes
+- **summary:** Tell Ralph how frequently to poll for new work
+- **action:** coordinator
+- **command:** Ralph trigger: "Ralph, check every N minutes"
+- **args:**
+  - `interval`: How often should Ralph poll? (in minutes) | default: 10
+- **confirm:** false
+
+### Start Squad Watch
+
+- **intent:** start watch, squad watch, monitor issues, watch for issues, auto-triage
+- **summary:** Start squad watch to continuously poll and triage issues
+- **action:** shell
+- **command:** squad watch
+- **args:**
+  - `interval`: Poll interval in minutes | default: 10
+- **confirm:** false
+- **platform_caveats:** CLI-only — long-running foreground process. Not viable in VS Code without an integrated terminal. Run: `squad watch --interval {n}` in your terminal.
+
+---
+
+## Plugins & Skills
+
+### Browse Plugin Marketplace
+
+- **intent:** browse plugins, explore plugins, what plugins are available, plugin marketplace
+- **summary:** Browse available plugins in the Squad marketplace
+- **action:** shell
+- **command:** squad plugin marketplace browse
+- **args:**
+  - `name`: Plugin name to search for | default: (browse all)
+- **confirm:** false
+
+### Add Marketplace Plugin
+
+- **intent:** add plugin, install plugin, get plugin from marketplace
+- **summary:** Add a plugin from the marketplace to this Squad
+- **action:** shell
+- **command:** squad plugin marketplace add
+- **args:**
+  - `plugin`: Plugin owner/repo (e.g., owner/plugin-name)
+- **confirm:** false
+
+### Remove Marketplace Plugin
+
+- **intent:** remove plugin, uninstall plugin, delete plugin
+- **summary:** Remove an installed marketplace plugin
+- **action:** shell
+- **command:** squad plugin marketplace remove
+- **args:**
+  - `name`: Plugin name to remove
+- **confirm:** true
+
+### List Marketplace Plugins
+
+- **intent:** list plugins, show installed plugins, what plugins do I have
+- **summary:** List all plugins registered in this Squad
+- **action:** shell
+- **command:** squad plugin marketplace list
+- **args:** (none)
+- **confirm:** false
+
+### List Installed Skills
+
+- **intent:** list skills, show skills, what skills are installed, skill catalog
+- **summary:** List all skills installed in .squad/skills/ and .github/skills/
+- **action:** coordinator
+- **command:** Direct Mode — list .squad/skills/ and .github/skills/ directories
+- **args:** (none)
+- **confirm:** false
+
+---
+
+## Model & Cost
+
+### Set Default Model
+
+- **intent:** set default model, change model, use gpt, use claude, switch model
+- **summary:** Set the default model for all agents in config.json
+- **action:** file-edit
+- **command:** .squad/config.json → defaultModel
+- **args:**
+  - `model`: Model name (e.g., gpt-5.6-luna, claude-sonnet-4.5, gpt-5.3-codex)
+- **confirm:** false
+
+### Override Per-Agent Model
+
+- **intent:** set model for agent, agent model override, use different model for one agent
+- **summary:** Set a model override for a specific agent in config.json
+- **action:** file-edit
+- **command:** .squad/config.json → agentModelOverrides.{agentName}
+- **args:**
+  - `agent`: Agent name (must match name in team.md)
+  - `model`: Model name (e.g., gpt-5.6-luna, claude-sonnet-4.5)
+- **confirm:** false
+
+### Clear Model Preference
+
+- **intent:** clear model, reset model, remove model preference, use default model
+- **summary:** Remove a model override from config.json (reverts to system default)
+- **action:** file-edit
+- **command:** .squad/config.json → remove defaultModel or agentModelOverrides.{agentName}
+- **args:**
+  - `scope`: Clear default or a specific agent? | choices: {default model, specific agent} | default: default model
+  - `agent`: Agent name (only if scope = specific agent)
+- **confirm:** false
+
+---
+
+## Sessions & State
+
+### Catch-Up Summary
+
+- **intent:** catch me up, what happened, status, what did the team do, session summary
+- **summary:** Summarize recent agent activity and key decisions
+- **action:** coordinator
+- **command:** Session catch-up flow (lazy scan)
+- **args:** (none)
+- **confirm:** false
+
+### Show Recent Decisions
+
+- **intent:** show decisions, recent decisions, what decisions were made, decision log
+- **summary:** Display recent entries from .squad/decisions.md
+- **action:** coordinator
+- **command:** Direct Mode — read decisions.md, answer
+- **args:** (none)
+- **confirm:** false
+
+### Archive Old Decisions
+
+- **intent:** archive decisions, clean up decisions, move old decisions, compact decisions
+- **summary:** Move old decisions from decisions.md to decisions-archive.md
+- **action:** coordinator
+- **command:** Move entries older than threshold from .squad/decisions.md → .squad/decisions-archive.md
+- **args:**
+  - `olderThan`: Archive decisions older than how many days? | default: 30
+- **confirm:** true
+
+### Summarize Agent History
+
+- **intent:** summarize history, what did agent do, agent history, compress history
+- **summary:** Spawn an agent to summarize and compress a team member's history file
+- **action:** coordinator
+- **command:** Spawn agent with history.md summarization task
+- **args:**
+  - `member`: Which team member's history to summarize?
+- **confirm:** false

--- a/.github/skills/test-discipline/SKILL.md
+++ b/.github/skills/test-discipline/SKILL.md
@@ -1,0 +1,37 @@
+---
+name: "test-discipline"
+description: "Update tests when changing APIs — no exceptions"
+domain: "quality"
+confidence: "high"
+source: "earned (Fenster/Hockney incident, test assertion sync violations)"
+---
+
+## Context
+
+When APIs or public interfaces change, tests must be updated in the same commit. When test assertions reference file counts or expected arrays, they must be kept in sync with disk reality. Stale tests block CI for other contributors.
+
+## Patterns
+
+- **API changes → test updates (same commit):** If you change a function signature, public interface, or exported API, update the corresponding tests before committing
+- **Test assertions → disk reality:** When test files contain expected counts (e.g., `EXPECTED_FEATURES`, `EXPECTED_SCENARIOS`), they must match the actual files on disk
+- **Add files → update assertions:** When adding docs pages, features, or any counted resource, update the test assertion array in the same commit
+- **CI failures → check assertions first:** Before debugging complex failures, verify test assertion arrays match filesystem state
+
+## Examples
+
+✓ **Correct:**
+- Changed auth API signature → updated auth.test.ts in same commit
+- Added `distributed-mesh.md` to features/ → added `'distributed-mesh'` to EXPECTED_FEATURES array
+- Deleted two scenario files → removed entries from EXPECTED_SCENARIOS
+
+✗ **Incorrect:**
+- Changed spawn parameters → committed without updating casting.test.ts (CI breaks for next person)
+- Added `built-in-roles.md` → left EXPECTED_FEATURES at old count (PR blocked)
+- Test says "expected 7 files" but disk has 25 (assertion staleness)
+
+## Anti-Patterns
+
+- Committing API changes without test updates ("I'll fix tests later")
+- Treating test assertion arrays as static (they evolve with content)
+- Assuming CI passing means coverage is correct (stale assertions can pass while being wrong)
+- Leaving gaps for other agents to discover

--- a/.github/skills/tiered-memory/SKILL.md
+++ b/.github/skills/tiered-memory/SKILL.md
@@ -1,0 +1,221 @@
+---
+name: tiered-memory
+description: Three-tier agent memory model (hot/cold/wiki) for context reduction per spawn
+domain: memory-management, performance
+confidence: design (runtime not yet implemented)
+source: design proposal
+---
+
+# Skill: Tiered Agent Memory
+
+> **Status (v0.10.0):** This skill describes a **design proposal**, not a shipped runtime. Skill files install via `squad init`/`upgrade`, but the underlying tier scaffolding (`.squad/memory/hot/`, `cold/`, `wiki/`), Scribe promotion logic, and spawn-template tier-aware reads are tracked in [bradygaster/squad#1264](https://github.com/bradygaster/squad/issues/1264). Until those land, agents continue to load full `history.md` + `decisions.md` on every spawn.
+
+## Overview
+
+Squad agents today load their full context history on every spawn, which grows unboundedly across sessions. The Tiered Agent Memory model proposes a three-tier separation so agents only load the bytes that are actually relevant to the current task, with older context kept available on demand.
+
+---
+
+## Memory Tiers
+
+### 🔥 Hot Tier — Current Session Context
+- **Size target:** keep small (~2–4KB typical)
+- **Load policy:** Always loaded. Every spawn includes hot memory by default.
+- **Contents:** Current task description, active decisions made this session, immediate blockers, last 3–5 actions taken, who you are talking to right now.
+- **Lifetime:** Current session only. Discarded after session ends (Scribe promotes relevant parts to Cold).
+- **Purpose:** Provide immediate task context without any latency or load decision.
+
+### ❄️ Cold Tier — Summarized Cross-Session History
+- **Size target:** larger summary, not full transcript (~8–12KB typical)
+- **Load policy:** Load on demand. Include only when the task explicitly needs history.
+- **Contents:** Summarized past sessions (compressed by Scribe), cross-session decisions, recurring patterns, unresolved issues from prior work.
+- **Lifetime:** Rolling window (default proposal: 30 days). Eligible entries are then promoted to Wiki.
+- **Purpose:** Answer "what have we tried before?" and "what was decided?" without replaying full transcripts.
+- **How to include:** Pass `--include-cold` in spawn template or add `## Cold Memory` section.
+
+### 📚 Wiki Tier — Durable Structured Knowledge
+- **Size target:** variable, structured reference docs
+- **Load policy:** Async write, selective read. Load only when task requires domain knowledge.
+- **Contents:** Architecture decisions (ADRs), agent charters, routing rules, stable conventions, external API contracts, known platform constraints.
+- **Lifetime:** Permanent until explicitly deprecated.
+- **Purpose:** Authoritative reference. Not history — structured facts.
+- **How to include:** Pass `--include-wiki` or reference specific wiki doc paths in spawn template.
+
+---
+
+## When to Load Each Tier
+
+| Situation | Hot | Cold | Wiki |
+|-----------|-----|------|------|
+| New task, no prior context needed | ✅ | ❌ | ❌ |
+| Resuming interrupted work | ✅ | ✅ | ❌ |
+| Debugging a recurring issue | ✅ | ✅ | ❌ |
+| Implementing against a spec/ADR | ✅ | ❌ | ✅ |
+| Onboarding to unfamiliar subsystem | ✅ | ❌ | ✅ |
+| Post-incident review | ✅ | ✅ | ✅ |
+
+---
+
+## Spawn Template Pattern
+
+The default spawn prompt should include **Hot tier only**:
+
+```
+## Memory Context
+
+### Hot (current session)
+{hot_context}
+```
+
+Add `--include-cold` when the task needs history:
+```
+## Memory Context
+
+### Hot (current session)
+{hot_context}
+
+### Cold (summarized history — load on demand)
+See: .squad/memory/cold/{agent-name}.md
+```
+
+Add `--include-wiki` when the task needs domain knowledge:
+```
+## Memory Context
+
+### Hot (current session)
+{hot_context}
+
+### Wiki (durable reference)
+See: .squad/memory/wiki/{topic}.md
+```
+
+---
+
+## Integration with Scribe Agent (design — not yet implemented)
+
+Scribe is the proposed memory coordinator for this system. Once the runtime lands, Scribe will:
+
+1. **End of session:** Compress Hot → Cold summary (target: ~10% of session verbosity)
+2. **Aged cold entries:** Promote Cold → Wiki for decisions/facts that aged into stable knowledge
+3. **On-demand wiki writes:** Any agent can request Scribe to write a wiki entry mid-session
+
+Until then, see the Scribe charter for current behavior: `.squad/agents/scribe/charter.md`
+
+---
+
+## Implementation Checklist (tracked in #1264)
+
+- [ ] Scribe writes Hot context file at session start (`.squad/memory/hot/{agent}.md`)
+- [ ] Scribe compresses and writes Cold summary at session end
+- [ ] Spawn templates default to Hot-only
+- [ ] Coordinators add `--include-cold` / `--include-wiki` flags as needed
+- [ ] Wiki entries stored in `.squad/memory/wiki/`
+- [ ] Cold entries stored in `.squad/memory/cold/` with rolling TTL
+
+---
+
+## References
+
+- Tracking issue: [bradygaster/squad#1264](https://github.com/bradygaster/squad/issues/1264) — installation gap + runtime status
+- Original design spike: [bradygaster/squad#686](https://github.com/bradygaster/squad/issues/686) — tiered memory implementation plan
+- Related: [bradygaster/squad#600](https://github.com/bradygaster/squad/issues/600) — context payload growth
+
+---
+
+## Spawn Template
+
+# Spawn Template: Agent with Tiered Memory
+
+Use this template when spawning any Squad agent. By default it loads **Hot tier only**. Add optional sections as needed.
+
+---
+
+## Task
+
+{task_description}
+
+## WHY
+
+{why_this_matters}
+
+## Success Criteria
+
+- [ ] {criterion_1}
+- [ ] {criterion_2}
+
+---
+
+## Memory Context
+
+### 🔥 Hot (always included)
+
+> Paste current session context here (~2–4KB target):
+
+```
+Current task: {task_description}
+Active decisions: {decisions_this_session}
+Last actions: {last_3_to_5_actions}
+Blockers: {current_blockers_or_none}
+Talking to: {current_interlocutor}
+```
+
+---
+
+### ❄️ Cold (include when task needs history — add `--include-cold`)
+
+> Load on demand. Do not inline unless specifically needed.
+
+Summarized cross-session history is at:
+`.squad/memory/cold/{agent-name}.md`
+
+Include when:
+- Resuming interrupted work
+- Debugging a recurring issue
+- "What have we tried before?"
+
+**To load cold memory, add this section and fetch the file before spawning:**
+
+```
+## Cold Memory Summary
+{contents_of_.squad/memory/cold/{agent-name}.md}
+```
+
+---
+
+### 📚 Wiki (include when task needs domain knowledge — add `--include-wiki`)
+
+> Load on demand. Reference specific wiki docs by path.
+
+Wiki entries are at: `.squad/memory/wiki/`
+
+Include when:
+- Implementing against an ADR or spec
+- Onboarding to unfamiliar subsystem
+- Need stable conventions or API contracts
+
+**To load wiki, add this section and reference the specific doc:**
+
+```
+## Wiki Reference
+{contents_of_.squad/memory/wiki/{topic}.md}
+```
+
+---
+
+## Escalation
+
+If blocked or uncertain:
+- Architecture questions → @picard
+- Security concerns → @worf
+- Infrastructure/deployment → @belanna
+- Memory/history questions → @scribe
+
+---
+
+## Notes
+
+- Hot tier is always included; keep it focused
+- Cold adds a summary; only include when history is relevant
+- Wiki adds variable size; only include specific relevant docs
+- Runtime backing is tracked in [bradygaster/squad#1264](https://github.com/bradygaster/squad/issues/1264) — until those changes land, this skill is design-only and agents continue to load full history.md + decisions.md on every spawn
+

--- a/.gitignore
+++ b/.gitignore
@@ -283,3 +283,7 @@ output/
 .squad/.scratch/
 .squad/.cache/
 */**/.env
+
+# dotnet run-file cache
+/dotnet/runfile-discovery/
+

--- a/.mcp.json
+++ b/.mcp.json
@@ -4,7 +4,7 @@
       "command": "npx",
       "args": [
         "-y",
-        "@bradygaster/squad-cli@0.10.0",
+        "@bradygaster/squad-cli@0.13.0",
         "state-mcp"
       ],
       "env": {},

--- a/.squad/agents/fact-checker/charter.md
+++ b/.squad/agents/fact-checker/charter.md
@@ -1,0 +1,83 @@
+# Fact Checker
+
+> Trust, but verify. Every claim gets a source check.
+
+## Identity
+
+- **Name:** Fact Checker
+- **Role:** Devil's Advocate & Verification Agent
+- **Style:** Rigorous but constructive. Flags issues clearly without being abrasive.
+- **Casting:** Gets a universe name like any other agent (not exempt like Scribe/Ralph).
+
+## What I Do
+
+Validate claims, detect hallucinations, and run counter-hypotheses on team output before it ships.
+
+## Verification Methodology
+
+For every claim or assertion I review:
+
+1. **Source Check:** What evidence supports this? Can I verify it?
+2. **Counter-Hypothesis:** What would disprove this? Is there an alternative explanation?
+3. **Existence Check:** Do the URLs, package names, API endpoints, file paths, and version numbers actually exist?
+4. **Consistency Check:** Does this contradict anything in `.squad/decisions.md` or prior team output?
+
+## Confidence Ratings
+
+Every verified item gets one of:
+
+| Rating | Meaning |
+|--------|---------|
+| ✅ Verified | Confirmed via source, test, or direct observation |
+| ⚠️ Unverified | Plausible but could not confirm — needs human review |
+| ❌ Contradicted | Found evidence that contradicts the claim |
+| 🔍 Needs Investigation | Requires deeper analysis beyond current scope |
+
+## When I'm Triggered
+
+- **Auto-trigger (via routing):** Tasks tagged with `review`, `verify`, `fact-check`, `audit`
+- **Pre-publish gate:** Before any artifact is delivered to the user, if configured
+- **Manual:** User says "fact-check this", "verify these claims", "double-check"
+- **Post-research:** After any agent produces research output or external references
+
+## How I Work
+
+1. **Read the artifact** — understand what's being claimed
+2. **Extract claims** — list every factual assertion (package versions, API behavior, file existence, etc.)
+3. **Verify each claim** — use available tools (grep, glob, web search, gh CLI) to check
+4. **Run counter-hypotheses** — for key assumptions, ask "what if this is wrong?"
+5. **Produce a verification report:**
+
+```markdown
+## Verification Report — {artifact name}
+
+### Claims Verified
+- ✅ {claim} — confirmed via {source}
+- ⚠️ {claim} — could not verify, {reason}
+- ❌ {claim} — contradicted by {evidence}
+
+### Counter-Hypotheses
+- {assumption} → Alternative: {counter}
+
+### Recommendation
+{proceed / revise / block with reasons}
+```
+
+6. **Write decision** if I found issues: `.squad/decisions/inbox/fact-checker-{slug}.md`
+
+## Boundaries
+
+**I handle:** Verification, fact-checking, counter-hypotheses, hallucination detection.
+
+**I don't handle:** Implementation, design, testing, or docs. I review, not create.
+
+**I am not a blocker by default.** My verification report is advisory unless the coordinator or a reviewer escalates it to a gate.
+
+## Project Context
+
+**Project:** {project_name}
+{project_description}
+
+## Learnings
+
+Initial setup complete. Ready for verification work.

--- a/.squad/agents/fact-checker/history.md
+++ b/.squad/agents/fact-checker/history.md
@@ -1,0 +1,16 @@
+# Project Context
+
+- **Project:** DataFilters
+- **Created:** 2026-09-06
+
+## Core Context
+
+Agent Fact Checker initialized and ready for work.
+
+## Recent Updates
+
+📌 Team initialized on 2026-09-06
+
+## Learnings
+
+Initial setup complete.

--- a/.squad/fact-checker/audit-trail.md
+++ b/.squad/fact-checker/audit-trail.md
@@ -1,0 +1,5 @@
+# Fact Checker Audit Trail
+
+> Append-only evidence log. Entries are succinct — verdict + citation, never raw source material.
+
+<!-- Fact Checker appends findings below -->

--- a/.squad/fact-checker/policy.md
+++ b/.squad/fact-checker/policy.md
@@ -1,0 +1,104 @@
+# Fact Checker Policy
+
+> Authoritative verification & devil's-advocate methodology for this project. Fact Checker enforces these standards.
+
+The Fact Checker is **one agent with two operating modes** — Verification (empirical claim checks) and Devil's Advocate (design challenge / pre-mortem). This policy defines what each mode does, what gets flagged at each confidence level, and which findings are advisory vs. blocking.
+
+---
+
+## Mode 1: Verification
+
+Empirical check of claims against sources. Triggered by `"fact-check this"`, `"verify these claims"`, `"is this true?"`, Pre-Ship ceremony, or after any agent produces external references.
+
+### What gets checked
+
+| Claim type | What to verify |
+|------------|----------------|
+| **URLs** | Does the URL actually resolve? (200, not 404 or 5xx) |
+| **Package names + versions** | Does the package exist on the registry at that version? |
+| **API endpoints** | Does the documented endpoint exist on the vendor's current docs? |
+| **File paths** | Does the file exist in the repo at the claimed path? |
+| **Function / type signatures** | Do they match the actual source? |
+| **Quoted text** | Does the source actually contain the quoted text verbatim? |
+| **Statistics / measurements** | Is the cited source authoritative and recent? |
+| **Cross-references to team decisions** | Does `.squad/decisions.md` actually say what was claimed? |
+
+### Confidence rating (every verified item gets one)
+
+| Rating | Meaning | Required next step |
+|--------|---------|--------------------|
+| ✅ **Verified** | Confirmed via source, test, or direct observation | None — proceed |
+| ⚠️ **Unverified** | Plausible but could not confirm (no source, source ambiguous) | Flag in the verification report; team decides whether to ship |
+| ❌ **Contradicted** | Found evidence that contradicts the claim | **Blocking** — must be revised before ship |
+| 🔍 **Needs Investigation** | Requires deeper analysis beyond current scope | Flag + recommend a follow-up |
+
+---
+
+## Mode 2: Devil's Advocate
+
+Design challenge + pre-mortem. Triggered by `"play devil's advocate"`, `"what's wrong with this plan?"`, `"steelman the opposite"`, `"pre-mortem this"`, or before any major architectural decision.
+
+### What gets produced (every DA brief)
+
+1. **Steelman of the opposition** — the strongest version of the counter-argument (not the weakest version that's easy to defeat).
+2. **Load-bearing assumptions** — list the things the team is treating as fixed that are actually choices. *"We assumed we had to use Postgres — what if we couldn't?"*
+3. **Pre-mortem** — concrete failure scenario in 30 days. *"Imagine this shipped and failed. Write the post-mortem now."*
+4. **Alternative approach** — at least one concrete alternative sketch, even if worse, so the chosen direction is a chosen direction.
+5. **Risk acceptance** — flag remaining risks for the team to consciously accept or mitigate. Never a veto.
+
+---
+
+## Hard Rules (Anti-Fabrication)
+
+These are violations Fact Checker will catch and flag — even in its own output:
+
+- **Never cite a URL, package, or API without verifying it exists.** If the verification tool isn't available in the session, mark as ⚠️ Unverified — never as ✅ Verified.
+- **Never invent measurement data, benchmarks, or "production results"** to support a claim. Cited measurements must link to a real source (`bradygaster/squad#1264` is the canonical example of this anti-pattern being caught).
+- **Never fabricate a counter-hypothesis** for Devil's Advocate mode. The steelman must be a real opposing argument that the team could reasonably encounter from a senior engineer.
+- **Never block on opinion.** Devil's Advocate flags risks; it does not veto. Only ❌ Contradicted findings in Verification mode are blocking by default.
+
+---
+
+## Advisory by Default
+
+Fact Checker is **advisory** by default — like Rai's 🟡 Yellow. Findings are surfaced; the team or coordinator decides whether to act.
+
+Two exceptions where Fact Checker becomes a **blocking gate**:
+
+1. **❌ Contradicted finding in Verification mode** during a Pre-Ship ceremony — the user-facing artifact must be revised.
+2. **Coordinator-escalated DA risk** — when the coordinator marks a Devil's Advocate finding as "must address before ship", standard Reviewer Rejection Protocol applies.
+
+---
+
+## Opt-Out Model
+
+- **Cannot disable** the anti-fabrication hard rules above. They are framework-level guarantees.
+- **Can disable** automatic Pre-Ship Fact Check triggering with justification logged to audit trail.
+- **Cannot disable** Devil's Advocate on architectural decisions if the user explicitly asks for it (`"play devil's advocate"`).
+- **Temporary opt-down** supported (auto re-enables after 30 days, same model as Rai).
+
+---
+
+## Audit Trail
+
+All Fact Checker findings (verification verdicts + DA briefs) are logged to `.squad/fact-checker/audit-trail.md` (append-only). Entries are **succinct** — never paste raw verification source material, only the verdict + citation. The audit trail is the team's evidence ledger:
+
+- What was checked
+- Which sources were consulted
+- Which verdict was issued (or which DA brief was produced)
+- Whether the team accepted the finding
+
+Decisions that affect other agents go to `.squad/decisions/inbox/fact-checker-{slug}.md` for Scribe to merge into `.squad/decisions.md`.
+
+---
+
+## Integration with Reviewer Rejection Protocol
+
+When Fact Checker issues a ❌ Contradicted verdict on a user-facing artifact at Pre-Ship time:
+
+1. **Reviewer Rejection Protocol activates** — the original author is locked out
+2. **Fact Checker names the fix agent** — usually the agent that produced the unverified claim
+3. **Pair mode** — Fact Checker provides the citations / counter-evidence so the fix agent can revise with grounding
+4. **Re-verification required** — Fact Checker must issue ✅ or ⚠️ before the artifact can ship
+
+This mirrors Rai's RAI Reviewer Rejection Protocol. The two are complementary: Rai blocks on safety/ethics/RAI violations, Fact Checker blocks on factual contradictions.

--- a/.squad/ralph-instructions.md
+++ b/.squad/ralph-instructions.md
@@ -1,0 +1,67 @@
+# Ralph Instructions
+<!-- User-owned: customize this file to override Ralph's autonomous-execution behavior.
+     squad init creates this file on first install; squad upgrade never overwrites it. -->
+
+<!--
+  PURPOSE
+  -------
+  When `.squad/ralph-instructions.md` exists, `squad watch --execute` instructs the
+  spawned Copilot session to read this file and follow ALL sections here instead of
+  the built-in fallback prompt.  If the file is absent, the built-in prompt is used.
+
+  CONTRACT (stable — safe to build on)
+  --------------------------------------
+  YOU CAN  customize via this file:
+    • Extra instructions given to Ralph at session start (Teams/Slack notifications,
+      calendar checks, post-task hooks, MCP-powered side effects, escalation paths)
+    • Additional eligibility rules or priority ordering for issue selection
+    • Agent persona, tone, or verbosity for session output
+
+  YOU CANNOT override via this file:
+    • Parallelism — Ralph always spawns agents for all actionable issues simultaneously
+    • Core eligibility filter (squad/squad:* label required, not blocked, not assigned)
+    • The underlying `gh` / Copilot CLI command used to spawn each session
+
+  TRUST IMPLICATIONS
+  ------------------
+  This file is read by the spawned Copilot session with full agent permissions.
+  Treat it like code — never paste untrusted content here.  Anyone with write access
+  to this file can influence what the agent does on your behalf.
+
+  If this file is missing or empty, `squad watch --execute` falls back to the
+  built-in prompt with no behavioral change.
+
+  PLACEHOLDERS
+  ------------
+  The following values are injected by execute.ts before the session reads this file:
+    (none currently — Ralph builds the issue list dynamically at runtime)
+
+  FORMAT
+  ------
+  Plain markdown.  Structure with ## sections.  The spawned session reads the whole
+  file, so keep it concise — one screen of instructions is ideal.
+-->
+
+## Ralph, Go!
+
+Read this file for your full instructions.  Follow ALL sections.
+MAXIMIZE PARALLELISM — spawn agents for ALL actionable issues simultaneously.
+
+### Issue Selection
+
+Work on every open, unblocked, unassigned issue labeled `squad` or `squad:{member}`.
+Skip issues that are assigned to a human, blocked, or marked `status:on-hold`.
+
+### Post-Task Actions
+
+<!-- Uncomment and customize to add post-task hooks, e.g. Teams notifications:
+
+After completing work on each issue:
+- Post a brief summary to the team channel via your Teams MCP tool.
+- Update the issue with a progress comment if no PR has been opened yet.
+-->
+
+### Escalation
+
+If you are blocked on an issue, comment on it explaining why, add a `status:blocked`
+label, and move to the next actionable item.  Do not halt the loop.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### 🧹 Housekeeping
 - Bumped `Ultimately` to `4.0.0`
 - Updated Squad team
+- Re-enabled mutation testing (Stryker) on the nightly pipeline for `DataFilters`, `DataFilters.Expressions` and `DataFilters.Queries`
 
 ## [0.13.2] / 2025-09-14
 ### 🚨 Fixes

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -6,6 +6,7 @@ using Candoumbe.Pipelines.Components.Formatting;
 using Candoumbe.Pipelines.Components.GitHub;
 using Candoumbe.Pipelines.Components.NuGet;
 using Candoumbe.Pipelines.Components.Workflows;
+using Candoumbe.Pipelines.Tools;
 using Fallout.Common;
 using Fallout.Common.CI.GitHubActions;
 using Fallout.Common.IO;
@@ -13,6 +14,7 @@ using Fallout.Common.ProjectModel;
 using Fallout.Common.Tooling;
 using Fallout.Common.Tools.DotNet;
 using Fallout.Common.Tools.GitHub;
+using static Serilog.Log;
 
 namespace DataFilters.ContinuousIntegration;
 
@@ -69,29 +71,29 @@ namespace DataFilters.ContinuousIntegration;
     ]
 )]
 
-// [GitHubActions("nightly", GitHubActionsImage.Ubuntu2204,
-//     AutoGenerate = false,
-//     FetchDepth = 0,
-//     OnCronSchedule = "0 0 * * *",
-//     InvokedTargets = [nameof(IMutationTest.MutationTests), nameof(IPushNugetPackages.Pack)],
-//     OnPushBranches = [IHaveDevelopBranch.DevelopBranchName],
-//
-//     CacheKeyFiles =
-//     [
-//         "src/**/*.csproj",
-//         "test/**/*.csproj",
-//         "stryker-config.json",
-//         "test/**/*/xunit.runner.json"
-//     ],
-//     EnableGitHubToken = true,
-//     ImportSecrets =
-//     [
-//         nameof(NugetApiKey),
-//         nameof(IReportCoverage.CodecovToken),
-//         nameof(IMutationTest.StrykerDashboardApiKey)
-//     ],
-//     PublishArtifacts = true
-// )]
+[GitHubActions("nightly", GitHubActionsImage.Ubuntu2204,
+    AutoGenerate = false,
+    FetchDepth = 0,
+    OnCronSchedule = "0 0 * * *",
+    InvokedTargets = [nameof(IMutationTest.MutationTests), nameof(IPushNugetPackages.Pack)],
+    OnPushBranches = [IHaveDevelopBranch.DevelopBranchName],
+
+    CacheKeyFiles =
+    [
+        "src/**/*.csproj",
+        "test/**/*.csproj",
+        "stryker-config.json",
+        "test/**/*/xunit.runner.json"
+    ],
+    EnableGitHubToken = true,
+    ImportSecrets =
+    [
+        nameof(IPushNugetPackages.NuGetApiKey),
+        nameof(IReportCoverage.CodecovToken),
+        nameof(IMutationTest.StrykerDashboardApiKey)
+    ],
+    PublishArtifacts = true
+)]
 [GitHubActions("nightly-manual", GitHubActionsImage.Ubuntu2204,
     AutoGenerate = false,
     FetchDepth = 0,
@@ -101,7 +103,7 @@ namespace DataFilters.ContinuousIntegration;
     [
         "src/**/*.csproj",
         "test/**/*.csproj",
-        "stryker-config.json",
+        "test/**/*/stryker-config.json",
         "test/**/*/xunit.runner.json"
     ],
     EnableGitHubToken = true,
@@ -124,6 +126,7 @@ public class Build : EnhancedBuild,
     IRestore,
     IDotnetFormat,
     IUnitTest,
+    IMutationTest,
     IBenchmark,
     IReportUnitTestCoverage,
     IPushNugetPackages,
@@ -174,4 +177,32 @@ public class Build : EnhancedBuild,
 
     /// <inheritdoc />
     bool IDotnetFormat.VerifyNoChanges => IsServerBuild;
+
+    /// <summary>
+    /// Projects to be targeted by mutation tests.
+    /// </summary>
+    private static readonly string[] s_projects = ["DataFilters", "DataFilters.Expressions", "DataFilters.Queries"];
+
+    /// <inheritdoc />
+    IEnumerable<MutationProjectConfiguration> IMutationTest.MutationTestsProjects =>
+    [
+        ..s_projects.Select(projectName => new MutationProjectConfiguration(sourceProject: Solution.AllProjects.Single(csproj => csproj.Name == projectName),
+                                                                            testProjects: Solution.AllProjects.Where(csproj => string.Equals(csproj.Name, $"{projectName}.UnitTests")),
+                                                                            configurationFile: this.Get<IHaveTestDirectory>().TestDirectory / $"{projectName}.UnitTests" / "stryker-config.json"))
+    ];
+
+    /// <summary>
+    /// Gets the Stryker settings for mutation testing.
+    /// </summary>
+    Configure<StrykerSettings> IMutationTest.StrykerArgumentsSettings => settings =>
+    {
+        if (EnvironmentInfo.HasVariable("IS_DEVCONTAINER"))
+        {
+            Information("Running in a dev container, adjusting Stryker settings accordingly.");
+            settings = settings.ResetOpenReport();
+        }
+
+        return settings;
+    };
+
 }


### PR DESCRIPTION
## Summary
Re-enable Stryker (mutation testing) on the nightly pipeline, previously disabled.

- Uncomment the `GitHubActions("nightly", ...)` attribute in `build/Build.cs`
- Fix the `NuGetApiKey` reference and the `stryker-config.json` cache path
- Implement `IMutationTest.MutationTestsProjects` for `DataFilters`, `DataFilters.Expressions` and `DataFilters.Queries`
- Adjust Stryker settings when running in a devcontainer
- Update `CHANGELOG.md`

Also includes a Squad upgrade (v0.10.0 → v0.13.0) and a `.gitignore` rule for the local `dotnet run-file` cache.